### PR TITLE
chore: standardize Renovate config with org-wide shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>lgtm-hq/.github:renovate-config"]
+}


### PR DESCRIPTION
## Summary

- Standardize Renovate configuration to extend the org-wide shared preset from `lgtm-hq/.github:renovate-config`
- Remove duplicated settings now inherited from the shared preset
- Use default Mend Renovate PR body format (removes any custom `prBody` overrides)

## Changes

- `renovate.json`: extend `local>lgtm-hq/.github:renovate-config` shared preset
- Common settings (schedule, labels, semantic commits, rate limits, lock file maintenance, etc.) are now inherited
- Repo-specific rules (if any) are preserved

## Shared preset includes

- `config:recommended` base
- `platformCommit: true`
- `assigneesFromCodeOwners: true`
- Schedule: 10-11 PM UTC
- Patch automerge (branch)
- GitHub Actions: pin digests + automerge + group
- Major deps grouped
- Lock file maintenance enabled
- Semantic commits: `chore(deps):`
- `rangeStrategy: pin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dependency management automation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->