### PR TITLE
chore: add CODEOWNERS for consistent review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS - Define code ownership for pull request reviews
+#
+# Rules are evaluated top-to-bottom; LAST matching pattern wins.
+
+* @lgtm-hq/maintainers @TurboCoder13
+
+/.github/workflows/ @lgtm-hq/maintainers


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds `.github/CODEOWNERS` so Renovate (`assigneesFromCodeOwners`) and GitHub code-owner routing behave consistently across repos.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Related Issues

N/A

## Details

Matches py-lintro ownership routing defaults (`@lgtm-hq/maintainers`, `@TurboCoder13`).
