### PR TITLE
ci: add reusable Lintro Quality Checks workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+---
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lintro:
+    permissions:
+      contents: read
+      packages: read
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@0de41c8e803ba2cb324dd9ec1d2e39eb870f9090


### PR DESCRIPTION
## Summary

- Add CI workflow calling `lgtm-ci` reusable-quality (pinned `0de41c8`)
- Aligns check name with org ruleset **Lintro Quality Checks**

## Test plan

- [ ] CI passes on this PR

## Merge order

Merge after https://github.com/lgtm-hq/lgtm-ci/pull/160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline configuration to enhance continuous integration workflow automation on pull requests and pushes to the main branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/podex/pull/95)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->