### PR TITLE
chore(ci): add PR auto-assign, title validation, and contributor docs

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,0 +1,25 @@
+---
+name: PR - Auto Assign
+# Automatically assigns a random CODEOWNER to new pull requests.
+# Ensures every PR has an assignee for accountability.
+
+"on":
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  assign:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    with:
+      job-name: "👤 Auto Assign PR Author"
+      codeowners-path: .github/CODEOWNERS
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      egress-policy: block
+      egress-preset: github-tooling
+      runner-image: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,11 +12,11 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@96a42109637efd4c019d176e0902e3be23295716  # v0.45.1
     with:
       job-name: "👤 Auto Assign PR Author"
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716'  # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -15,10 +15,10 @@ concurrency:
 jobs:
   check:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@96a42109637efd4c019d176e0902e3be23295716  # v0.45.1
     with:
       job-name: "📝 Validate PR Title"
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716'  # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       comment-marker: "<!-- semantic-pr-title -->"

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,27 @@
+---
+name: PR - Title Validation
+# Validates PR titles follow Conventional Commits format.
+
+"on":
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: semantic-pr-title-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    with:
+      job-name: "📝 Validate PR Title"
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      egress-policy: block
+      egress-preset: github-tooling
+      comment-marker: "<!-- semantic-pr-title -->"
+    permissions:
+      contents: read
+      pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog][kac], and this project adheres to
+[Semantic Versioning][semver].
+
+[kac]: https://keepachangelog.com/en/1.1.0/
+[semver]: https://semver.org/spec/v2.0.0.html
+
+## [Unreleased]
+
+### Added
+
+- CI: PR auto-assign and Conventional Commits PR-title validation workflows.
+- `CONTRIBUTING.md` documenting the development, lint, and PR workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to Podex
+
+Thanks for your interest in contributing. This guide covers the workflow and
+standards for changes to Podex.
+
+## Development setup
+
+Backend (Python, managed with [`uv`](https://docs.astral.sh/uv/)):
+
+```bash
+cd backend
+uv sync --extra dev
+uv run pytest
+```
+
+Frontend (Astro/React, managed with [`bun`](https://bun.sh/)):
+
+```bash
+cd frontend
+bun install
+bun run test
+```
+
+## Linting and formatting
+
+Podex uses [`lintro`](https://github.com/lgtm-hq/py-lintro) as the single entry
+point for linting and formatting. Run it before every commit:
+
+```bash
+uv run lintro fmt   # auto-fix formatting
+uv run lintro chk   # verify, must be clean
+```
+
+Do not invoke the underlying tools (ruff, black, mypy, eslint, etc.) directly.
+
+## Commits
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/):
+  `type(scope): summary` (e.g. `feat(api): add media search endpoint`).
+- Keep the subject in the imperative mood and under ~72 characters.
+- **Sign your commits** (`git commit -S`); the `main` ruleset requires signed
+  commits.
+
+## Pull requests
+
+- Branch from `main`; one focused change per PR.
+- PR titles must follow Conventional Commits (validated in CI).
+- All required checks must pass before merge.
+- Address review feedback (human and automated) before requesting merge.
+
+## Reporting issues
+
+Open a [GitHub issue](https://github.com/lgtm-hq/podex/issues) using a
+`type(scope): summary` title. Include reproduction steps for bugs and the
+motivation for feature requests.


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `chore(ci): add PR auto-assign, title validation, and contributor docs`
- Type:
  - [x] chore / ci / style
- Breaking change:
  - [ ] none

## What's Changing

First step of the lgtm-ci adoption (#114, Step 2) — the code-independent,
repo-governance workflows that improve the PR pipeline before the larger
foundation work lands:

- **`pr-auto-assign.yml`** — assigns a CODEOWNER to every PR (Closes #102).
- **`semantic-pr-title.yml`** — validates PR titles follow Conventional Commits.

Both are copied verbatim from the org's proven Rustume callers and pinned to
lgtm-ci **v0.45.1** (`96a4210`), matching the rest of the org for a known-good
interface. Also adds `CONTRIBUTING.md` and a Keep-a-Changelog `CHANGELOG.md`.

Deliberately **additive**: it does not touch `.github/workflows/ci.yml` or the
required `quality / Lintro Quality Checks` status check, so the merge gate is
unchanged. The `ci.yml` repin to `reusable-quality-lint.yml` (renamed upstream)
is deferred to its own PR because it requires a coordinated ruleset update to
the required-check name.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing (CONTRIBUTING.md added)

## Related Issues

Closes #102 | Related #114

## Details

- `pr-auto-assign` uses `pull_request_target`, so it begins working on the
  *next* PR (the base branch does not yet contain the workflow); it does not run
  as a check on this PR.
- `semantic-pr-title` runs on this PR; the title above is Conventional-Commits
  compliant.
- Follow-ups tracked in #114: `ci.yml` repin, security workflows (scorecards,
  codeql, dependency-review, sbom), and the test/build/deploy workflows that
  ride the foundation PR (#108).
- Reference PR for the overall migration: #103.