### PR TITLE
fix(backend): use assertpy in tests instead of a blanket bandit ignore

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
   "mypy>=1.14",
   "pytest>=8.0",
   "pytest-cov>=6.0",
+  "types-assertpy>=1.1.0.20260518",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -54,9 +55,6 @@ branch = true
 fail_under = 85
 show_missing = true
 skip_covered = false
-
-[tool.bandit]
-exclude_dirs = ["tests"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for application settings."""
 
+from assertpy import assert_that
+
 from podex.config import Settings, get_settings
 
 
@@ -7,11 +9,11 @@ def test_default_settings() -> None:
     """Defaults are sensible for local development."""
     settings = Settings()
 
-    assert settings.app_name == "podex"
-    assert settings.api_v2_prefix == "/api/v2"
-    assert settings.debug is False
+    assert_that(settings.app_name).is_equal_to("podex")
+    assert_that(settings.api_v2_prefix).is_equal_to("/api/v2")
+    assert_that(settings.debug).is_false()
 
 
 def test_get_settings_is_cached() -> None:
     """``get_settings`` returns a cached singleton."""
-    assert get_settings() is get_settings()
+    assert_that(get_settings()).is_same_as(get_settings())

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,5 +1,6 @@
 """Tests for the health and v2 status endpoints."""
 
+from assertpy import assert_that
 from fastapi.testclient import TestClient
 
 
@@ -7,13 +8,13 @@ def test_health_returns_ok(client: TestClient) -> None:
     """The liveness probe reports a healthy status."""
     response = client.get("/health")
 
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()).is_equal_to({"status": "ok"})
 
 
 def test_v2_status_returns_ok(client: TestClient) -> None:
     """The v2 surface reports that it is reachable."""
     response = client.get("/api/v2/status")
 
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok", "api": "v2"}
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()).is_equal_to({"status": "ok", "api": "v2"})

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -651,6 +651,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "types-assertpy" },
 ]
 
 [package.metadata]
@@ -669,6 +670,7 @@ dev = [
     { name = "mypy", specifier = ">=1.14" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "types-assertpy", specifier = ">=1.1.0.20260518" },
 ]
 
 [[package]]
@@ -1082,6 +1084,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "types-assertpy"
+version = "1.1.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/cd/1b5ad8aba7bf273817bee98f8f17e55dd2dc1b6244c3e0b23c397d2968d1/types_assertpy-1.1.0.20260518.tar.gz", hash = "sha256:5d41746e30a31aa0c4106bffbe668497b0c64ea86faab9efe00c5e84332725bf", size = 10790, upload-time = "2026-05-18T06:02:38.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/37/1d2d7c022af3e8c1b3ec18450b75afe4a426c7aa3dd825d07a6af4649df7/types_assertpy-1.1.0.20260518-py3-none-any.whl", hash = "sha256:bb079e00031a6c08e9294c176be1f32efbd6223bed71fd641132e36a94a8a350", size = 13115, upload-time = "2026-05-18T06:02:37.152Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(backend): use assertpy in tests instead of a blanket bandit ignore`
- Type:
  - [x] fix / perf (patch)

## What's Changing

Corrects the bandit approach introduced in #119. The blanket
`[tool.bandit] exclude_dirs = ["tests"]` is removed in favor of the org
convention (per winnow): tests use **assertpy** (`assert_that(...)`) instead of
bare `assert`, so bandit's `B101` never fires — and tests remain fully scanned
for every other issue.

- Remove `[tool.bandit]` blanket exclude.
- Convert `test_health.py` / `test_config.py` to `assert_that(...)`.
- Add `types-assertpy` stubs so strict mypy passes without
  `ignore_missing_imports`.

Validated locally: pytest 4 passed, ruff clean, strict mypy clean, **bandit
clean with no exclude**.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing (n/a)

## Related Issues

Related #31

## Details

Reference PR: #103.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated checks for app settings and health endpoints to use a more consistent assertion style.
  * Added coverage support for typed assertion helpers in the development workflow.

* **Chores**
  * Adjusted project development configuration and removed an outdated security tool setting from the main config.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->