### PR TITLE
chore(ci): add release automation (version PR + auto-tag)

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -1,0 +1,33 @@
+---
+name: Release - Auto Tag
+
+"on":
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-auto-tag-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  auto-tag:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    with:
+      version-source: python
+      version-file: backend/pyproject.toml
+      # Podex ships GitHub Releases (Docker images to GHCR on tag), not PyPI.
+      create-release: true
+      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      egress-policy: block
+      egress-preset: github-tooling
+    secrets:
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+    permissions:
+      actions: read
+      contents: write
+      issues: write

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -1,0 +1,38 @@
+---
+name: Release - Version PR
+
+"on":
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-version-pr-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  version-pr:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    with:
+      ecosystems: python
+      # yamllint disable-line rule:line-length
+      ecosystem-config: '{"python":{"pyproject":"backend/pyproject.toml","init":"backend/src/podex/__init__.py"}}'
+      auto-merge: true
+      # Allow MAJOR bumps so the version file stays aligned with auto-tag.
+      max-bump: major
+      # Patch releases auto-merge; minor/major need explicit review.
+      auto-merge-patch-only: true
+      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      egress-policy: block
+      egress-preset: pypi
+    secrets:
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `chore(ci): add release automation (version PR + auto-tag)`
- Type:
  - [x] chore / ci / style

## What's Changing

Activates the winnow release model (lgtm-ci v0.41.0), monorepo-aware:

- **`release-version-pr.yml`** — on push to `main`, opens a version-bump PR from
  Conventional-Commit history. Syncs `backend/pyproject.toml` + `__init__.py`
  via `ecosystem-config`. Patch bumps auto-merge; **minor/major need review**
  (controlled cadence).
- **`release-auto-tag.yml`** — tags the version and cuts a **GitHub Release**
  (`create-release: true`). **No PyPI** — podex is a service; Docker images to
  GHCR on tag arrive with the deployment slice.

Uses the org `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` secrets (visibility
`all`, confirmed).

## Checklist

- [x] Title follows Conventional Commits

## Related Issues

Related #114

## Details

- These workflows trigger on push to `main`, so they don't run as checks on this
  PR. After merge, the first run tags **v0.0.1** and opens the initial bump PR
  (the `feat` in #119 implies a minor → I'll review that bump PR).
- Reference PR: #103.