### PR TITLE
fix(ci): use default commit version-source for release auto-tag

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,8 +17,9 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
     with:
-      version-source: python
-      version-file: backend/pyproject.toml
+      # Default version-source (commit) reads the version from the merged
+      # `chore(release): version X.Y.Z` commit — language-agnostic, so no
+      # version-source/version-file needed for the backend/ monorepo layout.
       # Podex ships GitHub Releases (Docker images to GHCR on tag), not PyPI.
       create-release: true
       tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): use default commit version-source for release auto-tag`
- Type:
  - [x] fix / perf (patch)

## What's Changing

Fixes the release-auto-tag failure from #122. `version-source: python` is
**invalid** — `reusable-release-auto-tag` only supports `commit` (default) or
`cargo`, so the "Resolve version" step failed on the v0.1.0 release commit
(auto-opened failure issue #124).

Removes the bad `version-source`/`version-file` overrides and relies on the
default **`commit`** source, which reads the version from the merged
`chore(release): version X.Y.Z` commit — language-agnostic, works with the
`backend/` monorepo layout, and matches winnow's auto-tag exactly.

## Checklist

- [x] Title follows Conventional Commits

## Related Issues

Fixes #124 | Related #114

## Details

- The already-merged **v0.1.0** will be recovered after this lands via a
  `workflow_dispatch` of auto-tag with the `version` override (HEAD has since
  moved past the release commit). Future releases tag automatically, since
  auto-tag runs on the release-commit push where HEAD *is* the release commit.
- Reference PR: #103.