### PR TITLE
chore(ci): add action-pinning validation and dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,30 @@
+---
+name: Security - Dependency Review
+
+"on":
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions: {}
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    with:
+      fail-on-severity: high
+      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      egress-policy: block
+      egress-preset: scorecard
+      allowed-endpoints-mode: append
+      allowed-endpoints: |
+        api.deps.dev:443
+        release-assets.githubusercontent.com:443
+    permissions:
+      contents: read
+      pull-requests: read

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -1,0 +1,28 @@
+---
+name: Quality Check - Action Pinning Validation
+
+"on":
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  merge_group:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: validate-action-pinning-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    with:
+      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      egress-policy: block
+      egress-preset: github-tooling
+    permissions:
+      contents: read


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `chore(ci): add action-pinning validation and dependency review`
- Type:
  - [x] chore / ci / style

## What's Changing

lgtm-ci security adoption (#114 Step 3), pinned to v0.41.0:

- **`validate-action-pinning.yml`** — fails any PR whose workflows use
  non-SHA-pinned actions. Now viable because the untagged `ci.yml` was replaced
  by SHA-pinned, version-commented callers. **This PR self-tests it** against all
  existing workflows.
- **`dependency-review.yml`** — blocks PRs introducing high-severity dependency
  vulnerabilities.

## Checklist

- [x] Title follows Conventional Commits

## Related Issues

Related #114

## Details

- `codeql`, `sbom`, and `security-audit` follow as their own slices (codeql needs
  a config file; sbom/security-audit need `backend/` working-directory tuning).
- Reference PR: #103.