### PR TITLE
feat(api): add episodes catalog model and read endpoints

### DIFF
--- a/backend/src/podex/api/v2/episodes.py
+++ b/backend/src/podex/api/v2/episodes.py
@@ -1,0 +1,40 @@
+"""Public read endpoints for podcast episodes."""
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import select
+
+from podex.api.deps import DbSession
+from podex.models import Episode
+from podex.schemas.episode import EpisodeRead
+
+router = APIRouter(prefix="/episodes", tags=["episodes"])
+
+
+def list_episodes(db: DbSession, podcast_id: int | None = None) -> list[Episode]:
+    """List episodes, optionally filtered by podcast."""
+    statement = select(Episode).order_by(Episode.published_at.desc())
+    if podcast_id is not None:
+        statement = statement.where(Episode.podcast_id == podcast_id)
+    return list(db.execute(statement).scalars().all())
+
+
+def get_episode(episode_id: int, db: DbSession) -> Episode:
+    """Return a single episode by id."""
+    episode = db.get(Episode, episode_id)
+    if episode is None:
+        raise HTTPException(status_code=404, detail="Episode not found")
+    return episode
+
+
+router.add_api_route(
+    "",
+    list_episodes,
+    methods=["GET"],
+    response_model=list[EpisodeRead],
+)
+router.add_api_route(
+    "/{episode_id}",
+    get_episode,
+    methods=["GET"],
+    response_model=EpisodeRead,
+)

--- a/backend/src/podex/api/v2/router.py
+++ b/backend/src/podex/api/v2/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from podex.api.v2 import podcasts
+from podex.api.v2 import episodes, podcasts
 
 api_v2_router = APIRouter(tags=["v2"])
 
@@ -14,3 +14,4 @@ def read_status() -> dict[str, str]:
 
 api_v2_router.add_api_route("/status", read_status, methods=["GET"])
 api_v2_router.include_router(podcasts.router)
+api_v2_router.include_router(episodes.router)

--- a/backend/src/podex/database.py
+++ b/backend/src/podex/database.py
@@ -1,11 +1,26 @@
 """Database engine and session management."""
 
 from collections.abc import Iterator
+from typing import Any
 
-from sqlalchemy import create_engine
+from sqlalchemy import Engine, create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
 from podex.config import get_settings
+
+
+def enable_sqlite_foreign_keys(target_engine: Engine) -> None:
+    """Enforce foreign keys on SQLite, which disables them by default."""
+    if target_engine.dialect.name != "sqlite":
+        return
+
+    def _set_pragma(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    event.listen(target_engine, "connect", _set_pragma)
+
 
 _settings = get_settings()
 
@@ -13,6 +28,7 @@ _connect_args = (
     {"check_same_thread": False} if _settings.database_url.startswith("sqlite") else {}
 )
 engine = create_engine(_settings.database_url, connect_args=_connect_args)
+enable_sqlite_foreign_keys(engine)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
 

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -5,6 +5,7 @@ metadata-based table creation and Alembic autogenerate see every table.
 """
 
 from podex.models.base import Base
+from podex.models.episode import Episode
 from podex.models.podcast import Podcast
 
-__all__ = ["Base", "Podcast"]
+__all__ = ["Base", "Episode", "Podcast"]

--- a/backend/src/podex/models/episode.py
+++ b/backend/src/podex/models/episode.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy import DateTime, ForeignKey, Index, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from podex.models.base import Base
@@ -12,11 +12,14 @@ class Episode(Base):
     """A single podcast episode belonging to a podcast source."""
 
     __tablename__ = "episodes"
+    __table_args__ = (
+        # Serves both the podcast_id filter and the published_at ordering.
+        Index("ix_episodes_podcast_id_published_at", "podcast_id", "published_at"),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
     podcast_id: Mapped[int] = mapped_column(
         ForeignKey("podcasts.id", ondelete="CASCADE"),
-        index=True,
     )
     title: Mapped[str] = mapped_column(String(500), index=True)
     episode_number: Mapped[int | None] = mapped_column(default=None)

--- a/backend/src/podex/models/episode.py
+++ b/backend/src/podex/models/episode.py
@@ -1,0 +1,30 @@
+"""Episode ORM model."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class Episode(Base):
+    """A single podcast episode belonging to a podcast source."""
+
+    __tablename__ = "episodes"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    podcast_id: Mapped[int] = mapped_column(
+        ForeignKey("podcasts.id", ondelete="CASCADE"),
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(String(500), index=True)
+    episode_number: Mapped[int | None] = mapped_column(default=None)
+    published_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        default=None,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )

--- a/backend/src/podex/schemas/episode.py
+++ b/backend/src/podex/schemas/episode.py
@@ -1,0 +1,18 @@
+"""Episode API schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class EpisodeRead(BaseModel):
+    """Public representation of a podcast episode."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    podcast_id: int
+    title: str
+    episode_number: int | None
+    published_at: datetime | None
+    created_at: datetime

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,7 +8,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from podex.database import get_db
+from podex.database import enable_sqlite_foreign_keys, get_db
 from podex.main import create_app
 from podex.models import Base
 
@@ -21,6 +21,7 @@ def db_session() -> Iterator[Session]:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+    enable_sqlite_foreign_keys(engine)
     Base.metadata.create_all(engine)
     testing_session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     session = testing_session()

--- a/backend/tests/test_episodes.py
+++ b/backend/tests/test_episodes.py
@@ -7,11 +7,16 @@ from sqlalchemy.orm import Session
 from podex.models import Episode, Podcast
 
 
-def _seed_podcast(db: Session) -> int:
-    podcast = Podcast(name="The Example Show", slug="example-show")
+def _seed_podcast(
+    db: Session,
+    *,
+    slug: str = "example-show",
+    name: str = "The Example Show",
+) -> Podcast:
+    podcast = Podcast(name=name, slug=slug)
     db.add(podcast)
     db.commit()
-    return podcast.id
+    return podcast
 
 
 def test_list_episodes_empty(client: TestClient) -> None:
@@ -24,8 +29,8 @@ def test_list_episodes_empty(client: TestClient) -> None:
 
 def test_list_and_get_episode(client: TestClient, db_session: Session) -> None:
     """A stored episode is listed and retrievable by id."""
-    podcast_id = _seed_podcast(db_session)
-    db_session.add(Episode(podcast_id=podcast_id, title="Pilot", episode_number=1))
+    podcast = _seed_podcast(db_session)
+    db_session.add(Episode(podcast_id=podcast.id, title="Pilot", episode_number=1))
     db_session.commit()
 
     listed = client.get("/api/v2/episodes")
@@ -37,7 +42,7 @@ def test_list_and_get_episode(client: TestClient, db_session: Session) -> None:
     episode_id = body[0]["id"]
     fetched = client.get(f"/api/v2/episodes/{episode_id}")
     assert_that(fetched.status_code).is_equal_to(200)
-    assert_that(fetched.json()["podcast_id"]).is_equal_to(podcast_id)
+    assert_that(fetched.json()["title"]).is_equal_to("Pilot")
 
 
 def test_list_episodes_filtered_by_podcast(
@@ -46,14 +51,12 @@ def test_list_episodes_filtered_by_podcast(
 ) -> None:
     """The podcast_id query filter narrows the results."""
     first = _seed_podcast(db_session)
-    other = Podcast(name="Other Show", slug="other-show")
-    db_session.add(other)
-    db_session.commit()
-    db_session.add(Episode(podcast_id=first, title="A"))
+    other = _seed_podcast(db_session, slug="other-show", name="Other Show")
+    db_session.add(Episode(podcast_id=first.id, title="A"))
     db_session.add(Episode(podcast_id=other.id, title="B"))
     db_session.commit()
 
-    response = client.get("/api/v2/episodes", params={"podcast_id": first})
+    response = client.get("/api/v2/episodes", params={"podcast_id": first.id})
 
     assert_that(response.status_code).is_equal_to(200)
     body = response.json()

--- a/backend/tests/test_episodes.py
+++ b/backend/tests/test_episodes.py
@@ -1,5 +1,7 @@
 """Tests for the public episode endpoints."""
 
+from datetime import UTC, datetime
+
 from assertpy import assert_that
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -62,6 +64,30 @@ def test_list_episodes_filtered_by_podcast(
     body = response.json()
     assert_that(body).is_length(1)
     assert_that(body[0]["title"]).is_equal_to("A")
+
+
+def test_list_episodes_newest_first(client: TestClient, db_session: Session) -> None:
+    """Episodes are listed newest-first by published_at."""
+    podcast = _seed_podcast(db_session)
+    db_session.add(
+        Episode(
+            podcast_id=podcast.id,
+            title="Older",
+            published_at=datetime(2020, 1, 1, tzinfo=UTC),
+        ),
+    )
+    db_session.add(
+        Episode(
+            podcast_id=podcast.id,
+            title="Newer",
+            published_at=datetime(2024, 1, 1, tzinfo=UTC),
+        ),
+    )
+    db_session.commit()
+
+    body = client.get("/api/v2/episodes").json()
+
+    assert_that([episode["title"] for episode in body]).is_equal_to(["Newer", "Older"])
 
 
 def test_get_episode_not_found(client: TestClient) -> None:

--- a/backend/tests/test_episodes.py
+++ b/backend/tests/test_episodes.py
@@ -1,0 +1,68 @@
+"""Tests for the public episode endpoints."""
+
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.models import Episode, Podcast
+
+
+def _seed_podcast(db: Session) -> int:
+    podcast = Podcast(name="The Example Show", slug="example-show")
+    db.add(podcast)
+    db.commit()
+    return podcast.id
+
+
+def test_list_episodes_empty(client: TestClient) -> None:
+    """An empty catalog returns an empty list."""
+    response = client.get("/api/v2/episodes")
+
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()).is_equal_to([])
+
+
+def test_list_and_get_episode(client: TestClient, db_session: Session) -> None:
+    """A stored episode is listed and retrievable by id."""
+    podcast_id = _seed_podcast(db_session)
+    db_session.add(Episode(podcast_id=podcast_id, title="Pilot", episode_number=1))
+    db_session.commit()
+
+    listed = client.get("/api/v2/episodes")
+    assert_that(listed.status_code).is_equal_to(200)
+    body = listed.json()
+    assert_that(body).is_length(1)
+    assert_that(body[0]["title"]).is_equal_to("Pilot")
+
+    episode_id = body[0]["id"]
+    fetched = client.get(f"/api/v2/episodes/{episode_id}")
+    assert_that(fetched.status_code).is_equal_to(200)
+    assert_that(fetched.json()["podcast_id"]).is_equal_to(podcast_id)
+
+
+def test_list_episodes_filtered_by_podcast(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """The podcast_id query filter narrows the results."""
+    first = _seed_podcast(db_session)
+    other = Podcast(name="Other Show", slug="other-show")
+    db_session.add(other)
+    db_session.commit()
+    db_session.add(Episode(podcast_id=first, title="A"))
+    db_session.add(Episode(podcast_id=other.id, title="B"))
+    db_session.commit()
+
+    response = client.get("/api/v2/episodes", params={"podcast_id": first})
+
+    assert_that(response.status_code).is_equal_to(200)
+    body = response.json()
+    assert_that(body).is_length(1)
+    assert_that(body[0]["title"]).is_equal_to("A")
+
+
+def test_get_episode_not_found(client: TestClient) -> None:
+    """An unknown episode id returns 404."""
+    response = client.get("/api/v2/episodes/999")
+
+    assert_that(response.status_code).is_equal_to(404)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(api): add episodes catalog model and read endpoints`
- Type:
  - [x] feat (minor)

## What's Changing

Second data vertical, following the podcasts pattern from #127.

- SQLAlchemy **`Episode`** model (FK to `podcasts`, cascade on delete).
- **`GET /api/v2/episodes`** (list, optional `?podcast_id` filter, newest first)
  and **`/api/v2/episodes/{id}`** (detail, 404) with an `EpisodeRead` schema.
- 4 episode tests; suite now **11 tests at 96.7% coverage**.

Validated locally: ruff, ruff-format, strict mypy (24 files), bandit, pytest.

## Checklist

- [x] Title follows Conventional Commits

## Related Issues

Related #31, #45

## Details

- ORM subclass is covered by the existing `podex.models.*` mypy override (the
  dep-less CI-lint `disallow_subclassing_any` case; upstream py-lintro#1081).
- Endpoints use `add_api_route`; tests use `assertpy`; no ignores.
- Reference PR: #103.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added episode browsing and detail endpoints to the API.
  * Episodes can now be listed newest-first, filtered by podcast, or fetched individually.
  * Introduced episode data support in the app so episode records are recognized and exposed.

* **Tests**
  * Added coverage for empty results, filtered listing, successful lookups, and not-found responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->