### PR TITLE
feat(api): add media catalog model and read endpoints

### DIFF
--- a/backend/src/podex/api/v2/media.py
+++ b/backend/src/podex/api/v2/media.py
@@ -1,0 +1,40 @@
+"""Public read endpoints for canonical media items."""
+
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import select
+
+from podex.api.deps import DbSession
+from podex.models import Media, MediaType
+from podex.schemas.media import MediaRead
+
+router = APIRouter(prefix="/media", tags=["media"])
+
+
+def list_media(db: DbSession, media_type: MediaType | None = None) -> list[Media]:
+    """List media items, optionally filtered by type, ordered by title."""
+    statement = select(Media).order_by(Media.title)
+    if media_type is not None:
+        statement = statement.where(Media.type == media_type)
+    return list(db.execute(statement).scalars().all())
+
+
+def get_media(media_id: int, db: DbSession) -> Media:
+    """Return a single media item by id."""
+    media = db.get(Media, media_id)
+    if media is None:
+        raise HTTPException(status_code=404, detail="Media not found")
+    return media
+
+
+router.add_api_route(
+    "",
+    list_media,
+    methods=["GET"],
+    response_model=list[MediaRead],
+)
+router.add_api_route(
+    "/{media_id}",
+    get_media,
+    methods=["GET"],
+    response_model=MediaRead,
+)

--- a/backend/src/podex/api/v2/router.py
+++ b/backend/src/podex/api/v2/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from podex.api.v2 import episodes, podcasts
+from podex.api.v2 import episodes, media, podcasts
 
 api_v2_router = APIRouter(tags=["v2"])
 
@@ -15,3 +15,4 @@ def read_status() -> dict[str, str]:
 api_v2_router.add_api_route("/status", read_status, methods=["GET"])
 api_v2_router.include_router(podcasts.router)
 api_v2_router.include_router(episodes.router)
+api_v2_router.include_router(media.router)

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -6,6 +6,7 @@ metadata-based table creation and Alembic autogenerate see every table.
 
 from podex.models.base import Base
 from podex.models.episode import Episode
+from podex.models.media import Media, MediaType
 from podex.models.podcast import Podcast
 
-__all__ = ["Base", "Episode", "Podcast"]
+__all__ = ["Base", "Episode", "Media", "MediaType", "Podcast"]

--- a/backend/src/podex/models/media.py
+++ b/backend/src/podex/models/media.py
@@ -1,0 +1,45 @@
+"""Media item ORM model."""
+
+from datetime import datetime
+from enum import StrEnum, auto
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class MediaType(StrEnum):
+    """The kind of media a catalog item represents."""
+
+    BOOK = auto()
+    MOVIE = auto()
+    DOCUMENTARY = auto()
+    TV_SHOW = auto()
+    STUDY = auto()
+    PODCAST = auto()
+    ARTICLE = auto()
+    PERSON = auto()
+    PLACE = auto()
+
+
+class Media(Base):
+    """A canonical media item referenced across episodes."""
+
+    __tablename__ = "media"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    type: Mapped[MediaType] = mapped_column(
+        SAEnum(MediaType, native_enum=False, length=50),
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(String(500), index=True)
+    author: Mapped[str | None] = mapped_column(String(255), default=None)
+    year: Mapped[int | None] = mapped_column(default=None)
+    description: Mapped[str | None] = mapped_column(String(2000), default=None)
+    cover_url: Mapped[str | None] = mapped_column(String(1000), default=None)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )

--- a/backend/src/podex/schemas/media.py
+++ b/backend/src/podex/schemas/media.py
@@ -1,0 +1,22 @@
+"""Media API schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from podex.models.media import MediaType
+
+
+class MediaRead(BaseModel):
+    """Public representation of a canonical media item."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    type: MediaType
+    title: str
+    author: str | None
+    year: int | None
+    description: str | None
+    cover_url: str | None
+    created_at: datetime

--- a/backend/tests/test_media.py
+++ b/backend/tests/test_media.py
@@ -1,0 +1,54 @@
+"""Tests for the public media endpoints."""
+
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.models import Media, MediaType
+
+
+def test_list_media_empty(client: TestClient) -> None:
+    """An empty catalog returns an empty list."""
+    response = client.get("/api/v2/media")
+
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()).is_equal_to([])
+
+
+def test_list_and_get_media(client: TestClient, db_session: Session) -> None:
+    """A stored media item is listed and retrievable by id."""
+    db_session.add(Media(type=MediaType.BOOK, title="Dune", author="Herbert"))
+    db_session.commit()
+
+    listed = client.get("/api/v2/media")
+    assert_that(listed.status_code).is_equal_to(200)
+    body = listed.json()
+    assert_that(body).is_length(1)
+    assert_that(body[0]["type"]).is_equal_to("book")
+    assert_that(body[0]["title"]).is_equal_to("Dune")
+
+    media_id = body[0]["id"]
+    fetched = client.get(f"/api/v2/media/{media_id}")
+    assert_that(fetched.status_code).is_equal_to(200)
+    assert_that(fetched.json()["author"]).is_equal_to("Herbert")
+
+
+def test_list_media_filtered_by_type(client: TestClient, db_session: Session) -> None:
+    """The media_type query filter narrows the results."""
+    db_session.add(Media(type=MediaType.BOOK, title="Dune"))
+    db_session.add(Media(type=MediaType.MOVIE, title="Arrival"))
+    db_session.commit()
+
+    response = client.get("/api/v2/media", params={"media_type": "movie"})
+
+    assert_that(response.status_code).is_equal_to(200)
+    body = response.json()
+    assert_that(body).is_length(1)
+    assert_that(body[0]["title"]).is_equal_to("Arrival")
+
+
+def test_get_media_not_found(client: TestClient) -> None:
+    """An unknown media id returns 404."""
+    response = client.get("/api/v2/media/999")
+
+    assert_that(response.status_code).is_equal_to(404)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(api): add media catalog model and read endpoints`
- Type:
  - [x] feat (minor)

## What's Changing

Third data vertical — the canonical media catalog (books, films, studies, …).

- **`MediaType`** StrEnum + SQLAlchemy **`Media`** model (enum stored as varchar
  via `native_enum=False`).
- **`GET /api/v2/media`** (list, optional `?media_type` filter, by title) and
  **`/api/v2/media/{id}`** (detail, 404) with a `MediaRead` schema.
- 4 media tests; suite now **16 tests at 96.9% coverage**.

Validated locally: ruff, ruff-format, strict mypy (28 files), bandit, pytest.

## Checklist

- [x] Title follows Conventional Commits

## Related Issues

Related #31, #47

## Details

- `media_type` query param (not `type`) to avoid shadowing the builtin.
- ORM subclass covered by the existing `podex.models.*` mypy override; endpoints
  use `add_api_route`; tests use `assertpy`; no ignores.
- Reference PR: #103.