### PR TITLE
feat(api): add mentions linking media to episodes

### DIFF
--- a/backend/src/podex/api/v2/episodes.py
+++ b/backend/src/podex/api/v2/episodes.py
@@ -4,8 +4,9 @@ from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
 
 from podex.api.deps import DbSession
-from podex.models import Episode
+from podex.models import Episode, Mention
 from podex.schemas.episode import EpisodeRead
+from podex.schemas.mention import MentionRead
 
 router = APIRouter(prefix="/episodes", tags=["episodes"])
 
@@ -26,11 +27,29 @@ def get_episode(episode_id: int, db: DbSession) -> Episode:
     return episode
 
 
+def list_episode_mentions(episode_id: int, db: DbSession) -> list[Mention]:
+    """List media mentions within an episode, ordered by timestamp."""
+    if db.get(Episode, episode_id) is None:
+        raise HTTPException(status_code=404, detail="Episode not found")
+    statement = (
+        select(Mention)
+        .where(Mention.episode_id == episode_id)
+        .order_by(Mention.timestamp_seconds)
+    )
+    return list(db.execute(statement).scalars().all())
+
+
 router.add_api_route(
     "",
     list_episodes,
     methods=["GET"],
     response_model=list[EpisodeRead],
+)
+router.add_api_route(
+    "/{episode_id}/mentions",
+    list_episode_mentions,
+    methods=["GET"],
+    response_model=list[MentionRead],
 )
 router.add_api_route(
     "/{episode_id}",

--- a/backend/src/podex/api/v2/media.py
+++ b/backend/src/podex/api/v2/media.py
@@ -4,8 +4,9 @@ from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
 
 from podex.api.deps import DbSession
-from podex.models import Media, MediaType
+from podex.models import Media, MediaType, Mention
 from podex.schemas.media import MediaRead
+from podex.schemas.mention import MentionRead
 
 router = APIRouter(prefix="/media", tags=["media"])
 
@@ -26,11 +27,27 @@ def get_media(media_id: int, db: DbSession) -> Media:
     return media
 
 
+def list_media_mentions(media_id: int, db: DbSession) -> list[Mention]:
+    """List episode mentions of a media item."""
+    if db.get(Media, media_id) is None:
+        raise HTTPException(status_code=404, detail="Media not found")
+    statement = (
+        select(Mention).where(Mention.media_id == media_id).order_by(Mention.episode_id)
+    )
+    return list(db.execute(statement).scalars().all())
+
+
 router.add_api_route(
     "",
     list_media,
     methods=["GET"],
     response_model=list[MediaRead],
+)
+router.add_api_route(
+    "/{media_id}/mentions",
+    list_media_mentions,
+    methods=["GET"],
+    response_model=list[MentionRead],
 )
 router.add_api_route(
     "/{media_id}",

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -7,6 +7,7 @@ metadata-based table creation and Alembic autogenerate see every table.
 from podex.models.base import Base
 from podex.models.episode import Episode
 from podex.models.media import Media, MediaType
+from podex.models.mention import Mention
 from podex.models.podcast import Podcast
 
-__all__ = ["Base", "Episode", "Media", "MediaType", "Podcast"]
+__all__ = ["Base", "Episode", "Media", "MediaType", "Mention", "Podcast"]

--- a/backend/src/podex/models/mention.py
+++ b/backend/src/podex/models/mention.py
@@ -1,0 +1,32 @@
+"""Mention ORM model linking media to episodes."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class Mention(Base):
+    """An occurrence of a media item referenced within an episode."""
+
+    __tablename__ = "mentions"
+    __table_args__ = (Index("ix_mentions_episode_media", "episode_id", "media_id"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    episode_id: Mapped[int] = mapped_column(
+        ForeignKey("episodes.id", ondelete="CASCADE"),
+        index=True,
+    )
+    media_id: Mapped[int] = mapped_column(
+        ForeignKey("media.id", ondelete="CASCADE"),
+        index=True,
+    )
+    timestamp_seconds: Mapped[int | None] = mapped_column(default=None)
+    context: Mapped[str | None] = mapped_column(String(2000), default=None)
+    confidence: Mapped[float | None] = mapped_column(default=None)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )

--- a/backend/src/podex/schemas/mention.py
+++ b/backend/src/podex/schemas/mention.py
@@ -1,0 +1,19 @@
+"""Mention API schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class MentionRead(BaseModel):
+    """Public representation of a media mention within an episode."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    episode_id: int
+    media_id: int
+    timestamp_seconds: int | None
+    context: str | None
+    confidence: float | None
+    created_at: datetime

--- a/backend/tests/test_mentions.py
+++ b/backend/tests/test_mentions.py
@@ -1,0 +1,80 @@
+"""Tests for the nested mention endpoints."""
+
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.models import Episode, Media, MediaType, Mention, Podcast
+
+
+def _seed_mention(db: Session) -> Mention:
+    podcast = Podcast(name="The Show", slug="the-show")
+    db.add(podcast)
+    db.commit()
+    episode = Episode(podcast_id=podcast.id, title="Pilot")
+    media = Media(type=MediaType.BOOK, title="Dune")
+    db.add_all([episode, media])
+    db.commit()
+    mention = Mention(
+        episode_id=episode.id,
+        media_id=media.id,
+        timestamp_seconds=42,
+        context="a great book",
+    )
+    db.add(mention)
+    db.commit()
+    return mention
+
+
+def test_episode_mentions(client: TestClient, db_session: Session) -> None:
+    """An episode's mentions are listed."""
+    mention = _seed_mention(db_session)
+
+    response = client.get(f"/api/v2/episodes/{mention.episode_id}/mentions")
+
+    assert_that(response.status_code).is_equal_to(200)
+    body = response.json()
+    assert_that(body).is_length(1)
+    assert_that(body[0]["media_id"]).is_equal_to(mention.media_id)
+    assert_that(body[0]["timestamp_seconds"]).is_equal_to(42)
+
+
+def test_media_mentions(client: TestClient, db_session: Session) -> None:
+    """A media item's mentions are listed."""
+    mention = _seed_mention(db_session)
+
+    response = client.get(f"/api/v2/media/{mention.media_id}/mentions")
+
+    assert_that(response.status_code).is_equal_to(200)
+    body = response.json()
+    assert_that(body).is_length(1)
+    assert_that(body[0]["episode_id"]).is_equal_to(mention.episode_id)
+
+
+def test_episode_mentions_empty(client: TestClient, db_session: Session) -> None:
+    """An episode with no mentions returns an empty list."""
+    podcast = Podcast(name="The Show", slug="the-show")
+    db_session.add(podcast)
+    db_session.commit()
+    episode = Episode(podcast_id=podcast.id, title="Pilot")
+    db_session.add(episode)
+    db_session.commit()
+
+    response = client.get(f"/api/v2/episodes/{episode.id}/mentions")
+
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()).is_equal_to([])
+
+
+def test_episode_mentions_not_found(client: TestClient) -> None:
+    """Mentions for an unknown episode return 404."""
+    response = client.get("/api/v2/episodes/999/mentions")
+
+    assert_that(response.status_code).is_equal_to(404)
+
+
+def test_media_mentions_not_found(client: TestClient) -> None:
+    """Mentions for an unknown media item return 404."""
+    response = client.get("/api/v2/media/999/mentions")
+
+    assert_that(response.status_code).is_equal_to(404)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(api): add mentions linking media to episodes`
- Type:
  - [x] feat (minor)

## What's Changing

The **core media-index relationship** — a media item mentioned within an
episode (timestamp, context, confidence). This ties the catalog together.

- SQLAlchemy **`Mention`** model (FKs to `episodes` + `media`, composite index).
- **`GET /api/v2/episodes/{id}/mentions`** (by timestamp) and
  **`GET /api/v2/media/{id}/mentions`** (by episode) — both 404 on unknown
  parent — with a `MentionRead` schema.
- 5 mention tests; suite now **21 tests at 97.4% coverage**.

Validated locally: ruff, ruff-format, strict mypy (31 files), bandit, pytest.

## Checklist

- [x] Title follows Conventional Commits

## Related Issues

Related #31, #45

## Details

- Nested routes on the existing episodes/media routers; `add_api_route`;
  `assertpy` tests; test helper returns the `Mention` object (avoids the
  dep-less `no-any-return` trap). No ignores.
- Reference PR: #103.