### PR TITLE
chore(ci): add CodeQL code scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+---
+paths-ignore:
+  - backend/tests/**
+  - backend/alembic/versions/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+---
+name: Security - CodeQL Code Scanning
+
+"on":
+  push:
+    branches: [main]
+    paths: ['**.py', 'pyproject.toml', '.github/**']
+  pull_request:
+    branches: [main]
+    paths: ['**.py', 'pyproject.toml', '.github/**']
+  merge_group:
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  codeql:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    with:
+      languages: python
+      build-mode: none
+      config-file: .github/codeql/codeql-config.yml
+      category: '/language:all'
+      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      egress-policy: block
+      egress-preset: github-tooling
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `chore(ci): add CodeQL code scanning`
- Type:
  - [x] chore / ci / style

## What's Changing

Adds **CodeQL** Python code scanning (build-mode `none`, lgtm-ci v0.41.0) with a
config that ignores `backend/tests/**` and generated `alembic/versions/**`.

Part of the #114 security adoption. `sbom` and `security-audit` follow with the
deployment/deps slice — they carry the same monorepo `working-directory`
nuance that bit `test-python`, so they're grouped there rather than rushed here.

## Checklist

- [x] Title follows Conventional Commits

## Related Issues

Related #114

## Details

- CodeQL autodetects Python across the monorepo (no working-directory needed).
- Reference PR: #103.