### PR TITLE
ci: add frontend CI (astro check + vitest)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,42 @@
+---
+name: CI - Frontend
+
+"on":
+  push:
+    branches: [main]
+    paths: ['frontend/**', '.github/workflows/frontend-ci.yml']
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths: ['frontend/**', '.github/workflows/frontend-ci.yml']
+  merge_group:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: frontend-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  frontend:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node-custom.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    with:
+      package-manager: bun
+      working-directory: frontend
+      # astro check then vitest with coverage (threshold in vitest.config.ts);
+      # the && short-circuits so a check failure also fails the job.
+      test-command: 'bun run check && bun run test:coverage'
+      coverage: true
+      job-name: Frontend Checks
+      node-version: '22'
+      draft-pr-skip: true
+      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      # audit (not block) for now: no ready egress preset covers the node/bun
+      # install registries. Tighten to block with an explicit allowlist later.
+      egress-policy: audit
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ downloads/
 eggs/
 .eggs/
 lib/
+# The bare lib/ pattern above (Python build artifacts) also matches the
+# frontend TypeScript source directory; keep that source tracked.
+!frontend/src/lib/
+!frontend/src/lib/**
 lib64/
 parts/
 sdist/

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchPodcasts } from "./api";
+import type { Podcast } from "./types";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchPodcasts", () => {
+  it("returns the parsed podcast list", async () => {
+    const podcasts: Podcast[] = [
+      {
+        id: 1,
+        name: "The Example Show",
+        slug: "example-show",
+        description: null,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(podcasts), { status: 200 }),
+      ),
+    );
+
+    await expect(fetchPodcasts()).resolves.toEqual(podcasts);
+  });
+
+  it("throws on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 500 })),
+    );
+
+    await expect(fetchPodcasts()).rejects.toThrow(/500/);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,11 @@
+import { API_BASE_URL } from "./config";
+import type { Podcast } from "./types";
+
+/** Fetch the list of podcasts from the Podex API. */
+export async function fetchPodcasts(): Promise<Podcast[]> {
+  const response = await fetch(`${API_BASE_URL}/podcasts`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch podcasts: ${response.status}`);
+  }
+  return (await response.json()) as Podcast[];
+}

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,0 +1,3 @@
+/** Base URL for the Podex v2 API. */
+export const API_BASE_URL: string =
+  import.meta.env.PUBLIC_API_URL ?? "http://localhost:8000/api/v2";

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,8 @@
+/** A podcast source in the catalog. */
+export interface Podcast {
+  id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  created_at: string;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       provider: "v8",
       include: ["src/lib/**", "src/components/**/*.tsx"],
       exclude: ["src/test/**", "**/*.d.ts"],
-      reporter: ["text", "lcovonly"],
+      reporter: ["text", "lcovonly", "json-summary"],
       thresholds: { lines: 85, functions: 85, branches: 85, statements: 85 },
     },
   },


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `ci: add frontend CI (astro check + vitest)`
- Type:
  - [x] chore / ci / style

## What's Changing

Adds `frontend-ci.yml` so the frontend is validated in CI — closing the gap the
Astro 7 bump exposed (#140 was green while the frontend build was broken).

- `reusable-test-node-custom` (lgtm-ci v0.41.0), `package-manager: bun`,
  `working-directory: frontend`.
- `test-command: bun run check && bun run test:coverage` — **astro check** then
  **vitest** with the 85% coverage threshold from `vitest.config.ts`.
- Path-filtered to `frontend/**` (+ this workflow), so it only runs on frontend
  changes. **This PR self-tests it** (it touches the workflow file).

## Checklist

- [x] Title follows Conventional Commits

## Related Issues

Closes #144. Related #114, #17, #18.

## Details

- `egress-policy: audit` for now — no ready egress preset covers the node/bun
  install registries; tightening to `block` with an explicit allowlist is a
  noted follow-up.
- Adding this as an org-ruleset **required** check is a separate coordination
  step (the `checks-podex` ruleset is org-managed).
- Reference PR: #103.