### PR TITLE
feat(ci): add merge_group trigger to PR title validation

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -5,6 +5,7 @@ name: PR - Title Validation
 "on":
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
+  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(ci): add merge_group trigger to PR title validation`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Org merge-queue rollout (lgtm-hq/lgtm-ci#421): `check / 📝 Validate PR Title` is a required check but `semantic-pr-title.yml` only triggered on `pull_request`, so queue entries would time out. All other podex required-check workflows (quality-ci, test-ci) already carry `merge_group:`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing (not user-facing)

## Closes

- Closes #147
- Relates to lgtm-hq/lgtm-ci#421

## Details

Verified the pinned reusable (`reusable-semantic-pr-title.yml@96a42109`, v0.45.1) contains the `if: github.event_name != 'merge_group'` guard: on merge_group the job reports as skipped (validation already happened on the PR event), which satisfies the required check. Greptile flagged exactly this dependency (P1) — confirmed present at the pinned SHA. CodeRabbit: rate-limited, treated as done per protocol. `uv run lintro chk` clean.