### PR TITLE
chore(ci): adopt lgtm-ci v0.52.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,13 +22,13 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       languages: python
       build-mode: none
       config-file: .github/codeql/codeql-config.yml
       category: '/language:all'
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,8 +21,22 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: scorecard
-      allowed-endpoints-mode: append
-      allowed-endpoints: |
+      # replace (not append): the reusable's first harden-runner step applies
+      # allowed-endpoints verbatim before presets resolve, so a partial append
+      # list blocks github.com at checkout. Full scorecard preset expansion
+      # plus project extras, mirroring lgtm-ci's own caller at v0.52.3.
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        gcr.io:443
+        api.osv.dev:443
+        api.scorecard.dev:443
+        api.securityscorecards.dev:443
         api.deps.dev:443
         release-assets.githubusercontent.com:443
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,10 +15,10 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       fail-on-severity: high
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   frontend:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node-custom.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node-custom.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       package-manager: bun
       working-directory: frontend
@@ -32,7 +32,7 @@ jobs:
       job-name: Frontend Checks
       node-version: '22'
       draft-pr-skip: true
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       # audit (not block) for now: no ready egress preset covers the node/bun
       # install registries. Tighten to block with an explicit allowlist later.
       egress-policy: audit

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,11 +12,11 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@96a42109637efd4c019d176e0902e3be23295716  # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       job-name: "👤 Auto Assign PR Author"
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716'  # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,12 +11,12 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@96a42109637efd4c019d176e0902e3be23295716  # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       job-name: "🏷️ Auto Label PR"
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716'  # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/quality-ci.yml
+++ b/.github/workflows/quality-ci.yml
@@ -19,12 +19,12 @@ concurrency:
 jobs:
   quality:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     permissions:
       contents: read
       packages: read
     with:
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       working-directory: backend
       # yamllint disable-line rule:line-length
       lintro-image: ghcr.io/lgtm-hq/py-lintro@sha256:95b9fd9d62c3ca1227447467767ec915e78a7eef62282dd18c0b1c02ee4d3887
@@ -41,11 +41,11 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     permissions:
       contents: read
     with:
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       job-name: '🛠️ Lintro Code Quality'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.quality.result }}
@@ -65,12 +65,12 @@ jobs:
         || github.event.action == 'ready_for_review'
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     permissions:
       contents: read
       pull-requests: write
     with:
       exit-code: ${{ needs.quality.outputs.exit-code }}
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: github-tooling

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -15,14 +15,14 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       # Default version-source (commit) reads the version from the merged
       # `chore(release): version X.Y.Z` commit — language-agnostic, so no
       # version-source/version-file needed for the backend/ monorepo layout.
       # Podex ships GitHub Releases (Docker images to GHCR on tag), not PyPI.
       create-release: true
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     secrets:

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       ecosystems: python
       # yamllint disable-line rule:line-length
@@ -25,7 +25,7 @@ jobs:
       max-bump: major
       # Patch releases auto-merge; minor/major need explicit review.
       auto-merge-patch-only: true
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: pypi
     secrets:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -16,10 +16,10 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@96a42109637efd4c019d176e0902e3be23295716  # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       job-name: "🛡️ Scorecard Analysis"
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716'  # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,8 +22,22 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: scorecard
-      allowed-endpoints-mode: append
+      # replace (not append): the reusable's first harden-runner step applies
+      # allowed-endpoints verbatim before presets resolve, so a partial append
+      # list blocks github.com at checkout. Full scorecard preset expansion
+      # plus project extras.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        gcr.io:443
+        api.osv.dev:443
+        api.scorecard.dev:443
+        api.securityscorecards.dev:443
         agent.api.stepsecurity.io:443
         api.deps.dev:443
         api.osv.dev:443

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -16,10 +16,10 @@ concurrency:
 jobs:
   check:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@96a42109637efd4c019d176e0902e3be23295716  # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       job-name: "📝 Validate PR Title"
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716'  # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       comment-marker: "<!-- semantic-pr-title -->"

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -17,21 +17,48 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Compat mode (lgtm-ci contract #340): multi-runtime matrix must not
+  # collect coverage or publish PR summaries.
+  # Org ruleset (checks-podex): test / Aggregate Python Results
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
       python-versions: '3.11,3.12,3.13'
       working-directory: backend
       test-path: tests
-      coverage: true
-      coverage-format: auto
-      coverage-threshold: 85
-      upload-coverage: true
+      coverage: false
+      publish-test-summary: false
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
+      egress-policy: block
+      egress-preset: quality
+    permissions:
+      # multi-version matrix requires actions:write for artifact aggregation
+      actions: write
+      contents: read
+      pull-requests: write
+
+  # Coverage mode (lgtm-ci contract #340): single runtime with coverage
+  # reporting and the PR test summary comment.
+  test-coverage:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
+    with:
+      python-version: '3.13'
+      working-directory: backend
+      test-path: tests
+      coverage: true
+      coverage-format: json
+      coverage-threshold: 85
+      upload-coverage: true
+      publish-test-summary: true
+      draft-pr-skip: true
+      job-name: Python Coverage
+      runner-image: ubuntu-24.04
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: quality
     permissions:

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -19,9 +19,9 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@cecca744299be6a34f3b4ea4f18c00262081ab61  # v0.41.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:
-      tooling-ref: 'cecca744299be6a34f3b4ea4f18c00262081ab61'  # v0.41.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     permissions:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ci): adopt lgtm-ci v0.52.3
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Unifies the split lgtm-ci pins (v0.41.0 ×10, v0.45.1 ×4) at a single tooling ref, `66cad82ead0e5d119928c895c7d7da9c837989e5` (`v0.52.3`), across all 14 reusable workflow `uses:` pins and their `tooling-ref` inputs, with `# v0.52.3` comments on every pin (Renovate-trackable).

### Migrations applied (v0.41.0 → v0.52.3 gap, per `lgtm-ci/docs/workflow-contract.md`)

- **Compat vs coverage contract (lgtm-ci#340)** — `test-ci.yml` split into two modes, matching the py-lintro reference consumer:
  - `test` (compat): keeps the `3.11,3.12,3.13` matrix, now with `coverage: false` and `publish-test-summary: false`. The v0.52.3 contract-enforcement script fails any multi-version matrix combined with coverage or summary publishing, so the previous single-job config would hard-fail.
  - `test-coverage` (new): single `python-version: '3.13'` with `coverage: true`, `coverage-threshold: 85`, `upload-coverage: true`, `publish-test-summary: true` — coverage enforcement and the PR summary comment move here.
- **`coverage-format: auto` → `json`** — `auto` is not a recognized format at v0.52.3 (`run-pytest.sh` warns and falls back); `json` is the documented format for rich coverage PR comments with `upload-coverage: true`.
- **Test summary publishing (#281)** — no caller-side renames needed: podex never passed `post-pr-comment`/`coverage-pr-comment`; `publish-test-summary` is now passed explicitly in both test jobs. The `publish-quality-summary` caller job already matches the post-#281 naming and its `exit-code`/`status` outputs are unchanged at v0.52.3.
- **Input audit** — every input passed by all 14 callers was verified to exist in the corresponding reusable at `66cad82` (including `status-output`/`status-expected` on `reusable-required-check` and `comment-marker` on `reusable-semantic-pr-title`). The only breaking change in the gap (`reusable-sbom` `fail-on-severity` default, v0.52.0) does not apply — podex does not call `reusable-sbom`.
- **`draft-pr-skip`** — now defaults to `true` upstream; podex already passes it explicitly, so behavior is unchanged.

### Contract conformance

- `merge_group:` trigger present on every required-check caller (`quality-ci`, `test-ci`, `semantic-pr-title`).
- No `on.*.paths` filters on any required-check workflow (paths remain only on non-required workflows: codeql, frontend-ci, validate-action-pinning).

## Ruleset lockstep

None — all required check names in the `checks-podex` org ruleset are preserved:

| Required check | Status |
| --- | --- |
| `quality / Lintro Quality Checks` | unchanged (reusable default `job-name` still `Lintro Quality Checks`) |
| `lintro-code-quality / 🛠️ Lintro Code Quality` | unchanged |
| `check / 📝 Validate PR Title` | unchanged |
| `test / Aggregate Python Results` | unchanged — the `aggregate` job still runs for any non-empty `python-versions` matrix, independent of coverage |
| `Socket Security: Pull Request Alerts` | external app, unaffected |

The new `test-coverage / Python Coverage` check is additive and not part of the ruleset.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing (N/A — CI-only change)

## Related Issues

## Closes

- Closes #151

Related: epic lgtm-hq/lgtm-ci#510

## Details

Verification: all pins grep-verified at the new SHA; every passed input validated against the reusable workflow definitions checked out at tag `v0.52.3` (= `66cad82ead0e5d119928c895c7d7da9c837989e5`); workflow YAML parse-checked; `uv run lintro fmt` + `uv run lintro chk` pass with no issues.
