### PR TITLE
chore(ci): adopt canonical emoji check names

### DIFF
--- a/.github/workflows/quality-ci.yml
+++ b/.github/workflows/quality-ci.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Org ruleset (checks-podex): quality / 🛠️ Lintro Code Quality
   quality:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
@@ -24,6 +25,7 @@ jobs:
       contents: read
       packages: read
     with:
+      job-name: '🛠️ Lintro Code Quality'
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       working-directory: backend
       # yamllint disable-line rule:line-length

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -14,7 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  # Org ruleset (checks-podex): semantic-title / 📝 Validate PR Title
+  semantic-title:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@66cad82ead0e5d119928c895c7d7da9c837989e5  # v0.52.3
     with:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -30,7 +30,7 @@ jobs:
       coverage: false
       publish-test-summary: false
       draft-pr-skip: true
-      job-name: Python Compatibility
+      job-name: '🧪 Python Compatibility'
       runner-image: ubuntu-24.04
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
@@ -56,7 +56,7 @@ jobs:
       upload-coverage: true
       publish-test-summary: true
       draft-pr-skip: true
-      job-name: Python Coverage
+      job-name: '🧪 Python Coverage'
       runner-image: ubuntu-24.04
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title:

  ```text
  chore(ci): adopt canonical emoji check names
  ```

- Type:
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adopt the org's canonical emoji check-name scheme (lgtm-hq/lgtm-ci#514) in workflow caller job ids and `job-name` inputs:

- `quality-ci.yml`: set `job-name: '🛠️ Lintro Code Quality'` on the `quality` caller (was the reusable workflow default `Lintro Quality Checks`).
- `semantic-pr-title.yml`: rename caller job id `check` → `semantic-title` (check context becomes `semantic-title / 📝 Validate PR Title`). No `needs:` references to the old id exist.
- `test-ci.yml`: brand non-required contexts — `job-name: '🧪 Python Compatibility'` (test) and `job-name: '🧪 Python Coverage'` (test-coverage). The required `test / Aggregate Python Results` context is contract-static and unchanged.

## Ruleset lockstep

The `checks-podex` org ruleset must be updated in lockstep at merge time (coordinator-managed, temporary merge-queue disable). Only REQUIRED contexts that change:

| Required context (before) | Required context (after) |
| --- | --- |
| `quality / Lintro Quality Checks` | `quality / 🛠️ Lintro Code Quality` |
| `check / 📝 Validate PR Title` | `semantic-title / 📝 Validate PR Title` |

`test / Aggregate Python Results` is unchanged and needs no ruleset edit.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing (not user-facing)

## Related Issues

Closes #156 | Related lgtm-hq/lgtm-ci#514

## Details

- Caller-side only; no reusable workflow changes. lgtm-ci pins remain at v0.52.3.
- Verified with lintro (yamllint + actionlint): no issues.
- Do not merge until the coordinator schedules the ruleset lockstep window.
