### PR TITLE
fix(ci): pass complete egress allowlists to main-only workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,22 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
+      # CodeQL bundle downloads redirect to
+      # release-assets.githubusercontent.com, which the github-tooling preset
+      # lacks. The reusable's setup job hardens with this raw input before
+      # the allowlist resolver runs, and since lgtm-ci v0.50.0 a caller
+      # allowed-endpoints REPLACES the baseline, so the complete endpoint
+      # list must be passed (reusable input default plus the release-assets
+      # host) rather than a single appended host (lgtm-hq/lgtm-ci#517).
+      allowed-endpoints: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -28,6 +28,21 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5'  # v0.52.3
       egress-policy: block
       egress-preset: pypi
+      # The reusable's version-pr job hardens with this raw input before the
+      # allowlist resolver can apply the pypi preset, and since lgtm-ci
+      # v0.50.0 a caller allowed-endpoints REPLACES the baseline, so the
+      # complete endpoint list (github baseline plus the PyPI hosts pip
+      # needs) must be passed (lgtm-hq/lgtm-ci#517).
+      allowed-endpoints: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
+        pypi.org:443
+        files.pythonhosted.org:443
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): pass complete egress allowlists to main-only workflows
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Both main-only workflows fail on `main` after the lgtm-ci v0.52.3 upgrade because of harden-runner egress blocks:

- **Security - CodeQL Code Scanning** (run 29161349715): `ECONNREFUSED` downloading the CodeQL bundle v2.26.0 — the download redirects to `release-assets.githubusercontent.com:443`, which the `github-tooling` preset lacks (lgtm-hq/lgtm-ci#517).
- **Release - Version PR** (run 29161349712): pip cannot reach `pypi.org` (Connection refused) despite `egress-preset: pypi`.

Since lgtm-ci v0.50.0, a caller-supplied `allowed-endpoints` REPLACES the baseline (space-separated), and the reusable workflows harden the runner with the raw input before the allowlist resolver can apply the egress preset. This PR passes complete folded-scalar endpoint lists to both callers:

- `codeql.yml`: github baseline + `release-assets.githubusercontent.com:443`
- `release-version-pr.yml`: github baseline + `pypi.org:443` + `files.pythonhosted.org:443`

Mirrors the prior art in `winnow` (commit 94cc565) and `homebrew-tap`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Related Issues

Closes #160

## Details

Caller-side workaround for lgtm-hq/lgtm-ci#517 (reusable workflows harden with the raw `allowed-endpoints` input before the preset resolver runs). Verification: after merge, confirm the merge-triggered `Security - CodeQL Code Scanning` and `Release - Version PR` runs on `main` succeed.
