### PR TITLE
chore(deps): hold TypeScript 7 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>lgtm-hq/.github:renovate-config"]
+  "extends": ["local>lgtm-hq/.github:renovate-config"],
+  "packageRules": [
+    {
+      "description": "Hold TypeScript 7 until Astro/@astrojs/check support it",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Renovate hold: `typescript <7` (Astro/`@astrojs/check` peer limit; matches frontend pin from #150).
- Lets us close #173 without Renovate recreating it.

## Closes
- Relates to #173