### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Podex is a monorepo with two apps that together form the product:
+
+- `backend/` — FastAPI + SQLAlchemy REST API (`/api/v2` + `/health`), managed with `uv`, SQLite by default.
+- `frontend/` — Astro/React/Tailwind SSR discovery site (port 4321), managed with `bun`, which fetches podcasts from the backend.
+
+Standard commands live in `CONTRIBUTING.md` and the manifests (`backend/pyproject.toml`, `frontend/package.json`); prefer those. Key ones: backend tests `uv run pytest`, backend lint `uv run lintro chk` / `uv run lintro fmt`, frontend tests `bun run test:run`, frontend type/build check `bun run check`.
+
+Non-obvious caveats:
+
+- **Backend deps: run `uv sync` (not `uv sync --extra dev`).** `CONTRIBUTING.md` says `--extra dev`, but `dev` is a `[dependency-groups]` entry, not an optional extra, so `--extra dev` fails. `uv sync` installs the dev group by default.
+- **Run migrations before starting/using the API:** `cd backend && uv run alembic upgrade head`. `alembic.ini` has an empty `sqlalchemy.url`; `alembic/env.py` falls back to `PODEX_DATABASE_URL` (default `sqlite:///./podex.db`), so migrations and the app share the same DB file created in the `backend/` working dir. This is a one-shot setup step and is intentionally NOT in the automatic update script.
+- **Run the servers from their app dirs:**
+  - Backend: `cd backend && uv run uvicorn podex.main:app --reload --port 8000`
+  - Frontend: `cd frontend && bun run dev` (serves on `http://localhost:4321`)
+- **Frontend → backend wiring:** the frontend calls `http://localhost:8000/api/v2` by default (override with `PUBLIC_API_URL`); backend CORS already allows `http://localhost:4321`. Start the backend before the frontend for data to load.
+- **The `/api/v2` surface is read-only (GET only).** There are no write endpoints yet; the LLM ingestion pipeline described in the README is not implemented. To get data into the catalog for local testing, seed rows directly via the ORM (e.g. `uv run python -c "..."` using `podex.database.SessionLocal` and `podex.models.Podcast`). An empty catalog renders "No podcasts yet." in the UI.
+- `uv` is installed at `~/.local/bin/uv` and `bun` at `~/.bun/bin/bun` (added to `~/.bashrc` at setup time).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Podex development environment (backend + frontend) for Cursor Cloud agents, and documents durable, non-obvious setup caveats in a new `AGENTS.md`.

No application code was changed. The only committed change is `AGENTS.md`. Dependency refresh is handled by the registered update script (`uv sync --project backend` + `bun install --cwd frontend`).

## What was verified

**Backend** (`backend/`, FastAPI + SQLAlchemy, `uv`, SQLite)
- Install: `uv sync`
- Migrations: `uv run alembic upgrade head`
- Tests: `uv run pytest` — 23 passed
- Lint: `uv run lintro chk` — 100/100
- Run: `uv run uvicorn podex.main:app --reload --port 8000`

**Frontend** (`frontend/`, Astro/React/Tailwind, `bun`)
- Install: `bun install`
- Tests: `bun run test:run` — 2 passed
- Check: `bun run check` — 0 errors
- Run: `bun run dev` (port 4321)

## Hello-world end-to-end

Seeded a demo podcast via the ORM, confirmed it is served by `GET /api/v2/podcasts` and rendered by the Astro SSR frontend at `http://localhost:4321/`.

[podex_frontend_backend_demo.mp4](https://cursor.com/agents/bc-8d4203c3-7b62-43dd-ad99-c1d27e1e5d8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpodex_frontend_backend_demo.mp4)

[Podex frontend rendering the seeded podcast](https://cursor.com/agents/bc-8d4203c3-7b62-43dd-ad99-c1d27e1e5d8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpodex_frontend_ui.webp)
[Backend API JSON response](https://cursor.com/agents/bc-8d4203c3-7b62-43dd-ad99-c1d27e1e5d8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpodex_api_json.webp)

## Notes captured in AGENTS.md
- Use `uv sync` (not `uv sync --extra dev` as CONTRIBUTING.md says) — `dev` is a dependency-group, not an extra.
- Run `alembic upgrade head` before using the API (empty `sqlalchemy.url` falls back to `PODEX_DATABASE_URL`).
- The `/api/v2` surface is read-only; seed data via the ORM for local testing.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d4203c3-7b62-43dd-ad99-c1d27e1e5d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d4203c3-7b62-43dd-ad99-c1d27e1e5d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

