### PR TITLE
chore(deps): group TypeScript with Astro tooling in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,12 @@
       "description": "Hold TypeScript 7 until Astro/@astrojs/check support it",
       "matchPackageNames": ["typescript"],
       "allowedVersions": "<7"
+    },
+    {
+      "description": "Group TypeScript with Astro tooling to prevent split PRs",
+      "matchPackageNames": ["typescript", "@astrojs/check", "@astrojs/language-server"],
+      "groupName": "TypeScript and Astro tooling",
+      "groupSlug": "typescript-astro-tooling"
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(deps): group TypeScript with Astro tooling in Renovate
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Completes the residual Renovate side of #168: keep the existing `typescript <7` hold, and group `typescript` with `@astrojs/check` / `@astrojs/language-server` so majors cannot land in split PRs again.

The original `astro check` crash under TypeScript 7 is already mitigated on `main` (`typescript` pinned to `6.0.3`, plus the `#174` allowlist).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #168

## Details

Adds a second `packageRule` with `groupName` / `groupSlug` for the three packages, separate from the `allowedVersions: "<7"` rule so the version hold stays typescript-only.

Verification: valid JSON; `uv run lintro chk` clean for this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

