### PR TITLE
docs(backend): add Google docstrings to helper functions

### DIFF
--- a/backend/src/podex/database.py
+++ b/backend/src/podex/database.py
@@ -15,6 +15,12 @@ def enable_sqlite_foreign_keys(target_engine: Engine) -> None:
         return
 
     def _set_pragma(dbapi_connection: Any, _record: Any) -> None:
+        """Enable the foreign_keys pragma on each new SQLite connection.
+
+        Args:
+            dbapi_connection: The raw DBAPI connection being checked out.
+            _record: The connection pool record (unused).
+        """
         cursor = dbapi_connection.cursor()
         cursor.execute("PRAGMA foreign_keys=ON")
         cursor.close()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -38,6 +38,7 @@ def client(db_session: Session) -> Iterator[TestClient]:
     app = create_app()
 
     def override_get_db() -> Iterator[Session]:
+        """Yield the test database session in place of the real one."""
         yield db_session
 
     app.dependency_overrides[get_db] = override_get_db

--- a/backend/tests/test_episodes.py
+++ b/backend/tests/test_episodes.py
@@ -15,6 +15,16 @@ def _seed_podcast(
     slug: str = "example-show",
     name: str = "The Example Show",
 ) -> Podcast:
+    """Insert a podcast row into the database and return it.
+
+    Args:
+        db: Active SQLAlchemy session.
+        slug: URL-safe podcast identifier.
+        name: Human-readable podcast title.
+
+    Returns:
+        The newly created and committed Podcast instance.
+    """
     podcast = Podcast(name=name, slug=slug)
     db.add(podcast)
     db.commit()

--- a/backend/tests/test_mentions.py
+++ b/backend/tests/test_mentions.py
@@ -8,7 +8,9 @@ from podex.models import Episode, Media, MediaType, Mention, Podcast
 
 
 def _seed_mention(db: Session) -> Mention:
-    """Insert a complete mention fixture (podcast, episode, media, mention) and return it.
+    """Insert and return a complete mention fixture.
+
+    Builds a podcast, episode, media item, and the mention that links them.
 
     Args:
         db: Active SQLAlchemy session.

--- a/backend/tests/test_mentions.py
+++ b/backend/tests/test_mentions.py
@@ -8,6 +8,14 @@ from podex.models import Episode, Media, MediaType, Mention, Podcast
 
 
 def _seed_mention(db: Session) -> Mention:
+    """Insert a complete mention fixture (podcast, episode, media, mention) and return it.
+
+    Args:
+        db: Active SQLAlchemy session.
+
+    Returns:
+        The newly created and committed Mention instance.
+    """
     podcast = Podcast(name="The Show", slug="the-show")
     db.add(podcast)
     db.commit()

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -15,6 +15,14 @@ _ALEMBIC_INI = Path(__file__).resolve().parent.parent / "alembic.ini"
 
 
 def _upgraded_engine(db_url: str) -> Engine:
+    """Run Alembic migrations to head and return the resulting engine.
+
+    Args:
+        db_url: SQLAlchemy-compatible database URL for the target database.
+
+    Returns:
+        Engine connected to the fully migrated database.
+    """
     config = Config(str(_ALEMBIC_INI))
     config.set_main_option("sqlalchemy.url", db_url)
     command.upgrade(config, "head")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  docs(backend): add Google docstrings to helper functions
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds concise Google-style docstrings to the five helper functions that were the only undocumented ones repo-wide (AST scan). No behavior changes.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #170

## Details

Docstrings added for:

- `backend/src/podex/database.py` — `_set_pragma`
- `backend/tests/conftest.py` — `override_get_db`
- `backend/tests/test_migrations.py` — `_upgraded_engine`
- `backend/tests/test_episodes.py` — `_seed_podcast`
- `backend/tests/test_mentions.py` — `_seed_mention`

Verification: `uv run lintro fmt && uv run lintro chk` (backend), `uv run pytest` — 23 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

