### PR TITLE
feat(api): add per-IP rate limiting and request-context logging

### DIFF
--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -21,6 +21,15 @@ class Settings(BaseSettings):
     cors_origins: list[str] = ["http://localhost:4321"]
     database_url: str = "sqlite:///./podex.db"
 
+    # Rate limiting. Defaults are deliberately generous so ordinary traffic
+    # (and the test suite) never trips the limiter; tests inject tight values.
+    # The limiter is process-local for now; follow-up #107 moves it to a
+    # shared store so limits hold across workers.
+    rate_limit_enabled: bool = True
+    rate_limit_max_requests: int = 120
+    rate_limit_window_seconds: float = 60.0
+    rate_limit_exempt_paths: list[str] = ["/health"]
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/src/podex/main.py
+++ b/backend/src/podex/main.py
@@ -6,6 +6,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from podex.api.v2.router import api_v2_router
 from podex.config import Settings, get_settings
 from podex.logging_config import configure_logging
+from podex.middleware import RateLimitMiddleware, RequestContextMiddleware
+from podex.services.limiter import SlidingWindowRateLimiter
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -13,6 +15,22 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     resolved = settings or get_settings()
     configure_logging()
     app = FastAPI(title=resolved.app_name, debug=resolved.debug)
+
+    # Middleware is applied in reverse registration order (last added runs
+    # outermost). Register the rate limiter and request-context logger first so
+    # CORS ends up outermost and still annotates 429 responses.
+    if resolved.rate_limit_enabled:
+        limiter = SlidingWindowRateLimiter(
+            max_requests=resolved.rate_limit_max_requests,
+            window_seconds=resolved.rate_limit_window_seconds,
+        )
+        app.state.rate_limiter = limiter
+        app.add_middleware(
+            RateLimitMiddleware,
+            limiter=limiter,
+            exempt_paths=tuple(resolved.rate_limit_exempt_paths),
+        )
+    app.add_middleware(RequestContextMiddleware)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=resolved.cors_origins,

--- a/backend/src/podex/main.py
+++ b/backend/src/podex/main.py
@@ -36,6 +36,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         allow_origins=resolved.cors_origins,
         allow_methods=["*"],
         allow_headers=["*"],
+        # Non-safelisted response headers are invisible to cross-origin
+        # browser code unless exposed explicitly.
+        expose_headers=[
+            "X-Request-ID",
+            "X-RateLimit-Limit",
+            "X-RateLimit-Remaining",
+            "X-RateLimit-Reset",
+            "Retry-After",
+        ],
     )
     app.include_router(api_v2_router, prefix=resolved.api_v2_prefix)
 

--- a/backend/src/podex/middleware.py
+++ b/backend/src/podex/middleware.py
@@ -43,26 +43,53 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
         request.state.request_id = request_id
 
         start = time.perf_counter()
-        response = await call_next(request)
-        duration_ms = (time.perf_counter() - start) * 1000.0
+        status_code = 500
+        try:
+            response = await call_next(request)
+        except Exception:
+            # Still emit the access log (as a 500) so failed requests remain
+            # traceable by request id; the exception propagates to Starlette's
+            # error handling unchanged.
+            self._log_access(
+                request, status_code=status_code, start=start, request_id=request_id
+            )
+            raise
+        status_code = response.status_code
 
         response.headers[REQUEST_ID_HEADER] = request_id
+        self._log_access(
+            request, status_code=status_code, start=start, request_id=request_id
+        )
+        return response
+
+    @staticmethod
+    def _log_access(
+        request: Request, *, status_code: int, start: float, request_id: str
+    ) -> None:
+        """Emit one structured access-log line for a completed request.
+
+        Args:
+            request: The request being logged.
+            status_code: The response status code (500 for unhandled errors).
+            start: The ``time.perf_counter`` value captured at request start.
+            request_id: The request id associated with this request.
+        """
+        duration_ms = (time.perf_counter() - start) * 1000.0
         _access_logger.info(
             "%s %s %s %.2fms request_id=%s",
             request.method,
             request.url.path,
-            response.status_code,
+            status_code,
             duration_ms,
             request_id,
             extra={
                 "method": request.method,
                 "path": request.url.path,
-                "status_code": response.status_code,
+                "status_code": status_code,
                 "duration_ms": round(duration_ms, 2),
                 "request_id": request_id,
             },
         )
-        return response
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -91,6 +118,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     def _client_key(self, request: Request) -> str:
         """Derive the limiter key for a request.
+
+        ``X-Forwarded-For`` is deliberately not parsed here: it is trivially
+        spoofable unless validated against a trusted-proxy list. When deploying
+        behind a reverse proxy, run uvicorn with ``--proxy-headers`` (and
+        ``--forwarded-allow-ips``) so ``request.client`` already reflects the
+        real client address by the time it reaches this middleware.
 
         Args:
             request: The incoming request.

--- a/backend/src/podex/middleware.py
+++ b/backend/src/podex/middleware.py
@@ -28,9 +28,7 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
     method, path, status code, and wall-clock duration.
     """
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponder
-    ) -> Response:
+    async def dispatch(self, request: Request, call_next: RequestResponder) -> Response:
         """Wrap the downstream handler with request-id and access logging.
 
         Args:
@@ -73,6 +71,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     Exempt paths (health probes by default) bypass the limiter entirely.
     Allowed responses carry ``X-RateLimit-*`` headers; rejected requests receive
     a ``429`` with ``Retry-After`` and the same rate-limit headers.
+
+    Args:
+        app: The wrapped ASGI application.
+        limiter: The limiter instance enforcing per-client budgets.
+        exempt_paths: Paths that bypass rate limiting entirely.
     """
 
     def __init__(
@@ -82,13 +85,6 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         limiter: SlidingWindowRateLimiter,
         exempt_paths: tuple[str, ...] = (),
     ) -> None:
-        """Initialise the middleware.
-
-        Args:
-            app: The wrapped ASGI application.
-            limiter: The limiter instance enforcing per-client budgets.
-            exempt_paths: Paths that bypass rate limiting entirely.
-        """
         super().__init__(app)
         self._limiter = limiter
         self._exempt_paths = frozenset(exempt_paths)
@@ -106,9 +102,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             return request.client.host
         return "unknown"
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponder
-    ) -> Response:
+    async def dispatch(self, request: Request, call_next: RequestResponder) -> Response:
         """Apply rate limiting before delegating to the downstream handler.
 
         Args:

--- a/backend/src/podex/middleware.py
+++ b/backend/src/podex/middleware.py
@@ -1,0 +1,145 @@
+"""HTTP middleware: request-context logging and per-IP rate limiting."""
+
+import math
+import time
+from collections.abc import Awaitable, Callable
+from uuid import uuid4
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from podex.logging_config import get_logger
+from podex.services.limiter import SlidingWindowRateLimiter
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+_access_logger = get_logger("podex.access")
+
+RequestResponder = Callable[[Request], Awaitable[Response]]
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Attach a request id and emit a structured access log per request.
+
+    The middleware honours an inbound ``X-Request-ID`` header when present and
+    otherwise generates one. The id is stored on ``request.state.request_id``,
+    echoed back on the response, and included in the access log alongside the
+    method, path, status code, and wall-clock duration.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponder
+    ) -> Response:
+        """Wrap the downstream handler with request-id and access logging.
+
+        Args:
+            request: The incoming request being processed.
+            call_next: Callable that invokes the remaining middleware/handler
+                chain.
+
+        Returns:
+            Response: The downstream response with the request-id header set.
+        """
+        request_id = request.headers.get(REQUEST_ID_HEADER) or uuid4().hex
+        request.state.request_id = request_id
+
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration_ms = (time.perf_counter() - start) * 1000.0
+
+        response.headers[REQUEST_ID_HEADER] = request_id
+        _access_logger.info(
+            "%s %s %s %.2fms request_id=%s",
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration_ms,
+            request_id,
+            extra={
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "duration_ms": round(duration_ms, 2),
+                "request_id": request_id,
+            },
+        )
+        return response
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Enforce a per-client-IP request budget via a sliding-window limiter.
+
+    Exempt paths (health probes by default) bypass the limiter entirely.
+    Allowed responses carry ``X-RateLimit-*`` headers; rejected requests receive
+    a ``429`` with ``Retry-After`` and the same rate-limit headers.
+    """
+
+    def __init__(
+        self,
+        app: Callable[..., Awaitable[None]],
+        *,
+        limiter: SlidingWindowRateLimiter,
+        exempt_paths: tuple[str, ...] = (),
+    ) -> None:
+        """Initialise the middleware.
+
+        Args:
+            app: The wrapped ASGI application.
+            limiter: The limiter instance enforcing per-client budgets.
+            exempt_paths: Paths that bypass rate limiting entirely.
+        """
+        super().__init__(app)
+        self._limiter = limiter
+        self._exempt_paths = frozenset(exempt_paths)
+
+    def _client_key(self, request: Request) -> str:
+        """Derive the limiter key for a request.
+
+        Args:
+            request: The incoming request.
+
+        Returns:
+            str: The client host when known, otherwise ``"unknown"``.
+        """
+        if request.client is not None:
+            return request.client.host
+        return "unknown"
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponder
+    ) -> Response:
+        """Apply rate limiting before delegating to the downstream handler.
+
+        Args:
+            request: The incoming request being processed.
+            call_next: Callable that invokes the remaining middleware/handler
+                chain.
+
+        Returns:
+            Response: A ``429`` response when the budget is exhausted, otherwise
+            the downstream response annotated with rate-limit headers.
+        """
+        if request.url.path in self._exempt_paths:
+            return await call_next(request)
+
+        decision = self._limiter.check(self._client_key(request))
+        headers = {
+            "X-RateLimit-Limit": str(decision.limit),
+            "X-RateLimit-Remaining": str(decision.remaining),
+            "X-RateLimit-Reset": str(math.ceil(decision.reset_after)),
+        }
+
+        if not decision.allowed:
+            retry_after = math.ceil(decision.retry_after)
+            headers["Retry-After"] = str(retry_after)
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Rate limit exceeded. Try again later."},
+                headers=headers,
+            )
+
+        response = await call_next(request)
+        for name, value in headers.items():
+            response.headers[name] = value
+        return response

--- a/backend/src/podex/services/__init__.py
+++ b/backend/src/podex/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application service layer (rate limiting and related helpers)."""

--- a/backend/src/podex/services/limiter.py
+++ b/backend/src/podex/services/limiter.py
@@ -1,0 +1,123 @@
+"""In-memory per-client rate limiting.
+
+This limiter keeps a sliding window of request timestamps per client key in
+process memory. It is intentionally simple and process-local: each worker
+enforces its own counts. Follow-up #107 will replace this store with a shared
+backend (e.g. Redis) so limits hold across multiple workers/instances.
+"""
+
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    """Outcome of a single rate-limit check.
+
+    Attributes:
+        allowed: Whether the request is permitted under the current window.
+        limit: The maximum number of requests allowed per window.
+        remaining: Requests still permitted in the current window.
+        reset_after: Seconds until the window has fully drained.
+        retry_after: Seconds the client should wait before retrying. ``0`` when
+            the request is allowed.
+    """
+
+    allowed: bool
+    limit: int
+    remaining: int
+    reset_after: float
+    retry_after: float
+
+
+class SlidingWindowRateLimiter:
+    """Thread-safe sliding-window rate limiter keyed by an arbitrary client id.
+
+    A request is allowed when the number of hits recorded within the trailing
+    ``window_seconds`` is below ``max_requests``. Timestamps outside the window
+    are evicted lazily on each check.
+    """
+
+    def __init__(self, *, max_requests: int, window_seconds: float) -> None:
+        """Initialise the limiter.
+
+        Args:
+            max_requests: Maximum requests permitted per rolling window. Must be
+                a positive integer.
+            window_seconds: Length of the rolling window in seconds. Must be
+                positive.
+
+        Raises:
+            ValueError: If ``max_requests`` or ``window_seconds`` is not
+                positive.
+        """
+        if max_requests <= 0:
+            raise ValueError("max_requests must be positive")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self._max_requests = max_requests
+        self._window_seconds = window_seconds
+        self._hits: dict[str, deque[float]] = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    @property
+    def max_requests(self) -> int:
+        """Return the configured per-window request ceiling."""
+        return self._max_requests
+
+    @property
+    def window_seconds(self) -> float:
+        """Return the configured rolling window length in seconds."""
+        return self._window_seconds
+
+    def check(self, key: str, *, now: float | None = None) -> RateLimitDecision:
+        """Record and evaluate a request for ``key`` against the window.
+
+        When the request is allowed its timestamp is recorded; when it is denied
+        no timestamp is added, so a rejected client does not extend its own
+        penalty window.
+
+        Args:
+            key: Stable identifier for the client (typically the remote IP).
+            now: Optional monotonic timestamp override, primarily for tests. When
+                omitted, :func:`time.monotonic` is used.
+
+        Returns:
+            RateLimitDecision: The evaluation result including remaining quota
+            and retry hints.
+        """
+        current = time.monotonic() if now is None else now
+        window_start = current - self._window_seconds
+        with self._lock:
+            hits = self._hits[key]
+            while hits and hits[0] <= window_start:
+                hits.popleft()
+
+            if len(hits) >= self._max_requests:
+                oldest = hits[0]
+                retry_after = max(0.0, oldest + self._window_seconds - current)
+                return RateLimitDecision(
+                    allowed=False,
+                    limit=self._max_requests,
+                    remaining=0,
+                    reset_after=retry_after,
+                    retry_after=retry_after,
+                )
+
+            hits.append(current)
+            remaining = self._max_requests - len(hits)
+            reset_after = hits[0] + self._window_seconds - current
+            return RateLimitDecision(
+                allowed=True,
+                limit=self._max_requests,
+                remaining=remaining,
+                reset_after=reset_after,
+                retry_after=0.0,
+            )
+
+    def reset(self) -> None:
+        """Clear all recorded hits, primarily to isolate tests."""
+        with self._lock:
+            self._hits.clear()

--- a/backend/src/podex/services/limiter.py
+++ b/backend/src/podex/services/limiter.py
@@ -38,21 +38,18 @@ class SlidingWindowRateLimiter:
     A request is allowed when the number of hits recorded within the trailing
     ``window_seconds`` is below ``max_requests``. Timestamps outside the window
     are evicted lazily on each check.
+
+    Args:
+        max_requests: Maximum requests permitted per rolling window. Must be
+            a positive integer.
+        window_seconds: Length of the rolling window in seconds. Must be
+            positive.
+
+    Raises:
+        ValueError: If ``max_requests`` or ``window_seconds`` is not positive.
     """
 
     def __init__(self, *, max_requests: int, window_seconds: float) -> None:
-        """Initialise the limiter.
-
-        Args:
-            max_requests: Maximum requests permitted per rolling window. Must be
-                a positive integer.
-            window_seconds: Length of the rolling window in seconds. Must be
-                positive.
-
-        Raises:
-            ValueError: If ``max_requests`` or ``window_seconds`` is not
-                positive.
-        """
         if max_requests <= 0:
             raise ValueError("max_requests must be positive")
         if window_seconds <= 0:

--- a/backend/src/podex/services/limiter.py
+++ b/backend/src/podex/services/limiter.py
@@ -8,8 +8,10 @@ backend (e.g. Redis) so limits hold across multiple workers/instances.
 
 import threading
 import time
-from collections import defaultdict, deque
+from collections import deque
 from dataclasses import dataclass
+
+_SWEEP_INTERVAL_CHECKS = 1024
 
 
 @dataclass(frozen=True)
@@ -56,8 +58,9 @@ class SlidingWindowRateLimiter:
             raise ValueError("window_seconds must be positive")
         self._max_requests = max_requests
         self._window_seconds = window_seconds
-        self._hits: dict[str, deque[float]] = defaultdict(deque)
+        self._hits: dict[str, deque[float]] = {}
         self._lock = threading.Lock()
+        self._checks_since_sweep = 0
 
     @property
     def max_requests(self) -> int:
@@ -68,6 +71,29 @@ class SlidingWindowRateLimiter:
     def window_seconds(self) -> float:
         """Return the configured rolling window length in seconds."""
         return self._window_seconds
+
+    def _maybe_sweep(self, window_start: float) -> None:
+        """Periodically drop keys whose hits have all aged out of the window.
+
+        Without this, a client that stops sending requests (or an attacker
+        rotating source IPs) would leave its bucket in memory forever. The
+        sweep runs every ``_SWEEP_INTERVAL_CHECKS`` checks so the amortized
+        cost per request stays O(1). Must be called with ``self._lock`` held.
+
+        Args:
+            window_start: Timestamps at or before this instant are stale.
+        """
+        self._checks_since_sweep += 1
+        if self._checks_since_sweep < _SWEEP_INTERVAL_CHECKS:
+            return
+        self._checks_since_sweep = 0
+        stale = [
+            key
+            for key, hits in self._hits.items()
+            if not hits or hits[-1] <= window_start
+        ]
+        for key in stale:
+            del self._hits[key]
 
     def check(self, key: str, *, now: float | None = None) -> RateLimitDecision:
         """Record and evaluate a request for ``key`` against the window.
@@ -88,7 +114,8 @@ class SlidingWindowRateLimiter:
         current = time.monotonic() if now is None else now
         window_start = current - self._window_seconds
         with self._lock:
-            hits = self._hits[key]
+            self._maybe_sweep(window_start)
+            hits = self._hits.setdefault(key, deque())
             while hits and hits[0] <= window_start:
                 hits.popleft()
 
@@ -118,3 +145,4 @@ class SlidingWindowRateLimiter:
         """Clear all recorded hits, primarily to isolate tests."""
         with self._lock:
             self._hits.clear()
+            self._checks_since_sweep = 0

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -14,6 +14,16 @@ def test_default_settings() -> None:
     assert_that(settings.debug).is_false()
 
 
+def test_rate_limit_defaults_are_generous() -> None:
+    """Rate-limit defaults are enabled but roomy so normal traffic is fine."""
+    settings = Settings()
+
+    assert_that(settings.rate_limit_enabled).is_true()
+    assert_that(settings.rate_limit_max_requests).is_greater_than(0)
+    assert_that(settings.rate_limit_window_seconds).is_greater_than(0)
+    assert_that(settings.rate_limit_exempt_paths).contains("/health")
+
+
 def test_get_settings_is_cached() -> None:
     """``get_settings`` returns a cached singleton."""
     assert_that(get_settings()).is_same_as(get_settings())

--- a/backend/tests/test_limiter.py
+++ b/backend/tests/test_limiter.py
@@ -99,6 +99,24 @@ def test_uses_monotonic_clock_by_default() -> None:
     assert_that(decision.allowed).is_true()
 
 
+def test_stale_keys_are_swept_to_bound_memory() -> None:
+    """Buckets for clients that stopped sending are eventually dropped.
+
+    Without the periodic sweep, every distinct key ever checked would keep an
+    entry in the internal store forever (unbounded growth under IP rotation).
+    """
+    limiter = SlidingWindowRateLimiter(max_requests=5, window_seconds=10.0)
+
+    for index in range(1023):
+        limiter.check(f"key-{index}", now=0.0)
+    # The 1024th check triggers the sweep; every key last seen at t=0 is
+    # stale relative to the window ending at t=100.
+    limiter.check("fresh", now=100.0)
+
+    assert_that(limiter._hits).is_length(1)
+    assert_that(limiter._hits).contains_key("fresh")
+
+
 @pytest.mark.parametrize("bad_window", [-1.0, 0.0])
 def test_window_must_be_positive(bad_window: float) -> None:
     """Non-positive windows are rejected regardless of the exact value."""

--- a/backend/tests/test_limiter.py
+++ b/backend/tests/test_limiter.py
@@ -1,0 +1,107 @@
+"""Unit tests for the sliding-window rate limiter."""
+
+import pytest
+from assertpy import assert_that
+
+from podex.services.limiter import SlidingWindowRateLimiter
+
+
+def test_allows_requests_under_the_limit() -> None:
+    """Requests below the ceiling are permitted with decreasing remaining quota."""
+    limiter = SlidingWindowRateLimiter(max_requests=3, window_seconds=60.0)
+
+    first = limiter.check("client", now=0.0)
+    second = limiter.check("client", now=1.0)
+
+    assert_that(first.allowed).is_true()
+    assert_that(first.remaining).is_equal_to(2)
+    assert_that(second.allowed).is_true()
+    assert_that(second.remaining).is_equal_to(1)
+
+
+def test_blocks_requests_over_the_limit() -> None:
+    """The request that exceeds the ceiling is denied with a retry hint."""
+    limiter = SlidingWindowRateLimiter(max_requests=2, window_seconds=60.0)
+
+    limiter.check("client", now=0.0)
+    limiter.check("client", now=1.0)
+    denied = limiter.check("client", now=2.0)
+
+    assert_that(denied.allowed).is_false()
+    assert_that(denied.remaining).is_equal_to(0)
+    assert_that(denied.limit).is_equal_to(2)
+    assert_that(denied.retry_after).is_equal_to(58.0)
+
+
+def test_window_slides_to_free_capacity() -> None:
+    """Hits older than the window are evicted, freeing capacity again."""
+    limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=10.0)
+
+    assert_that(limiter.check("client", now=0.0).allowed).is_true()
+    assert_that(limiter.check("client", now=5.0).allowed).is_false()
+    assert_that(limiter.check("client", now=11.0).allowed).is_true()
+
+
+def test_keys_are_tracked_independently() -> None:
+    """Separate client keys do not share the same budget."""
+    limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0)
+
+    assert_that(limiter.check("a", now=0.0).allowed).is_true()
+    assert_that(limiter.check("b", now=0.0).allowed).is_true()
+    assert_that(limiter.check("a", now=1.0).allowed).is_false()
+
+
+def test_denied_request_does_not_extend_penalty() -> None:
+    """A rejected request is not recorded, so the window still drains on time."""
+    limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=10.0)
+
+    limiter.check("client", now=0.0)
+    limiter.check("client", now=8.0)  # denied, must not be recorded
+    allowed_again = limiter.check("client", now=10.5)
+
+    assert_that(allowed_again.allowed).is_true()
+
+
+def test_reset_clears_recorded_hits() -> None:
+    """Calling ``reset`` restores full capacity for every key."""
+    limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0)
+
+    limiter.check("client", now=0.0)
+    limiter.reset()
+
+    assert_that(limiter.check("client", now=1.0).allowed).is_true()
+
+
+def test_rejects_non_positive_configuration() -> None:
+    """Invalid limiter configuration raises ``ValueError``."""
+    assert_that(SlidingWindowRateLimiter).raises(ValueError).when_called_with(
+        max_requests=0, window_seconds=60.0
+    )
+    assert_that(SlidingWindowRateLimiter).raises(ValueError).when_called_with(
+        max_requests=1, window_seconds=0.0
+    )
+
+
+def test_exposes_configuration_via_properties() -> None:
+    """The limiter reports its configured ceiling and window."""
+    limiter = SlidingWindowRateLimiter(max_requests=5, window_seconds=30.0)
+
+    assert_that(limiter.max_requests).is_equal_to(5)
+    assert_that(limiter.window_seconds).is_equal_to(30.0)
+
+
+def test_uses_monotonic_clock_by_default() -> None:
+    """Omitting ``now`` falls back to the monotonic clock without error."""
+    limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0)
+
+    decision = limiter.check("client")
+
+    assert_that(decision.allowed).is_true()
+
+
+@pytest.mark.parametrize("bad_window", [-1.0, 0.0])
+def test_window_must_be_positive(bad_window: float) -> None:
+    """Non-positive windows are rejected regardless of the exact value."""
+    assert_that(SlidingWindowRateLimiter).raises(ValueError).when_called_with(
+        max_requests=1, window_seconds=bad_window
+    )

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -119,6 +119,44 @@ def test_client_key_falls_back_when_client_unknown() -> None:
     assert_that(middleware._client_key(request)).is_equal_to("unknown")
 
 
+def test_access_log_emitted_when_handler_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unhandled handler exceptions still produce a 500 access-log line."""
+    app = create_app(Settings(rate_limit_enabled=False))
+
+    async def _boom() -> None:
+        """Route handler that always fails."""
+        raise RuntimeError("boom")
+
+    app.add_api_route("/boom", _boom, methods=["GET"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with caplog.at_level(logging.INFO, logger="podex.access"):
+            response = client.get("/boom", headers={REQUEST_ID_HEADER: "err-1"})
+
+    assert_that(response.status_code).is_equal_to(500)
+    records = [r for r in caplog.records if r.name == "podex.access"]
+    assert_that(records).is_not_empty()
+    record = records[-1]
+    assert_that(record.__dict__["status_code"]).is_equal_to(500)
+    assert_that(record.__dict__["request_id"]).is_equal_to("err-1")
+
+
+def test_cors_exposes_rate_limit_headers_to_browsers() -> None:
+    """Cross-origin responses expose the request-id and rate-limit headers."""
+    settings = Settings(rate_limit_enabled=True)
+    with _make_client(settings) as client:
+        response = client.get(
+            "/api/v2/status", headers={"Origin": "http://localhost:4321"}
+        )
+
+    exposed = response.headers.get("Access-Control-Expose-Headers", "")
+    assert_that(exposed).contains("X-Request-ID")
+    assert_that(exposed).contains("X-RateLimit-Limit")
+    assert_that(exposed).contains("Retry-After")
+
+
 def test_access_log_records_request_details(
     tight_client: TestClient, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -1,0 +1,136 @@
+"""Integration tests for request-context logging and rate-limit middleware."""
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from podex.config import Settings
+from podex.main import create_app
+from podex.middleware import REQUEST_ID_HEADER, RateLimitMiddleware
+from podex.services.limiter import SlidingWindowRateLimiter
+
+
+def _make_client(settings: Settings) -> TestClient:
+    """Build a test client for an app configured with ``settings``.
+
+    Args:
+        settings: The settings used to construct the application.
+
+    Returns:
+        TestClient: A client bound to the configured application.
+    """
+    return TestClient(create_app(settings))
+
+
+@pytest.fixture
+def tight_client() -> Iterator[TestClient]:
+    """Return a client whose limiter allows only two requests per window.
+
+    Yields:
+        TestClient: A client backed by an app with a tight rate limit.
+    """
+    settings = Settings(
+        rate_limit_enabled=True,
+        rate_limit_max_requests=2,
+        rate_limit_window_seconds=60.0,
+        rate_limit_exempt_paths=["/health"],
+    )
+    with _make_client(settings) as client:
+        yield client
+
+
+def test_generates_request_id_when_absent(tight_client: TestClient) -> None:
+    """The middleware attaches a generated request id to every response."""
+    response = tight_client.get("/api/v2/status")
+
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.headers).contains_key(REQUEST_ID_HEADER)
+    assert_that(response.headers[REQUEST_ID_HEADER]).is_not_empty()
+
+
+def test_echoes_inbound_request_id(tight_client: TestClient) -> None:
+    """A caller-supplied request id is echoed back unchanged."""
+    response = tight_client.get(
+        "/api/v2/status", headers={REQUEST_ID_HEADER: "trace-123"}
+    )
+
+    assert_that(response.headers[REQUEST_ID_HEADER]).is_equal_to("trace-123")
+
+
+def test_allowed_responses_carry_rate_limit_headers(
+    tight_client: TestClient,
+) -> None:
+    """Successful responses expose the remaining rate-limit budget."""
+    response = tight_client.get("/api/v2/status")
+
+    assert_that(response.headers["X-RateLimit-Limit"]).is_equal_to("2")
+    assert_that(response.headers["X-RateLimit-Remaining"]).is_equal_to("1")
+    assert_that(response.headers).contains_key("X-RateLimit-Reset")
+
+
+def test_blocks_requests_over_limit_with_429(tight_client: TestClient) -> None:
+    """Once the budget is exhausted the middleware returns a 429 with hints."""
+    tight_client.get("/api/v2/status")
+    tight_client.get("/api/v2/status")
+    blocked = tight_client.get("/api/v2/status")
+
+    assert_that(blocked.status_code).is_equal_to(429)
+    assert_that(blocked.headers).contains_key("Retry-After")
+    assert_that(blocked.headers["X-RateLimit-Remaining"]).is_equal_to("0")
+    assert_that(blocked.json()["detail"]).contains("Rate limit")
+    assert_that(blocked.headers).contains_key(REQUEST_ID_HEADER)
+
+
+def test_health_is_exempt_from_rate_limiting(tight_client: TestClient) -> None:
+    """The health probe bypasses the limiter regardless of request volume."""
+    for _ in range(5):
+        response = tight_client.get("/health")
+        assert_that(response.status_code).is_equal_to(200)
+
+    assert_that(response.headers).does_not_contain_key("X-RateLimit-Limit")
+
+
+def test_rate_limiting_can_be_disabled() -> None:
+    """Disabling the limiter removes both the 429 path and its headers."""
+    settings = Settings(rate_limit_enabled=False)
+    with _make_client(settings) as client:
+        for _ in range(10):
+            response = client.get("/api/v2/status")
+            assert_that(response.status_code).is_equal_to(200)
+
+    assert_that(response.headers).does_not_contain_key("X-RateLimit-Limit")
+    assert_that(response.headers).contains_key(REQUEST_ID_HEADER)
+
+
+def test_client_key_falls_back_when_client_unknown() -> None:
+    """A request without client info is keyed under a stable placeholder."""
+    limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0)
+
+    async def _app(scope: object, receive: object, send: object) -> None:
+        """No-op ASGI app used only to construct the middleware."""
+
+    middleware = RateLimitMiddleware(_app, limiter=limiter)
+    request = Request({"type": "http", "headers": [], "method": "GET", "path": "/"})
+
+    assert_that(middleware._client_key(request)).is_equal_to("unknown")
+
+
+def test_access_log_records_request_details(
+    tight_client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Each request emits an access log with method, path, status, and id."""
+    with caplog.at_level(logging.INFO, logger="podex.access"):
+        tight_client.get("/api/v2/status", headers={REQUEST_ID_HEADER: "log-1"})
+
+    records = [r for r in caplog.records if r.name == "podex.access"]
+    assert_that(records).is_not_empty()
+    record = records[-1]
+    assert_that(record.__dict__["method"]).is_equal_to("GET")
+    assert_that(record.__dict__["path"]).is_equal_to("/api/v2/status")
+    assert_that(record.__dict__["status_code"]).is_equal_to(200)
+    assert_that(record.__dict__["request_id"]).is_equal_to("log-1")
+    assert_that(record.__dict__["duration_ms"]).is_greater_than_or_equal_to(0.0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(api): add per-IP rate limiting and request-context logging
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds process-local per-IP sliding-window rate limiting and structured request logging (method, path, status, duration, request id) for the current read-only `/api/v2` + `/health` surface. Tunable via `PODEX_RATE_LIMIT_*` settings; `/health` exempt by default.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #16

## Details

- New `podex.services.limiter.SlidingWindowRateLimiter` (in-memory; follow-up #107 for shared store)
- `RequestContextMiddleware` + `RateLimitMiddleware` with `X-Request-ID` and `X-RateLimit-*` / `Retry-After` on 429
- Defaults: 120 req / 60s; tests inject tight limits
- Verification: `uv run lintro fmt && uv run lintro chk`, `uv run pytest` — 43 passed, coverage ~98%
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

