### PR TITLE
feat(frontend): add loading and empty state components

### DIFF
--- a/frontend/src/components/DegradedBanner.test.tsx
+++ b/frontend/src/components/DegradedBanner.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DegradedBanner from "./DegradedBanner";
+
+describe("DegradedBanner", () => {
+  it("renders the default error message", () => {
+    render(<DegradedBanner />);
+    expect(
+      screen.getByText("Unable to load podcasts right now."),
+    ).toBeDefined();
+  });
+
+  it("renders a custom message when provided", () => {
+    render(<DegradedBanner message="Something went wrong." />);
+    expect(screen.getByText("Something went wrong.")).toBeDefined();
+  });
+
+  it("exposes role=alert for screen readers", () => {
+    render(<DegradedBanner />);
+    expect(screen.getByRole("alert")).toBeDefined();
+  });
+});

--- a/frontend/src/components/DegradedBanner.tsx
+++ b/frontend/src/components/DegradedBanner.tsx
@@ -1,0 +1,13 @@
+interface DegradedBannerProps {
+  message?: string;
+}
+
+export default function DegradedBanner({
+  message = "Unable to load podcasts right now.",
+}: DegradedBannerProps) {
+  return (
+    <p role="alert" className="text-red-600">
+      {message}
+    </p>
+  );
+}

--- a/frontend/src/components/EmptyState.test.tsx
+++ b/frontend/src/components/EmptyState.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import EmptyState from "./EmptyState";
+
+describe("EmptyState", () => {
+  it("renders the title", () => {
+    render(<EmptyState title="No podcasts yet." />);
+    expect(screen.getByText("No podcasts yet.")).toBeDefined();
+  });
+
+  it("exposes role=status for screen readers", () => {
+    render(<EmptyState title="Nothing here." />);
+    expect(screen.getByRole("status")).toBeDefined();
+  });
+
+  it("renders description when provided", () => {
+    render(
+      <EmptyState title="Empty" description="Check back later." />,
+    );
+    expect(screen.getByText("Check back later.")).toBeDefined();
+  });
+
+  it("does not render a description paragraph when omitted", () => {
+    const { container } = render(<EmptyState title="Empty" />);
+    const paras = container.querySelectorAll("p");
+    expect(paras).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,15 @@
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+}
+
+export default function EmptyState({ title, description }: EmptyStateProps) {
+  return (
+    <div role="status">
+      <p className="text-gray-600">{title}</p>
+      {description && (
+        <p className="mt-1 text-sm text-gray-500">{description}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SkeletonList.test.tsx
+++ b/frontend/src/components/SkeletonList.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import SkeletonList from "./SkeletonList";
+
+describe("SkeletonList", () => {
+  it("renders 4 skeleton items by default", () => {
+    const { container } = render(<SkeletonList />);
+    expect(container.querySelectorAll("li")).toHaveLength(4);
+  });
+
+  it("renders the requested number of skeleton items", () => {
+    const { container } = render(<SkeletonList count={6} />);
+    expect(container.querySelectorAll("li")).toHaveLength(6);
+  });
+
+  it("marks the list as aria-busy while loading", () => {
+    render(<SkeletonList />);
+    const list = screen.getByRole("list");
+    expect(list.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("hides decorative skeleton items from screen readers", () => {
+    const { container } = render(<SkeletonList count={2} />);
+    const items = container.querySelectorAll("li");
+    items.forEach((item) => {
+      expect(item.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+});

--- a/frontend/src/components/SkeletonList.tsx
+++ b/frontend/src/components/SkeletonList.tsx
@@ -1,0 +1,25 @@
+interface SkeletonListProps {
+  count?: number;
+}
+
+function SkeletonItem() {
+  return (
+    <li
+      aria-hidden="true"
+      className="animate-pulse rounded-lg border border-gray-200 p-4"
+    >
+      <div className="mb-2 h-4 w-1/3 rounded bg-gray-200" />
+      <div className="h-3 w-2/3 rounded bg-gray-100" />
+    </li>
+  );
+}
+
+export default function SkeletonList({ count = 4 }: SkeletonListProps) {
+  return (
+    <ul aria-busy="true" aria-label="Loading…" className="space-y-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonItem key={i} />
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -1,4 +1,6 @@
 ---
+import DegradedBanner from "../components/DegradedBanner";
+import EmptyState from "../components/EmptyState";
 import PodcastCard from "../components/PodcastCard.astro";
 import { fetchPodcasts } from "../lib/api";
 import type { Podcast } from "../lib/types";
@@ -24,9 +26,9 @@ try {
     <h1 class="mb-6 text-2xl font-bold">Podex</h1>
     {
       loadError ? (
-        <p class="text-red-600">Unable to load podcasts right now.</p>
+        <DegradedBanner />
       ) : podcasts.length === 0 ? (
-        <p class="text-gray-600">No podcasts yet.</p>
+        <EmptyState title="No podcasts yet." />
       ) : (
         <ul class="space-y-3">
           {podcasts.map((podcast) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(frontend): add loading and empty state components
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds reusable, accessible empty / loading / degraded UI components and wires them into the podcasts home page. Adapted to current slim `main` (media/episodes/stats routes from the original prompt do not exist yet).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #17

## Details

- `EmptyState`, `SkeletonList`, and `DegradedBanner` React components with Vitest coverage
- `index.astro` uses `DegradedBanner` / `EmptyState` instead of inline `<p>` copy
- `SkeletonList` shipped for reuse when client-side list loading lands
- Verification: `bun run check`, `bun run test:run` (13 passed), `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

