### PR TITLE
chore(security): allowlist example env placeholders in secret scanning

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,24 @@
+# .env.staging.example — copy to .env.staging and replace every change-me-* value
+# before deploying. This file is tracked in git; it contains ONLY placeholder values.
+# Real secrets must never be committed.
+
+# ── Database ─────────────────────────────────────────────────────────────────
+POSTGRES_PASSWORD=change-me-postgres-password
+DATABASE_URL=postgresql://podex:change-me-postgres-password@db:5432/podex
+
+# ── Transcript storage (encrypted S3) ────────────────────────────────────────
+# Generate the Fernet key with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+TRANSCRIPT_ARTIFACT_ENCRYPTION_KEY=change-me-fernet-key
+TRANSCRIPT_ARTIFACT_S3_BUCKET=change-me-private-transcript-bucket
+
+# ── Search ────────────────────────────────────────────────────────────────────
+MEILI_MASTER_KEY=change-me-meilisearch-master-key
+
+# ── API authentication ────────────────────────────────────────────────────────
+API_KEY=change-me-podex-api-key
+
+# ── Email (magic-link auth) ───────────────────────────────────────────────────
+SMTP_HOST=change-me-smtp-host
+SMTP_USERNAME=change-me-smtp-user
+SMTP_PASSWORD=change-me-smtp-password

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,35 @@
+# GitGuardian configuration — allowlist for example env templates and placeholder values.
+# Docs: https://docs.gitguardian.com/ggshield-docs/configuration
+#
+# IMPORTANT: real secret files (.env, backend/.env, .env.staging) are NOT ignored here;
+# they must never be committed and are covered by .gitignore only.
+version: 2
+
+secret:
+  # Ignore example / template files that intentionally contain placeholder values.
+  # These patterns match *.env*.example and .env*.example anywhere in the tree,
+  # plus the top-level staging template explicitly.
+  ignored_paths:
+    - '**/*.env*.example'
+    - '**/.env*.example'
+    - '.env.staging.example'
+
+  # Ignore the known change-me-* placeholder strings used in staging templates (#103).
+  # Each entry is the literal placeholder value, not a regex.
+  ignored_matches:
+    - name: staging placeholder — postgres password
+      match: change-me-postgres-password
+    - name: staging placeholder — fernet encryption key
+      match: change-me-fernet-key
+    - name: staging placeholder — private S3 transcript bucket
+      match: change-me-private-transcript-bucket
+    - name: staging placeholder — meilisearch master key
+      match: change-me-meilisearch-master-key
+    - name: staging placeholder — podex API key
+      match: change-me-podex-api-key
+    - name: staging placeholder — SMTP host
+      match: change-me-smtp-host
+    - name: staging placeholder — SMTP username
+      match: change-me-smtp-user
+    - name: staging placeholder — SMTP password
+      match: change-me-smtp-password

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+# Allowlist real env files that may live locally but must never be committed.
+# These paths are excluded from gitleaks scanning when the files are present on disk.
+# Patterns are TOML multiline strings (raw strings with ''') matching Go regexp.
+paths = ['''backend/\.env''', '''\.env''', '''\.env\..*''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,12 @@
+# A custom gitleaks config REPLACES the built-in ruleset unless it extends it;
+# without this extend block no rules run at all and nothing is ever detected.
+[extend]
+useDefault = true
+
 [allowlist]
-# Allowlist real env files that may live locally but must never be committed.
-# These paths are excluded from gitleaks scanning when the files are present on disk.
-# Patterns are TOML multiline strings (raw strings with ''') matching Go regexp.
-paths = ['''backend/\.env''', '''\.env''', '''\.env\..*''']
+# Allowlist ONLY example/template env files and their change-me-* placeholder
+# values. Real env files (.env, backend/.env, .env.staging) must stay fully
+# scannable so an accidental commit of real secrets is still caught.
+# Patterns are Go regexps in TOML raw strings.
+paths = ['''(^|/)\.env(\.[a-z0-9-]+)?\.example$''']
+regexes = ['''change-me-[a-z0-9-]+''']

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,7 @@
+# gitleaks ignore list — exact paths relative to repo root.
+# Files listed here are skipped by gitleaks even if they contain secret-like content.
+# Real env files should never be committed; this list exists for belt-and-suspenders
+# coverage when gitleaks is run against the working tree rather than git history.
+backend/.env
+.env
+*.env.local

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,7 +1,0 @@
-# gitleaks ignore list — exact paths relative to repo root.
-# Files listed here are skipped by gitleaks even if they contain secret-like content.
-# Real env files should never be committed; this list exists for belt-and-suspenders
-# coverage when gitleaks is run against the working tree rather than git history.
-backend/.env
-.env
-*.env.local


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(security): allowlist example env placeholders in secret scanning
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Configures GitGuardian and gitleaks so tracked `change-me-*` placeholders in `*.env*.example` templates are not treated as leaked secrets (the failure mode seen on PR #103), while real env files stay fully scanned.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #111

## Details

- `.gitguardian.yaml` (v2): path ignore for `**/*.env*.example` plus `ignored_matches` for known `change-me-*` placeholders
- `.gitleaks.toml` / `.gitleaksignore` aligned with the phase-2 allowlist for real env paths
- Narrow `.env.staging.example` with placeholder-only values to exercise the allowlist (not full staging deploy from #21)
- Real paths (`.env`, `backend/.env`, `.env.staging`) are **not** ignored by GitGuardian
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a staging environment template with placeholders and deployment guidance for database, storage, search, authentication, and email configuration.
  - Clarified that the template must be copied before deployment and that real secrets must never be committed.

- **Chores**
  - Added secret-scanning configuration to recognize approved example files and local environment files while helping prevent accidental exposure of real credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->