### PR TITLE
test(api): add cross-resource v2 API smoke coverage

### DIFF
--- a/backend/tests/test_api_smoke.py
+++ b/backend/tests/test_api_smoke.py
@@ -1,0 +1,194 @@
+"""Cross-resource smoke tests for the live v2 API surface.
+
+Unlike the per-resource unit tests, these exercise the whole read surface
+through the running FastAPI application so that a regression in wiring
+(routing, serialization, or the persisted ORM graph) is caught as a failing
+end-to-end walk across podcasts, episodes, media, and mentions.
+"""
+
+from dataclasses import dataclass
+
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.models import Episode, Media, MediaType, Mention, Podcast
+
+
+@dataclass
+class SeededGraph:
+    """Identifiers for a linked podcast, episode, media, and mention graph.
+
+    Attributes:
+        podcast_id: Identifier of the seeded podcast source.
+        episode_id: Identifier of the seeded episode belonging to the podcast.
+        media_id: Identifier of the seeded canonical media item.
+        mention_id: Identifier of the mention linking the episode to the media.
+    """
+
+    podcast_id: int
+    episode_id: int
+    media_id: int
+    mention_id: int
+
+
+def _seed_graph(db: Session) -> SeededGraph:
+    """Persist a fully connected catalog graph and return its identifiers.
+
+    Args:
+        db: Database session used to persist the catalog rows.
+
+    Returns:
+        The identifiers of the seeded podcast, episode, media, and mention.
+    """
+    podcast = Podcast(
+        name="The Example Show",
+        slug="example-show",
+        description="A show about examples.",
+    )
+    db.add(podcast)
+    db.commit()
+
+    episode = Episode(podcast_id=podcast.id, title="Pilot", episode_number=1)
+    media = Media(type=MediaType.BOOK, title="Dune", author="Herbert", year=1965)
+    db.add_all([episode, media])
+    db.commit()
+
+    mention = Mention(
+        episode_id=episode.id,
+        media_id=media.id,
+        timestamp_seconds=42,
+        context="a great book",
+        confidence=0.9,
+    )
+    db.add(mention)
+    db.commit()
+
+    return SeededGraph(
+        podcast_id=podcast.id,
+        episode_id=episode.id,
+        media_id=media.id,
+        mention_id=mention.id,
+    )
+
+
+def test_health_and_status_smoke(client: TestClient) -> None:
+    """Both the liveness probe and the v2 status endpoint respond healthy."""
+    health = client.get("/health")
+    assert_that(health.status_code).is_equal_to(200)
+    assert_that(health.json()).is_equal_to({"status": "ok"})
+
+    status = client.get("/api/v2/status")
+    assert_that(status.status_code).is_equal_to(200)
+    assert_that(status.json()).is_equal_to({"status": "ok", "api": "v2"})
+
+
+def test_podcast_resource_smoke(client: TestClient, db_session: Session) -> None:
+    """Podcasts are listed, individually fetchable, and 404 when unknown."""
+    graph = _seed_graph(db_session)
+
+    listed = client.get("/api/v2/podcasts")
+    assert_that(listed.status_code).is_equal_to(200)
+    assert_that([item["id"] for item in listed.json()]).contains(graph.podcast_id)
+
+    fetched = client.get(f"/api/v2/podcasts/{graph.podcast_id}")
+    assert_that(fetched.status_code).is_equal_to(200)
+    assert_that(fetched.json()["slug"]).is_equal_to("example-show")
+
+    missing = client.get("/api/v2/podcasts/999")
+    assert_that(missing.status_code).is_equal_to(404)
+
+
+def test_episode_resource_smoke(client: TestClient, db_session: Session) -> None:
+    """Episodes list, filter by podcast, fetch, expose mentions, and 404."""
+    graph = _seed_graph(db_session)
+
+    listed = client.get("/api/v2/episodes")
+    assert_that(listed.status_code).is_equal_to(200)
+    assert_that([item["id"] for item in listed.json()]).contains(graph.episode_id)
+
+    filtered = client.get("/api/v2/episodes", params={"podcast_id": graph.podcast_id})
+    assert_that(filtered.status_code).is_equal_to(200)
+    assert_that([item["id"] for item in filtered.json()]).is_equal_to(
+        [graph.episode_id],
+    )
+
+    fetched = client.get(f"/api/v2/episodes/{graph.episode_id}")
+    assert_that(fetched.status_code).is_equal_to(200)
+    assert_that(fetched.json()["title"]).is_equal_to("Pilot")
+
+    mentions = client.get(f"/api/v2/episodes/{graph.episode_id}/mentions")
+    assert_that(mentions.status_code).is_equal_to(200)
+    assert_that([item["id"] for item in mentions.json()]).is_equal_to(
+        [graph.mention_id],
+    )
+
+    missing = client.get("/api/v2/episodes/999")
+    assert_that(missing.status_code).is_equal_to(404)
+
+
+def test_media_resource_smoke(client: TestClient, db_session: Session) -> None:
+    """Media list, filter by type, fetch, expose mentions, and 404."""
+    graph = _seed_graph(db_session)
+
+    listed = client.get("/api/v2/media")
+    assert_that(listed.status_code).is_equal_to(200)
+    assert_that([item["id"] for item in listed.json()]).contains(graph.media_id)
+
+    filtered = client.get("/api/v2/media", params={"media_type": "book"})
+    assert_that(filtered.status_code).is_equal_to(200)
+    assert_that([item["id"] for item in filtered.json()]).is_equal_to([graph.media_id])
+
+    empty = client.get("/api/v2/media", params={"media_type": "movie"})
+    assert_that(empty.status_code).is_equal_to(200)
+    assert_that(empty.json()).is_equal_to([])
+
+    fetched = client.get(f"/api/v2/media/{graph.media_id}")
+    assert_that(fetched.status_code).is_equal_to(200)
+    assert_that(fetched.json()["author"]).is_equal_to("Herbert")
+
+    mentions = client.get(f"/api/v2/media/{graph.media_id}/mentions")
+    assert_that(mentions.status_code).is_equal_to(200)
+    assert_that([item["id"] for item in mentions.json()]).is_equal_to(
+        [graph.mention_id],
+    )
+
+    missing = client.get("/api/v2/media/999")
+    assert_that(missing.status_code).is_equal_to(404)
+
+
+def test_full_graph_walk_via_http(client: TestClient, db_session: Session) -> None:
+    """A seeded graph is fully traversable through the public HTTP surface.
+
+    Starting from the podcast, the walk follows episodes to their mentions and
+    then resolves each mention back to its canonical media item, asserting that
+    the foreign-key relationships survive serialization end to end.
+    """
+    graph = _seed_graph(db_session)
+
+    podcast = client.get(f"/api/v2/podcasts/{graph.podcast_id}").json()
+    assert_that(podcast["id"]).is_equal_to(graph.podcast_id)
+
+    episodes = client.get(
+        "/api/v2/episodes",
+        params={"podcast_id": graph.podcast_id},
+    ).json()
+    assert_that(episodes).is_length(1)
+    episode = episodes[0]
+    assert_that(episode["podcast_id"]).is_equal_to(graph.podcast_id)
+
+    mentions = client.get(f"/api/v2/episodes/{episode['id']}/mentions").json()
+    assert_that(mentions).is_length(1)
+    mention = mentions[0]
+    assert_that(mention["episode_id"]).is_equal_to(episode["id"])
+    assert_that(mention["media_id"]).is_equal_to(graph.media_id)
+    assert_that(mention["timestamp_seconds"]).is_equal_to(42)
+
+    media = client.get(f"/api/v2/media/{mention['media_id']}").json()
+    assert_that(media["id"]).is_equal_to(graph.media_id)
+    assert_that(media["title"]).is_equal_to("Dune")
+
+    back_reference = client.get(f"/api/v2/media/{media['id']}/mentions").json()
+    assert_that([item["id"] for item in back_reference]).is_equal_to(
+        [graph.mention_id],
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(api): add cross-resource v2 API smoke coverage
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Incremental acceptance-coverage slice for #20: cross-resource HTTP smoke tests over the live `/api/v2` catalog surface (health, podcasts, episodes, media, mentions graph). Ingestion tests deferred — that pipeline is not on `main` yet.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #20

## Details

- New `backend/tests/test_api_smoke.py` (5 tests)
- Seeds podcast → episode → media → mention and walks the graph via HTTP
- Covers list filters (`podcast_id`, `media_type`) and 404 paths
- **Not** `Closes #20` — #20 is a standing umbrella
- Verification: `uv run lintro fmt/chk` (0 issues), `uv run pytest` (28 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3901b083-52cc-42d2-84dc-d02ba9fcc811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for core API workflows.
  * Verified health checks, resource retrieval, filtering, not-found responses, and relationships between podcasts, episodes, mentions, and media.
  * Improved confidence that linked data remains consistent across API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->