### PR TITLE
fix(api): back rate limiter with Redis shared store

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "pydantic-settings>=2.6",
   "sqlalchemy>=2.0",
   "alembic>=1.13",
+  "redis>=5.0",
 ]
 
 [project.urls]
@@ -34,6 +35,7 @@ Issues = "https://github.com/lgtm-hq/podex/issues"
 [dependency-groups]
 dev = [
   "assertpy>=1.1",
+  "fakeredis[lua]>=2.26",
   "httpx>=0.28",
   "lintro==0.80.8",
   "mypy>=1.14",

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -23,12 +23,15 @@ class Settings(BaseSettings):
 
     # Rate limiting. Defaults are deliberately generous so ordinary traffic
     # (and the test suite) never trips the limiter; tests inject tight values.
-    # The limiter is process-local for now; follow-up #107 moves it to a
-    # shared store so limits hold across workers.
+    # When ``rate_limit_redis_url`` is unset the limiter runs process-locally;
+    # setting it (e.g. ``redis://redis:6379/0``) switches to a shared Redis
+    # store so limits hold across workers/instances.
     rate_limit_enabled: bool = True
     rate_limit_max_requests: int = 120
     rate_limit_window_seconds: float = 60.0
     rate_limit_exempt_paths: list[str] = ["/health"]
+    rate_limit_redis_url: str = ""
+    rate_limit_redis_prefix: str = "podex:ratelimit"
 
 
 @lru_cache

--- a/backend/src/podex/main.py
+++ b/backend/src/podex/main.py
@@ -7,7 +7,7 @@ from podex.api.v2.router import api_v2_router
 from podex.config import Settings, get_settings
 from podex.logging_config import configure_logging
 from podex.middleware import RateLimitMiddleware, RequestContextMiddleware
-from podex.services.limiter import SlidingWindowRateLimiter
+from podex.services.limiter_factory import build_rate_limiter
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -20,10 +20,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # outermost). Register the rate limiter and request-context logger first so
     # CORS ends up outermost and still annotates 429 responses.
     if resolved.rate_limit_enabled:
-        limiter = SlidingWindowRateLimiter(
-            max_requests=resolved.rate_limit_max_requests,
-            window_seconds=resolved.rate_limit_window_seconds,
-        )
+        limiter = build_rate_limiter(resolved)
         app.state.rate_limiter = limiter
         app.add_middleware(
             RateLimitMiddleware,

--- a/backend/src/podex/middleware.py
+++ b/backend/src/podex/middleware.py
@@ -10,7 +10,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from podex.logging_config import get_logger
-from podex.services.limiter import SlidingWindowRateLimiter
+from podex.services.limiter import RateLimiter
 
 REQUEST_ID_HEADER = "X-Request-ID"
 
@@ -101,7 +101,10 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     Args:
         app: The wrapped ASGI application.
-        limiter: The limiter instance enforcing per-client budgets.
+        limiter: The limiter instance enforcing per-client budgets. Any object
+            implementing the :class:`RateLimiter` protocol (in-memory sliding
+            window in dev/tests, Redis-backed sliding window in production) is
+            accepted.
         exempt_paths: Paths that bypass rate limiting entirely.
     """
 
@@ -109,7 +112,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self,
         app: Callable[..., Awaitable[None]],
         *,
-        limiter: SlidingWindowRateLimiter,
+        limiter: RateLimiter,
         exempt_paths: tuple[str, ...] = (),
     ) -> None:
         super().__init__(app)

--- a/backend/src/podex/services/limiter.py
+++ b/backend/src/podex/services/limiter.py
@@ -2,14 +2,17 @@
 
 This limiter keeps a sliding window of request timestamps per client key in
 process memory. It is intentionally simple and process-local: each worker
-enforces its own counts. Follow-up #107 will replace this store with a shared
-backend (e.g. Redis) so limits hold across multiple workers/instances.
+enforces its own counts. It remains the default backend and the fallback used
+in development/tests; when ``rate_limit_redis_url`` is configured the factory
+in :mod:`podex.services.limiter_factory` swaps in a Redis-backed limiter that
+shares state across workers.
 """
 
 import threading
 import time
 from collections import deque
 from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
 
 _SWEEP_INTERVAL_CHECKS = 1024
 
@@ -32,6 +35,30 @@ class RateLimitDecision:
     remaining: int
     reset_after: float
     retry_after: float
+
+
+@runtime_checkable
+class RateLimiter(Protocol):
+    """Structural interface implemented by every limiter backend.
+
+    Any object exposing ``max_requests``/``window_seconds`` and a
+    ``check(key, *, now=None)`` returning :class:`RateLimitDecision` satisfies
+    the middleware contract. Concrete implementations live in
+    :class:`SlidingWindowRateLimiter` (in-memory) and
+    :class:`podex.services.redis_limiter.RedisSlidingWindowRateLimiter`
+    (shared Redis store).
+    """
+
+    @property
+    def max_requests(self) -> int:
+        """Return the configured per-window request ceiling."""
+
+    @property
+    def window_seconds(self) -> float:
+        """Return the configured rolling window length in seconds."""
+
+    def check(self, key: str, *, now: float | None = None) -> RateLimitDecision:
+        """Record and evaluate a request for ``key``."""
 
 
 class SlidingWindowRateLimiter:

--- a/backend/src/podex/services/limiter_factory.py
+++ b/backend/src/podex/services/limiter_factory.py
@@ -1,0 +1,59 @@
+"""Rate-limiter backend selection.
+
+The application talks to a single :class:`~podex.services.limiter.RateLimiter`
+interface; this module hides which concrete backend gets wired in. When
+``rate_limit_redis_url`` is configured, requests share state through Redis so
+horizontal scaling and restarts don't leak budget. Otherwise we fall back to
+the in-process sliding-window implementation, which is what development, CI,
+and single-worker deployments actually need.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from podex.services.limiter import RateLimiter, SlidingWindowRateLimiter
+
+if TYPE_CHECKING:
+    from podex.config import Settings
+
+
+def build_rate_limiter(settings: Settings) -> RateLimiter:
+    """Return the limiter backend selected by ``settings``.
+
+    Selection rules:
+
+    * ``settings.rate_limit_redis_url`` is empty → return an in-memory
+      :class:`SlidingWindowRateLimiter`.
+    * ``settings.rate_limit_redis_url`` is set → return a
+      :class:`~podex.services.redis_limiter.RedisSlidingWindowRateLimiter`
+      pointed at that URL, with its shared key prefix taken from
+      ``settings.rate_limit_redis_prefix``.
+
+    ``redis`` is imported lazily so environments that never opt into the
+    shared store don't pay the import cost and don't require the extra to be
+    resolvable at boot for image builds that strip it.
+
+    Args:
+        settings: The active application settings.
+
+    Returns:
+        RateLimiter: A ready-to-use limiter matching the configured backend.
+    """
+    if not settings.rate_limit_redis_url:
+        return SlidingWindowRateLimiter(
+            max_requests=settings.rate_limit_max_requests,
+            window_seconds=settings.rate_limit_window_seconds,
+        )
+
+    import redis
+
+    from podex.services.redis_limiter import RedisSlidingWindowRateLimiter
+
+    client = redis.Redis.from_url(settings.rate_limit_redis_url)
+    return RedisSlidingWindowRateLimiter(
+        client,
+        max_requests=settings.rate_limit_max_requests,
+        window_seconds=settings.rate_limit_window_seconds,
+        key_prefix=settings.rate_limit_redis_prefix,
+    )

--- a/backend/src/podex/services/limiter_factory.py
+++ b/backend/src/podex/services/limiter_factory.py
@@ -17,6 +17,14 @@ from podex.services.limiter import RateLimiter, SlidingWindowRateLimiter
 if TYPE_CHECKING:
     from podex.config import Settings
 
+# Finite Redis timeouts so a wedged or slow shared store does not stall the
+# request path. Rate limiting is a soft guarantee: values are intentionally
+# tight (sub-second) because the limiter runs inline in every request, and the
+# limiter itself fails open on ``redis.RedisError`` so a bounded timeout is
+# always preferable to hanging.
+_REDIS_CONNECT_TIMEOUT_SECONDS = 0.5
+_REDIS_SOCKET_TIMEOUT_SECONDS = 0.25
+
 
 def build_rate_limiter(settings: Settings) -> RateLimiter:
     """Return the limiter backend selected by ``settings``.
@@ -32,7 +40,12 @@ def build_rate_limiter(settings: Settings) -> RateLimiter:
 
     ``redis`` is imported lazily so environments that never opt into the
     shared store don't pay the import cost and don't require the extra to be
-    resolvable at boot for image builds that strip it.
+    resolvable at boot for image builds that strip it. When the Redis backend
+    is selected the client is built with finite connect and socket timeouts
+    so an unhealthy Redis instance surfaces quickly and the limiter's
+    fail-open path (see
+    :class:`~podex.services.redis_limiter.RedisSlidingWindowRateLimiter`)
+    can admit requests instead of stalling them.
 
     Args:
         settings: The active application settings.
@@ -50,7 +63,11 @@ def build_rate_limiter(settings: Settings) -> RateLimiter:
 
     from podex.services.redis_limiter import RedisSlidingWindowRateLimiter
 
-    client = redis.Redis.from_url(settings.rate_limit_redis_url)
+    client = redis.Redis.from_url(
+        settings.rate_limit_redis_url,
+        socket_connect_timeout=_REDIS_CONNECT_TIMEOUT_SECONDS,
+        socket_timeout=_REDIS_SOCKET_TIMEOUT_SECONDS,
+    )
     return RedisSlidingWindowRateLimiter(
         client,
         max_requests=settings.rate_limit_max_requests,

--- a/backend/src/podex/services/redis_limiter.py
+++ b/backend/src/podex/services/redis_limiter.py
@@ -6,18 +6,30 @@ configured budget by N and every restart forgets recent hits. This module
 implements the same sliding-window contract on top of a shared Redis store so
 limits hold across workers and process restarts.
 
-The critical section (evict stale hits, count, conditionally record the new
-hit, refresh TTL) runs as a single ``EVAL`` so racing workers cannot both
-observe "room for one more" and each admit a request. A denied request is not
-recorded, mirroring the in-memory limiter's behaviour so a rejected client
-never extends its own penalty window.
+Design notes:
+
+* The critical section (evict stale hits, count, conditionally record the new
+  hit, refresh TTL) runs as a single ``EVAL`` so racing workers cannot both
+  observe "room for one more" and each admit a request.
+* The timestamp used for scoring comes from Redis' own ``TIME`` command inside
+  the script rather than from each worker's local clock. Otherwise clock skew
+  between workers could evict another worker's hits early or over-block
+  clients. Tests still override the clock via ``now=`` for determinism.
+* A denied request is not recorded, mirroring the in-memory limiter so a
+  rejected client never extends its own penalty window.
+* Redis outages must not take user traffic down. Every ``EVAL`` runs against a
+  client with finite connect/socket timeouts (configured by the factory) and
+  is guarded by a fail-open ``try``/``except redis.RedisError``: on error the
+  request is admitted so a broken cache never turns into a hard 5xx.
 """
 
 from __future__ import annotations
 
-import time
+import logging
 import uuid
 from typing import TYPE_CHECKING, cast
+
+import redis
 
 from podex.services.limiter import RateLimitDecision
 
@@ -25,14 +37,25 @@ if TYPE_CHECKING:
     from redis import Redis
 
 
+_logger = logging.getLogger(__name__)
+
 _LUA_SLIDING_WINDOW = """
 local zkey = KEYS[1]
-local now = tonumber(ARGV[1])
-local window_start = tonumber(ARGV[2])
+local now_override = ARGV[1]
+local window_seconds = tonumber(ARGV[2])
 local max_requests = tonumber(ARGV[3])
 local ttl_seconds = tonumber(ARGV[4])
 local member = ARGV[5]
 
+local now
+if now_override == '' then
+    local t = redis.call('TIME')
+    now = tonumber(t[1]) + tonumber(t[2]) / 1000000
+else
+    now = tonumber(now_override)
+end
+
+local window_start = now - window_seconds
 redis.call('ZREMRANGEBYSCORE', zkey, '-inf', window_start)
 local count = redis.call('ZCARD', zkey)
 local allowed = 0
@@ -50,21 +73,25 @@ if #first >= 1 then
         oldest_score = tonumber(score)
     end
 end
-return {allowed, count, tostring(oldest_score)}
+return {allowed, count, tostring(oldest_score), tostring(now)}
 """
 
 
 class RedisSlidingWindowRateLimiter:
     """Sliding-window rate limiter backed by a shared Redis instance.
 
-    State is stored in one sorted set per client key: scores are wall-clock
-    timestamps (``time.time``) and members are unique per hit so identical
-    timestamps do not collide. All mutation happens inside a Lua script so the
-    evict/count/admit sequence is atomic across concurrent workers.
+    State is stored in one sorted set per client key: scores are Redis-provided
+    wall-clock timestamps (from ``redis.call('TIME')``) and members are unique
+    per hit so identical timestamps do not collide. All mutation happens inside
+    a Lua script so the evict/count/admit sequence is atomic across concurrent
+    workers.
 
     Args:
         client: A ``redis.Redis``-compatible client (real or ``fakeredis``).
-            Must support ``eval`` with the script above.
+            Should be configured with finite ``socket_connect_timeout`` and
+            ``socket_timeout`` so a wedged Redis does not stall the request
+            path. :func:`podex.services.limiter_factory.build_rate_limiter`
+            wires those in when it constructs the client.
         max_requests: Maximum requests permitted per rolling window.
         window_seconds: Length of the rolling window in seconds.
         key_prefix: Prefix applied to every Redis key so multiple applications
@@ -106,37 +133,68 @@ class RedisSlidingWindowRateLimiter:
         """Return the fully namespaced Redis sorted-set key for ``key``."""
         return f"{self._key_prefix}:{key}"
 
+    def _fail_open_decision(self) -> RateLimitDecision:
+        """Return an allow decision used when Redis is unreachable.
+
+        Rate limiting is a soft guarantee; taking the API down whenever the
+        shared cache is unavailable would be a worse outcome than briefly
+        admitting more traffic than the limit. The middleware exposes the
+        configured ceiling but reports full remaining quota so a subsequent
+        healthy check can enforce again.
+        """
+        return RateLimitDecision(
+            allowed=True,
+            limit=self._max_requests,
+            remaining=self._max_requests,
+            reset_after=0.0,
+            retry_after=0.0,
+        )
+
     def check(self, key: str, *, now: float | None = None) -> RateLimitDecision:
         """Record and evaluate a request for ``key`` against the shared window.
 
+        The Lua script derives its own timestamp from ``redis.call('TIME')``
+        in production so every worker agrees on the clock. Callers may pass
+        ``now`` to override this for deterministic tests.
+
         Args:
             key: Stable identifier for the client (typically the remote IP).
-            now: Optional wall-clock timestamp override, primarily for tests.
-                When omitted, :func:`time.time` is used so scores are directly
-                comparable across processes.
+            now: Optional wall-clock timestamp override, intended for tests.
+                When omitted, the script uses Redis' own clock so scores are
+                directly comparable across workers regardless of local skew.
 
         Returns:
             RateLimitDecision: The evaluation result including remaining quota
-            and retry hints.
+            and retry hints. If Redis is unreachable the limiter fails open
+            (see :meth:`_fail_open_decision`).
         """
-        current = time.time() if now is None else now
-        window_start = current - self._window_seconds
-        member = f"{current}:{uuid.uuid4().hex}"
+        now_arg = "" if now is None else str(now)
+        member = uuid.uuid4().hex
 
-        raw = self._client.eval(
-            _LUA_SLIDING_WINDOW,
-            1,
-            self._redis_key(key),
-            current,
-            window_start,
-            self._max_requests,
-            self._ttl_seconds,
-            member,
-        )
+        try:
+            raw = self._client.eval(
+                _LUA_SLIDING_WINDOW,
+                1,
+                self._redis_key(key),
+                now_arg,
+                self._window_seconds,
+                self._max_requests,
+                self._ttl_seconds,
+                member,
+            )
+        except redis.RedisError:
+            _logger.warning(
+                "rate limiter redis check failed; failing open for key=%s",
+                key,
+                exc_info=True,
+            )
+            return self._fail_open_decision()
+
         result = cast(list[object], raw)
         allowed_flag = int(cast(int, result[0]))
         count = int(cast(int, result[1]))
         oldest_score = float(cast(str | bytes, result[2]))
+        current = float(cast(str | bytes, result[3]))
 
         if not allowed_flag:
             retry_after = max(0.0, oldest_score + self._window_seconds - current)
@@ -163,8 +221,13 @@ class RedisSlidingWindowRateLimiter:
 
         Intended for isolating tests: matches
         :meth:`SlidingWindowRateLimiter.reset` semantically. Uses ``SCAN`` so
-        the operation is safe against large keyspaces.
+        the operation is safe against large keyspaces. Redis errors are
+        swallowed so ``reset`` (which callers use for test-fixture cleanup)
+        never masks the real failure with a scan error.
         """
         pattern = f"{self._key_prefix}:*"
-        for raw_key in self._client.scan_iter(match=pattern):
-            self._client.delete(raw_key)
+        try:
+            for raw_key in self._client.scan_iter(match=pattern):
+                self._client.delete(raw_key)
+        except redis.RedisError:
+            _logger.warning("rate limiter redis reset failed; ignoring", exc_info=True)

--- a/backend/src/podex/services/redis_limiter.py
+++ b/backend/src/podex/services/redis_limiter.py
@@ -1,0 +1,170 @@
+"""Redis-backed sliding-window rate limiter.
+
+The in-memory :class:`~podex.services.limiter.SlidingWindowRateLimiter` keeps
+per-client state in each worker, so N workers effectively multiply the
+configured budget by N and every restart forgets recent hits. This module
+implements the same sliding-window contract on top of a shared Redis store so
+limits hold across workers and process restarts.
+
+The critical section (evict stale hits, count, conditionally record the new
+hit, refresh TTL) runs as a single ``EVAL`` so racing workers cannot both
+observe "room for one more" and each admit a request. A denied request is not
+recorded, mirroring the in-memory limiter's behaviour so a rejected client
+never extends its own penalty window.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import TYPE_CHECKING, cast
+
+from podex.services.limiter import RateLimitDecision
+
+if TYPE_CHECKING:
+    from redis import Redis
+
+
+_LUA_SLIDING_WINDOW = """
+local zkey = KEYS[1]
+local now = tonumber(ARGV[1])
+local window_start = tonumber(ARGV[2])
+local max_requests = tonumber(ARGV[3])
+local ttl_seconds = tonumber(ARGV[4])
+local member = ARGV[5]
+
+redis.call('ZREMRANGEBYSCORE', zkey, '-inf', window_start)
+local count = redis.call('ZCARD', zkey)
+local allowed = 0
+if count < max_requests then
+    redis.call('ZADD', zkey, now, member)
+    count = count + 1
+    allowed = 1
+end
+redis.call('EXPIRE', zkey, ttl_seconds)
+local first = redis.call('ZRANGE', zkey, 0, 0)
+local oldest_score = 0
+if #first >= 1 then
+    local score = redis.call('ZSCORE', zkey, first[1])
+    if score then
+        oldest_score = tonumber(score)
+    end
+end
+return {allowed, count, tostring(oldest_score)}
+"""
+
+
+class RedisSlidingWindowRateLimiter:
+    """Sliding-window rate limiter backed by a shared Redis instance.
+
+    State is stored in one sorted set per client key: scores are wall-clock
+    timestamps (``time.time``) and members are unique per hit so identical
+    timestamps do not collide. All mutation happens inside a Lua script so the
+    evict/count/admit sequence is atomic across concurrent workers.
+
+    Args:
+        client: A ``redis.Redis``-compatible client (real or ``fakeredis``).
+            Must support ``eval`` with the script above.
+        max_requests: Maximum requests permitted per rolling window.
+        window_seconds: Length of the rolling window in seconds.
+        key_prefix: Prefix applied to every Redis key so multiple applications
+            can share one Redis without colliding.
+
+    Raises:
+        ValueError: If ``max_requests`` or ``window_seconds`` is not positive.
+    """
+
+    def __init__(
+        self,
+        client: Redis,
+        *,
+        max_requests: int,
+        window_seconds: float,
+        key_prefix: str = "podex:ratelimit",
+    ) -> None:
+        if max_requests <= 0:
+            raise ValueError("max_requests must be positive")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self._client = client
+        self._max_requests = max_requests
+        self._window_seconds = window_seconds
+        self._key_prefix = key_prefix
+        self._ttl_seconds = max(1, int(window_seconds) + 1)
+
+    @property
+    def max_requests(self) -> int:
+        """Return the configured per-window request ceiling."""
+        return self._max_requests
+
+    @property
+    def window_seconds(self) -> float:
+        """Return the configured rolling window length in seconds."""
+        return self._window_seconds
+
+    def _redis_key(self, key: str) -> str:
+        """Return the fully namespaced Redis sorted-set key for ``key``."""
+        return f"{self._key_prefix}:{key}"
+
+    def check(self, key: str, *, now: float | None = None) -> RateLimitDecision:
+        """Record and evaluate a request for ``key`` against the shared window.
+
+        Args:
+            key: Stable identifier for the client (typically the remote IP).
+            now: Optional wall-clock timestamp override, primarily for tests.
+                When omitted, :func:`time.time` is used so scores are directly
+                comparable across processes.
+
+        Returns:
+            RateLimitDecision: The evaluation result including remaining quota
+            and retry hints.
+        """
+        current = time.time() if now is None else now
+        window_start = current - self._window_seconds
+        member = f"{current}:{uuid.uuid4().hex}"
+
+        raw = self._client.eval(
+            _LUA_SLIDING_WINDOW,
+            1,
+            self._redis_key(key),
+            current,
+            window_start,
+            self._max_requests,
+            self._ttl_seconds,
+            member,
+        )
+        result = cast(list[object], raw)
+        allowed_flag = int(cast(int, result[0]))
+        count = int(cast(int, result[1]))
+        oldest_score = float(cast(str | bytes, result[2]))
+
+        if not allowed_flag:
+            retry_after = max(0.0, oldest_score + self._window_seconds - current)
+            return RateLimitDecision(
+                allowed=False,
+                limit=self._max_requests,
+                remaining=0,
+                reset_after=retry_after,
+                retry_after=retry_after,
+            )
+
+        remaining = self._max_requests - count
+        reset_after = max(0.0, oldest_score + self._window_seconds - current)
+        return RateLimitDecision(
+            allowed=True,
+            limit=self._max_requests,
+            remaining=remaining,
+            reset_after=reset_after,
+            retry_after=0.0,
+        )
+
+    def reset(self) -> None:
+        """Remove every rate-limit key under this limiter's prefix.
+
+        Intended for isolating tests: matches
+        :meth:`SlidingWindowRateLimiter.reset` semantically. Uses ``SCAN`` so
+        the operation is safe against large keyspaces.
+        """
+        pattern = f"{self._key_prefix}:*"
+        for raw_key in self._client.scan_iter(match=pattern):
+            self._client.delete(raw_key)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -27,3 +27,11 @@ def test_rate_limit_defaults_are_generous() -> None:
 def test_get_settings_is_cached() -> None:
     """``get_settings`` returns a cached singleton."""
     assert_that(get_settings()).is_same_as(get_settings())
+
+
+def test_rate_limit_redis_url_defaults_to_disabled() -> None:
+    """Default deployment stays on the in-memory backend (empty Redis URL)."""
+    settings = Settings()
+
+    assert_that(settings.rate_limit_redis_url).is_equal_to("")
+    assert_that(settings.rate_limit_redis_prefix).is_not_empty()

--- a/backend/tests/test_limiter.py
+++ b/backend/tests/test_limiter.py
@@ -324,9 +324,7 @@ def test_build_rate_limiter_returns_redis_backend_when_url_set(
 
 def test_both_backends_satisfy_the_rate_limiter_protocol() -> None:
     """Both backends structurally implement the ``RateLimiter`` protocol."""
-    memory: RateLimiter = SlidingWindowRateLimiter(
-        max_requests=1, window_seconds=60.0
-    )
+    memory: RateLimiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0)
     shared: RateLimiter = _make_redis_limiter(max_requests=1, window_seconds=60.0)
 
     assert_that(isinstance(memory, RateLimiter)).is_true()

--- a/backend/tests/test_limiter.py
+++ b/backend/tests/test_limiter.py
@@ -1,7 +1,11 @@
 """Unit tests for the sliding-window rate limiter (in-memory + Redis backends)."""
 
+import logging
+from typing import Any
+
 import fakeredis
 import pytest
+import redis
 from assertpy import assert_that
 
 from podex.config import Settings
@@ -320,6 +324,127 @@ def test_build_rate_limiter_returns_redis_backend_when_url_set(
     assert_that(limiter.max_requests).is_equal_to(2)
     decision = limiter.check("factory-client", now=0.0)
     assert_that(decision.allowed).is_true()
+
+
+def test_redis_limiter_uses_redis_clock_when_now_not_provided() -> None:
+    """Without a ``now`` override the limiter uses Redis' own ``TIME`` command.
+
+    Workers writing scores based on their local clocks would produce skew:
+    one worker's slightly-future clock could evict another worker's fresh
+    hits or extend penalty windows. The Lua script derives ``now`` from
+    ``redis.call('TIME')`` so every worker agrees on the timeline.
+    """
+    limiter = _make_redis_limiter(max_requests=1, window_seconds=60.0)
+
+    first = limiter.check("client")
+    denied = limiter.check("client")
+
+    assert_that(first.allowed).is_true()
+    assert_that(denied.allowed).is_false()
+    assert_that(denied.retry_after).is_greater_than(0.0)
+    assert_that(denied.retry_after).is_less_than_or_equal_to(60.0)
+
+
+def test_redis_limiter_fails_open_on_redis_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A broken Redis must not take user traffic down.
+
+    Rate limiting is a soft guarantee; failing closed on every request during
+    a Redis outage would be worse than briefly admitting slightly more
+    traffic. The limiter logs a warning and returns an allow decision.
+    """
+
+    class _BrokenClient:
+        """Redis stand-in whose commands always raise ``ConnectionError``."""
+
+        def eval(self, *_: object, **__: object) -> object:
+            """Simulate an unreachable Redis on the hot path."""
+            raise redis.ConnectionError("simulated redis outage")
+
+        def scan_iter(self, *_: object, **__: object) -> object:
+            """Simulate an unreachable Redis on the cleanup path."""
+            raise redis.ConnectionError("simulated redis outage")
+
+        def delete(self, *_: object, **__: object) -> int:
+            """Never reached because ``scan_iter`` fails first."""
+            return 0
+
+    limiter = RedisSlidingWindowRateLimiter(
+        _BrokenClient(),
+        max_requests=2,
+        window_seconds=60.0,
+        key_prefix="fail-open-test",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="podex.services.redis_limiter"):
+        decision = limiter.check("client")
+
+    assert_that(decision.allowed).is_true()
+    assert_that(decision.limit).is_equal_to(2)
+    assert_that(decision.remaining).is_equal_to(2)
+    assert_that(decision.retry_after).is_equal_to(0.0)
+    messages = [r.getMessage() for r in caplog.records]
+    assert_that(any("failing open" in m for m in messages)).is_true()
+
+
+def test_redis_limiter_reset_swallows_redis_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``reset`` must never surface Redis errors to fixture cleanup callers."""
+
+    class _BrokenClient:
+        """Redis stand-in whose ``scan_iter`` blows up."""
+
+        def scan_iter(self, *_: object, **__: object) -> object:
+            """Simulate an unreachable Redis during teardown."""
+            raise redis.ConnectionError("simulated redis outage")
+
+        def delete(self, *_: object, **__: object) -> int:
+            """Never reached because ``scan_iter`` fails first."""
+            return 0
+
+    limiter = RedisSlidingWindowRateLimiter(
+        _BrokenClient(),
+        max_requests=1,
+        window_seconds=60.0,
+        key_prefix="fail-open-test",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="podex.services.redis_limiter"):
+        limiter.reset()
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert_that(any("reset failed" in m for m in messages)).is_true()
+
+
+def test_build_rate_limiter_configures_finite_redis_timeouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The factory must give the Redis client finite connect/socket timeouts.
+
+    Without bounded timeouts a slow or unavailable Redis stalls every request
+    (the limiter runs inline in middleware). The factory owns client
+    construction, so the timeouts must be applied there.
+    """
+    captured: dict[str, Any] = {}
+
+    def fake_from_url(url: str, **kwargs: Any) -> fakeredis.FakeStrictRedis:
+        """Capture kwargs so the test can assert on the wiring."""
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return fakeredis.FakeStrictRedis()
+
+    monkeypatch.setattr(redis.Redis, "from_url", staticmethod(fake_from_url))
+
+    settings = Settings(rate_limit_redis_url="redis://localhost:6379/0")
+
+    build_rate_limiter(settings)
+
+    assert_that(captured["kwargs"]).contains_key("socket_connect_timeout")
+    assert_that(captured["kwargs"]).contains_key("socket_timeout")
+    assert_that(captured["kwargs"]["socket_connect_timeout"]).is_greater_than(0.0)
+    assert_that(captured["kwargs"]["socket_timeout"]).is_greater_than(0.0)
 
 
 def test_both_backends_satisfy_the_rate_limiter_protocol() -> None:

--- a/backend/tests/test_limiter.py
+++ b/backend/tests/test_limiter.py
@@ -1,9 +1,13 @@
-"""Unit tests for the sliding-window rate limiter."""
+"""Unit tests for the sliding-window rate limiter (in-memory + Redis backends)."""
 
+import fakeredis
 import pytest
 from assertpy import assert_that
 
-from podex.services.limiter import SlidingWindowRateLimiter
+from podex.config import Settings
+from podex.services.limiter import RateLimiter, SlidingWindowRateLimiter
+from podex.services.limiter_factory import build_rate_limiter
+from podex.services.redis_limiter import RedisSlidingWindowRateLimiter
 
 
 def test_allows_requests_under_the_limit() -> None:
@@ -123,3 +127,207 @@ def test_window_must_be_positive(bad_window: float) -> None:
     assert_that(SlidingWindowRateLimiter).raises(ValueError).when_called_with(
         max_requests=1, window_seconds=bad_window
     )
+
+
+def _make_redis_limiter(
+    *, max_requests: int = 2, window_seconds: float = 60.0
+) -> RedisSlidingWindowRateLimiter:
+    """Return a Redis-backed limiter wired to a fresh in-memory fake."""
+    client = fakeredis.FakeStrictRedis()
+    return RedisSlidingWindowRateLimiter(
+        client,
+        max_requests=max_requests,
+        window_seconds=window_seconds,
+        key_prefix="test:ratelimit",
+    )
+
+
+def test_redis_limiter_allows_requests_under_the_limit() -> None:
+    """Redis-backed limiter admits requests below the ceiling."""
+    limiter = _make_redis_limiter(max_requests=3, window_seconds=60.0)
+
+    first = limiter.check("client", now=0.0)
+    second = limiter.check("client", now=1.0)
+
+    assert_that(first.allowed).is_true()
+    assert_that(first.remaining).is_equal_to(2)
+    assert_that(second.allowed).is_true()
+    assert_that(second.remaining).is_equal_to(1)
+
+
+def test_redis_limiter_blocks_requests_over_the_limit() -> None:
+    """Redis-backed limiter returns the same denial hints as the in-memory one."""
+    limiter = _make_redis_limiter(max_requests=2, window_seconds=60.0)
+
+    limiter.check("client", now=0.0)
+    limiter.check("client", now=1.0)
+    denied = limiter.check("client", now=2.0)
+
+    assert_that(denied.allowed).is_false()
+    assert_that(denied.remaining).is_equal_to(0)
+    assert_that(denied.limit).is_equal_to(2)
+    assert_that(denied.retry_after).is_equal_to(58.0)
+
+
+def test_redis_limiter_window_slides_to_free_capacity() -> None:
+    """Aged-out timestamps free capacity in the Redis-backed limiter too."""
+    limiter = _make_redis_limiter(max_requests=1, window_seconds=10.0)
+
+    assert_that(limiter.check("client", now=0.0).allowed).is_true()
+    assert_that(limiter.check("client", now=5.0).allowed).is_false()
+    assert_that(limiter.check("client", now=11.0).allowed).is_true()
+
+
+def test_redis_limiter_keys_are_tracked_independently() -> None:
+    """Distinct client keys have independent budgets in Redis."""
+    limiter = _make_redis_limiter(max_requests=1, window_seconds=60.0)
+
+    assert_that(limiter.check("a", now=0.0).allowed).is_true()
+    assert_that(limiter.check("b", now=0.0).allowed).is_true()
+    assert_that(limiter.check("a", now=1.0).allowed).is_false()
+
+
+def test_redis_limiter_denied_request_does_not_extend_penalty() -> None:
+    """Rejected requests are not recorded, matching the in-memory contract."""
+    limiter = _make_redis_limiter(max_requests=1, window_seconds=10.0)
+
+    limiter.check("client", now=0.0)
+    limiter.check("client", now=8.0)
+    allowed_again = limiter.check("client", now=10.5)
+
+    assert_that(allowed_again.allowed).is_true()
+
+
+def test_redis_limiter_two_instances_share_state() -> None:
+    """Two limiter instances wired to the same Redis enforce a shared budget.
+
+    This is the whole point of the shared store: additional workers must not
+    multiply the effective limit.
+    """
+    client = fakeredis.FakeStrictRedis()
+    worker_a = RedisSlidingWindowRateLimiter(
+        client, max_requests=2, window_seconds=60.0, key_prefix="shared"
+    )
+    worker_b = RedisSlidingWindowRateLimiter(
+        client, max_requests=2, window_seconds=60.0, key_prefix="shared"
+    )
+
+    assert_that(worker_a.check("client", now=0.0).allowed).is_true()
+    assert_that(worker_b.check("client", now=1.0).allowed).is_true()
+    assert_that(worker_a.check("client", now=2.0).allowed).is_false()
+    assert_that(worker_b.check("client", now=3.0).allowed).is_false()
+
+
+def test_redis_limiter_reset_clears_recorded_hits() -> None:
+    """``reset`` wipes every key under the limiter's prefix."""
+    limiter = _make_redis_limiter(max_requests=1, window_seconds=60.0)
+
+    limiter.check("client", now=0.0)
+    limiter.reset()
+
+    assert_that(limiter.check("client", now=1.0).allowed).is_true()
+
+
+def test_redis_limiter_uses_wall_clock_by_default() -> None:
+    """Omitting ``now`` falls back to ``time.time`` without error."""
+    limiter = _make_redis_limiter(max_requests=1, window_seconds=60.0)
+
+    decision = limiter.check("client")
+
+    assert_that(decision.allowed).is_true()
+
+
+def test_redis_limiter_exposes_configuration_via_properties() -> None:
+    """The Redis limiter reports its configured ceiling and window."""
+    limiter = _make_redis_limiter(max_requests=5, window_seconds=30.0)
+
+    assert_that(limiter.max_requests).is_equal_to(5)
+    assert_that(limiter.window_seconds).is_equal_to(30.0)
+
+
+def test_redis_limiter_rejects_non_positive_configuration() -> None:
+    """Invalid configuration is rejected the same way as the in-memory backend."""
+    client = fakeredis.FakeStrictRedis()
+
+    assert_that(RedisSlidingWindowRateLimiter).raises(ValueError).when_called_with(
+        client, max_requests=0, window_seconds=60.0
+    )
+    assert_that(RedisSlidingWindowRateLimiter).raises(ValueError).when_called_with(
+        client, max_requests=1, window_seconds=0.0
+    )
+
+
+def test_redis_limiter_matches_in_memory_decisions_over_a_sequence() -> None:
+    """Both backends must reach the same allow/deny verdict at each step.
+
+    Documents the equivalence the middleware relies on: swapping the backend
+    must not change externally observable behaviour.
+    """
+    memory = SlidingWindowRateLimiter(max_requests=3, window_seconds=10.0)
+    shared = _make_redis_limiter(max_requests=3, window_seconds=10.0)
+
+    times = [0.0, 1.0, 2.0, 3.0, 4.0, 9.5, 10.5, 11.5, 12.5]
+    for now in times:
+        memory_decision = memory.check("client", now=now)
+        redis_decision = shared.check("client", now=now)
+        assert_that(redis_decision.allowed).is_equal_to(memory_decision.allowed)
+
+
+def test_build_rate_limiter_returns_in_memory_when_redis_url_unset() -> None:
+    """An empty ``rate_limit_redis_url`` selects the in-memory backend."""
+    settings = Settings(
+        rate_limit_max_requests=4,
+        rate_limit_window_seconds=15.0,
+        rate_limit_redis_url="",
+    )
+
+    limiter = build_rate_limiter(settings)
+
+    assert_that(limiter).is_instance_of(SlidingWindowRateLimiter)
+    assert_that(limiter.max_requests).is_equal_to(4)
+    assert_that(limiter.window_seconds).is_equal_to(15.0)
+
+
+def test_build_rate_limiter_returns_redis_backend_when_url_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-empty ``rate_limit_redis_url`` selects the shared backend.
+
+    The factory imports ``redis`` lazily; we swap in a fakeredis-backed
+    ``from_url`` so no real network connection is attempted.
+    """
+    import redis
+
+    client = fakeredis.FakeStrictRedis()
+
+    def fake_from_url(url: str, **_: object) -> fakeredis.FakeStrictRedis:
+        """Return a shared fakeredis client regardless of URL."""
+        assert_that(url).is_equal_to("redis://localhost:6379/0")
+        return client
+
+    monkeypatch.setattr(redis.Redis, "from_url", staticmethod(fake_from_url))
+
+    settings = Settings(
+        rate_limit_max_requests=2,
+        rate_limit_window_seconds=60.0,
+        rate_limit_redis_url="redis://localhost:6379/0",
+        rate_limit_redis_prefix="podex-test:ratelimit",
+    )
+
+    limiter = build_rate_limiter(settings)
+
+    assert_that(limiter).is_instance_of(RedisSlidingWindowRateLimiter)
+    assert_that(limiter.max_requests).is_equal_to(2)
+    decision = limiter.check("factory-client", now=0.0)
+    assert_that(decision.allowed).is_true()
+
+
+def test_both_backends_satisfy_the_rate_limiter_protocol() -> None:
+    """Both backends structurally implement the ``RateLimiter`` protocol."""
+    memory: RateLimiter = SlidingWindowRateLimiter(
+        max_requests=1, window_seconds=60.0
+    )
+    shared: RateLimiter = _make_redis_limiter(max_requests=1, window_seconds=60.0)
+
+    assert_that(isinstance(memory, RateLimiter)).is_true()
+    assert_that(isinstance(shared, RateLimiter)).is_true()

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import Iterator
 
+import fakeredis
 import pytest
 from assertpy import assert_that
 from fastapi.testclient import TestClient
@@ -12,6 +13,7 @@ from podex.config import Settings
 from podex.main import create_app
 from podex.middleware import REQUEST_ID_HEADER, RateLimitMiddleware
 from podex.services.limiter import SlidingWindowRateLimiter
+from podex.services.redis_limiter import RedisSlidingWindowRateLimiter
 
 
 def _make_client(settings: Settings) -> TestClient:
@@ -155,6 +157,44 @@ def test_cors_exposes_rate_limit_headers_to_browsers() -> None:
     assert_that(exposed).contains("X-Request-ID")
     assert_that(exposed).contains("X-RateLimit-Limit")
     assert_that(exposed).contains("Retry-After")
+
+
+def test_middleware_works_with_redis_backed_limiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The middleware treats a Redis-backed limiter identically to the in-memory one.
+
+    Exercises the shared-store path end-to-end (allow/deny, rate-limit headers,
+    429 payload) by monkeypatching the factory to return a fakeredis-backed
+    limiter. Guards against regressions in the ``RateLimiter`` protocol.
+    """
+    shared_limiter = RedisSlidingWindowRateLimiter(
+        fakeredis.FakeStrictRedis(),
+        max_requests=2,
+        window_seconds=60.0,
+        key_prefix="mw-test:ratelimit",
+    )
+
+    monkeypatch.setattr(
+        "podex.main.build_rate_limiter", lambda _settings: shared_limiter
+    )
+
+    settings = Settings(
+        rate_limit_enabled=True,
+        rate_limit_max_requests=2,
+        rate_limit_window_seconds=60.0,
+    )
+    with TestClient(create_app(settings)) as client:
+        first = client.get("/api/v2/status")
+        second = client.get("/api/v2/status")
+        third = client.get("/api/v2/status")
+
+    assert_that(first.status_code).is_equal_to(200)
+    assert_that(first.headers["X-RateLimit-Limit"]).is_equal_to("2")
+    assert_that(second.status_code).is_equal_to(200)
+    assert_that(third.status_code).is_equal_to(429)
+    assert_that(third.headers).contains_key("Retry-After")
+    assert_that(third.json()["detail"]).contains("Rate limit")
 
 
 def test_access_log_records_request_details(

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -99,6 +99,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -224,6 +233,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ed/86ed74d8829c3bc565025c1c9efaf8518c9165fbf8c9cc2c026c8ed21bd9/fakeredis-2.36.2.tar.gz", hash = "sha256:c37a0b307fae3f27ec7c19e59519e57b8c52782e00303df9075361b5ba441be6", size = 213336, upload-time = "2026-06-17T13:25:38.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/4d/e6e40f93031adbf654d34e542bd396e9f3bc1c6209b40c920d58c9e1317a/fakeredis-2.36.2-py3-none-any.whl", hash = "sha256:84cbb9c74ca8946c0d2499daadf3a5d0bfe3cfbac71e3398316d1a1eab3421c4", size = 141039, upload-time = "2026-06-17T13:25:36.638Z" },
+]
+
+[package.optional-dependencies]
+lua = [
+    { name = "lupa" },
 ]
 
 [[package]]
@@ -523,6 +550,65 @@ wheels = [
 ]
 
 [[package]]
+name = "lupa"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a6/0f869fbb07c393f15473b1eefefb7b5bec162fb7481803d040ed4dc46002/lupa-2.8.tar.gz", hash = "sha256:d8022641b9ec8ecf2c5ecbe9f47e5a70e0b87c4b5ae921b92cb02a638e0acd08", size = 6156370, upload-time = "2026-04-15T20:08:30.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/21/9be4516ddd22f8eadba336d9ba065d17d79108465ae1b7f71424ab99b9d0/lupa-2.8-cp310-abi3-win32.whl", hash = "sha256:c2a5fd15dc62374e1661a55f01744c9ec1c56f291ba4a0749d3af2174556e78f", size = 1594887, upload-time = "2026-04-15T20:05:23.377Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/99/1557c9685d7034d9ce8dd2b54c40a26d6deb7c67c1fdb5c801abd1a02c3f/lupa-2.8-cp310-abi3-win_arm64.whl", hash = "sha256:9e304fb1c50cf23fd8882afbe1aa87525ef8a72667bcab3b37b2bbb2bc542269", size = 1371742, upload-time = "2026-04-15T20:05:27.417Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/0a/5a740717f27aa77481e6a61b97cf79d1e0c1ede729b1268caacded915326/lupa-2.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b12e43c1fb787189dfc28cd604aef0baa2cb95e27da19498d520361d0ace070a", size = 1202376, upload-time = "2026-04-15T20:05:44.049Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/75/6b64d0098c64275a801896cb7a6a30e7e653d25fa102c64e747292afcdbb/lupa-2.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f603391dffb256e36a79fd2044084d5f4b8a0a4c0e5ad291cd3ab3aaf1fd0a", size = 1839271, upload-time = "2026-04-15T20:05:47.399Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2f/0d4f00563046ff616ef6a421f8b776a5ffb327f7b32ed69e856d52b917a8/lupa-2.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f6f41c91366e7d0d474f87d81c1274af861f40812bf729c9f97ab4c8f3c7ac8", size = 2376251, upload-time = "2026-04-15T20:05:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/8e/caa83237f427d9e85b7f02c816e7270c9c9571dec1673e06b0180402f70e/lupa-2.8-cp311-cp311-win_amd64.whl", hash = "sha256:f5a6af145b0ea818f01d27bfe2583a4b538570bef61d22c8773e0eccf011234c", size = 1923488, upload-time = "2026-04-15T20:05:52.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0b/368f2f0bc750b25c69d4563e44f677925ab5dd3d2887f9b0c15465d21a2a/lupa-2.8-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:f4342f4de76ae7ce2ab0672d36003bdb7e1a33252f293b569298ddd792e70e33", size = 1194056, upload-time = "2026-04-15T20:05:55.794Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0f/c89eb8dd36fdea4e50ae3f7f5275bea3b0cc5d4057b8ee7b3bbc78010422/lupa-2.8-cp312-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:4203fa1659315e939a5304e75001b8cc14234fb3cbb3ed86c049b0cc5d90fcee", size = 1434278, upload-time = "2026-04-15T20:05:57.94Z" },
+    { url = "https://files.pythonhosted.org/packages/47/30/c3b4d2cd8733621b404b8a4214e5f852955c4ba632546dc84123bea9ee89/lupa-2.8-cp312-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:81f2d843ce668b653146c007467570210ae44be51dac6926666c51d49536f307", size = 1150068, upload-time = "2026-04-15T20:06:01.04Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d2/bac12c398519efafc6af84be1974edd0d7a4895fb4735b5c8d615d298595/lupa-2.8-cp312-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d3d0cde2c77588d1c60875a4f34f059513476c6e1775351897195b51e0f3df08", size = 1409532, upload-time = "2026-04-15T20:06:03.592Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6a/18b52e11962014026e07813530b0b108ee8bc0a2a13ef0eaea5d41dce023/lupa-2.8-cp312-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9e0d11b8f3a8dac6413f704fef7161d048bb10c58bdac6cbffa5e60efa56e9a3", size = 1242687, upload-time = "2026-04-15T20:06:06.863Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8e/7fd4eb049875f61429b96780d2eae4700f0e78fe0a52db8edb231b1cd09f/lupa-2.8-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54cff414f21f8cd8c6be4aae52541f3b9cd39602b59e3a3db9b5c9f9f674ff18", size = 1856038, upload-time = "2026-04-15T20:06:09.358Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/37ad9d2773d30f2931890d310a4bdce28d45484206e6f48bc18b0325eabd/lupa-2.8-cp312-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:24b4d8af5558e549b70daf1547f5c1c1d664ecea9fc790f83efe5d75e9a93797", size = 1128982, upload-time = "2026-04-15T20:06:12.312Z" },
+    { url = "https://files.pythonhosted.org/packages/57/31/c0fd7984c24844ea79caa45c0235f61a06b38fd69a839f6c62770f8d684a/lupa-2.8-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce86dff1ee7f7cf45f5622065ae991949dd7bb1703581cbc58a630137bb7ccf9", size = 1457594, upload-time = "2026-04-15T20:06:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/a28e411be30ec1bf0db1eb0c087eebc73be9e7a1adcfe6ac209861ccc446/lupa-2.8-cp312-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f4d01b2a08c70bbb883a9e082b6b36b89121ed5910b710f1ba11c73295ff4fba", size = 1425721, upload-time = "2026-04-15T20:06:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c1/359f767c4ae024be30d909fe8a9f0e9af266bad47ce2bd2ed248fb986fcf/lupa-2.8-cp312-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:7f210d5a8353e510ea1199c42cf3cbdd630553bf2bc8fb4c00fea06fdec7c798", size = 1253258, upload-time = "2026-04-15T20:06:21.17Z" },
+    { url = "https://files.pythonhosted.org/packages/17/52/473f11790c261fd02bbf318a546fe040e9ec9f677181272fa78d3b4112a4/lupa-2.8-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f81a02806e7c7ad26d8c6fa222c8bef1b0c1b124347c879be880b41339d41e4", size = 2395272, upload-time = "2026-04-15T20:06:24.137Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bf/75c8795655a8836eab6a11a630352c4b7c5dc5c54d075077bc9bffdeee45/lupa-2.8-cp312-abi3-win32.whl", hash = "sha256:360056453a7a4eaa4ac5a204c31a5a014b1eb2ee5490603234d2ba831684f1f2", size = 1606136, upload-time = "2026-04-15T20:06:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/29/11a2cdd612b6f55e506292dfb6ba343216e80a693e7fe3f876ef204ce9c6/lupa-2.8-cp312-abi3-win_arm64.whl", hash = "sha256:1628371c6592a6d5650497a9e31fb2bb3a7e9883c1f301d1111265e484045af9", size = 1364495, upload-time = "2026-04-15T20:06:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/17/fa834b6b09ad17e7df5d0f7715d64877a125a3776ada689751a1f9dc2959/lupa-2.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:450650f91c48c2415b0d59ab3abfcfda3b6efb5b858205f4d4bda8ad141fa529", size = 1190111, upload-time = "2026-04-15T20:06:32.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/43/45589901b7d1a0e3a9d91d19a311fb6a56924e8571536c3f2212160fd953/lupa-2.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27044f3363047f946b3d3aab9157cbd172b3538ada9ec1baef43432bf7d03a78", size = 1812999, upload-time = "2026-04-15T20:06:35.664Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ac/4ade7d15ff5c61758d7943ac6f0a496bf1cc65b6c09f842b52a0702e664c/lupa-2.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cf4f064a0e5531afce2d7d750120c10c10f9529139af6ca6150d13151034398", size = 2368731, upload-time = "2026-04-15T20:06:37.959Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/27/05f950d15b8ab120b39c43588b438ff3ace70c1b1b0225a960393a497483/lupa-2.8-cp312-cp312-win_amd64.whl", hash = "sha256:281bedc5deb92d31e649a3552edd662449365a635904fa4d5cb4509c7245e34e", size = 1941809, upload-time = "2026-04-15T20:06:40.302Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3f/19f83c3a0c84dc8bea8a58e7416dca6a3ede662c33c8d1ec758e5afc754a/lupa-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45fc9da0145ecb0083ef5ff9975116cc784bd0258bdc2bd131ba15483ce18398", size = 1201203, upload-time = "2026-04-15T20:06:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0f/a14f0073f09610158038582e230618a48c14da6bd88185289461aa4cb854/lupa-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58e18afed57955b41130e269c78f53d4123ab86e236b53816f4cbffa25cb5d30", size = 1806210, upload-time = "2026-04-15T20:06:45.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/14/48fff156c63a136001a7620878af7d31aa07e66b495ed621e3eddd73c294/lupa-2.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc47f536ac13a79cef47d29a2b205576a22841f042a2bcec1676b95806e7706a", size = 2359005, upload-time = "2026-04-15T20:06:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/18/3ac638ec90edf178242b8a2b2f00f8adae694248c03a26341ef941bb746e/lupa-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:ce9404c661dbac65cc9bed351ad45e797af93d30d70be309a3fa8209ac86d93b", size = 1936754, upload-time = "2026-04-15T20:06:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ef/5ee5fed6ea7459a671196359ce04bfeeaf26be1dac8ff24bf28e5c7a6e81/lupa-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:348c3f8ecabb6324dcbc05c2740d762ef8fcec7b06c79e45262ab97a217684e3", size = 1209388, upload-time = "2026-04-15T20:06:53.022Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b1/67a940d5542cb0384b443fe951b5a83ea9340d1333a733a258fdd1c619ba/lupa-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951496471056061598a7d1729a6cdf48d662fec777a9f2d8aa5a1e62fd30e5a5", size = 1826821, upload-time = "2026-04-15T20:06:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a2/b354e5ba3b911ec50686003dc8897e892b9e8c5c036b33219b03d54c4daf/lupa-2.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a591b9947ca347b41a63370e121d6e2b1458fe6dde9ae065029ec10a37f25ff4", size = 2366893, upload-time = "2026-04-15T20:06:58.9Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/52/d76066401f29539df5352f70ecded66576f32933b6045cd0bfc56cb770b9/lupa-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:3903c9cf628dae2f56405503247b77a61a3a61bd2dda470e336950c74776d55d", size = 1994716, upload-time = "2026-04-15T20:07:19.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bd/3efc437a4361c16d25e66478c50357c9a8e8ecfb718fe749eb9ca3176ef6/lupa-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f711a8ab0486b9ac6fdda94a22ddcfbc9f0d4a27e3a8cf1bf79c6e48b33017c1", size = 1251217, upload-time = "2026-04-15T20:07:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f4/2e9f8ecbaca854bfdf14af8a9b505ec0cbc640377b3b218921594b7563cd/lupa-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc51250e76367a3e27fcd01dc769b9bfcbbc34f48df48dde53d6af6e75b7eaa5", size = 1814701, upload-time = "2026-04-15T20:07:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/4000b1acaa8b1f3827fcff0cfcdff44d3befddda42cab7e685a49689b5a1/lupa-2.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8a22088a552828958603323f0a5c4b3e11e03b75d0bf4c965ef879de9b60a8d", size = 2348414, upload-time = "2026-04-15T20:07:07.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/78/26ee48d3890cddf03cefb65f433e3492759c0b3c0582180755bddbaab7bd/lupa-2.8-cp314-cp314t-win32.whl", hash = "sha256:4f7c553c1d8cfffbe85d81daef730d12cae4b6002d457542914da0ac8a1145b3", size = 1831611, upload-time = "2026-04-15T20:07:09.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/4a5cc64a3cad22821ae4c3f7a90456a08ca19457d8354f4abf46ad03c7e8/lupa-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:d8766aff03a78c80ad2d188a8bdb216de5ec838359cd87e05bbdfa56394a6105", size = 2209250, upload-time = "2026-04-15T20:07:11.906Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/cdcb654daf668192aaf36b0aeb94f2281dad092aaa5003688691131736ea/lupa-2.8-cp314-cp314t-win_arm64.whl", hash = "sha256:91d622777febda3ab1bed1d45295f2f32a4680c7b3d7caf8c669998ed5c44118", size = 1126735, upload-time = "2026-04-15T20:07:15.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/44/de1961ad38e17cd326a53c246c7e3b91178ed578f4cf22ffcd5e7e11b041/lupa-2.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b036738282a5acd2e71fdddb317c9df8b87c1673aa57f403d05fcc2be8abc4ba", size = 1186020, upload-time = "2026-04-15T20:07:35.017Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c2/276f0b9dc8bcc5a8a58af5316dfa0e6f56be3613dd6dbcc8d3d2cb6559ba/lupa-2.8-cp39-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ac6b6e8d0e617e26a98cbb44880bcd75de5d32b3ad7b3b3793583909292b47ed", size = 1468944, upload-time = "2026-04-15T20:07:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/63/38/52934e52a5180dc6425d20284d004fe4b27a4f9171a82dc99fb67af250bf/lupa-2.8-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ba3a7dd839f90c3d2e53bebe3c192b1f3f9fd720a6781256405123211fd0dce6", size = 1172998, upload-time = "2026-04-15T20:07:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/82/76b3809bd0839d9b3b4ec58d06591e08f17337b6d9576877cb9d48b34e94/lupa-2.8-cp39-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d7edb13a7a5250b5c6c22d1495d9e842b5c9fc5081c8fe6b5efe2112fe3e41f9", size = 1449975, upload-time = "2026-04-15T20:07:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/16/07/2f89d54f747c67c23b4b9ae4aa8c8dd06bb409155dedcf406157f2736b66/lupa-2.8-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:891f72e0bffbed1e4175f975aeb2a083956586a100066525e1be485f617f7b25", size = 1281944, upload-time = "2026-04-15T20:07:46.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bd/7375d2b0fcae79d806baf52a76f26c96964593f58e1372d13ae5ac09c676/lupa-2.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a295f87b5b7ebbfd5191932e8cb0e51df3c7769101ac6b6c7d7c9fb27bfd1307", size = 1910455, upload-time = "2026-04-15T20:07:49.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/8abb3bc0e08b311fc01db05b6e9f9ff31a8f65e4fc3f0aeb05cfef75c8ac/lupa-2.8-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4fe5d7a810b64ea8511eb885fc8cdde042ee5ff7b7d08ae78f32449756acb177", size = 1155548, upload-time = "2026-04-15T20:07:52.657Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2e/9eeecd3f493099721c1d3f31beeca23a4237db1a54223684df4dc96aa1bd/lupa-2.8-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:bfc470012ef66ad064c7bd77416af03a3452ef630b04b9012595ea13f2e54518", size = 1489232, upload-time = "2026-04-15T20:07:54.92Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/13/731c99dc2e7652ae818a6de45bdf0142049f7cb566049061c898355f1891/lupa-2.8-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:250e035fdaffe8c87093e3ebc206ac29a26131b1568ea711d780c26001ce96e7", size = 1466321, upload-time = "2026-04-15T20:07:57.627Z" },
+    { url = "https://files.pythonhosted.org/packages/de/71/3ad8cc4fc05a77dc0d3f7079348bd1cad4675a0d14c24f8e6a3ce5f008f7/lupa-2.8-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b9bddb09acfffb4f828f790f444b11dc0cca591afea1a244d9329eea2d20c003", size = 1288577, upload-time = "2026-04-15T20:07:59.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b2/1175f6d0aa7b68627fbe2f58bd1e8bea36a89d10dfd67671d2b024c96162/lupa-2.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e64acbbd47e9b82a64405a39e0d2b36a5a7dad8ab41c0f3437f572f7d282ba3", size = 2444866, upload-time = "2026-04-15T20:08:02.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f7/e78df680c7a0ea452daac07467ca188d63c2c00ca1c884c0a50e27eb83b5/lupa-2.8-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32e4e5103bbddcdd2458fb2ccae6c8ba11c9997c711d7e379e0d45551d109c76", size = 1778509, upload-time = "2026-04-15T20:08:21.784Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/23/0e53cabb16b2a8aa9cf1fde499c097d8942c5dab709fc8e921f3b824b18b/lupa-2.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7667001804657496dee9feced2daae5000b4604a3218dd8e6b7b754982ba88b8", size = 2300480, upload-time = "2026-04-15T20:08:24.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/0271227eab939921a12ebba5d17aa4cd18346aa534ca7f5da09cd0b63dd4/lupa-2.8-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:86f6f668966965b15247dc32d064cfe7be67b71e584ccfacbe2f637575296878", size = 1847445, upload-time = "2026-04-15T20:08:27.031Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
@@ -726,6 +812,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "redis" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -733,6 +820,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "assertpy" },
+    { name = "fakeredis", extra = ["lua"] },
     { name = "httpx" },
     { name = "lintro" },
     { name = "mypy" },
@@ -747,6 +835,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "redis", specifier = ">=5.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
@@ -754,6 +843,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "assertpy", specifier = ">=1.1" },
+    { name = "fakeredis", extras = ["lua"], specifier = ">=2.26" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "lintro", specifier = "==0.80.8" },
     { name = "mypy", specifier = ">=1.14" },
@@ -997,6 +1087,18 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1007,6 +1109,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(api): back rate limiter with Redis shared store
  ```

- Type:
  - [x] fix / perf (patch)
  - [ ] feat (minor)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Backs the endpoint rate limiter with an optional Redis sliding-window store so limits hold across workers and restarts. When `PODEX_RATE_LIMIT_REDIS_URL` is unset, the existing in-memory limiter remains the default for local/dev/test.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #107

## Details

- Adds `RateLimiter` protocol, `RedisSlidingWindowRateLimiter`, and `build_rate_limiter(settings)` factory.
- New settings: `rate_limit_redis_url`, `rate_limit_redis_prefix`.
- Runtime dep: `redis`; test dep: `fakeredis`.
- Client key derivation unchanged (`request.client` only; no raw `X-Forwarded-For` trust).
- Verification: `uv run lintro fmt`, `uv run lintro chk`, `uv run pytest` (68 passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Redis-backed rate limiting for shared request limits across workers and instances.
  * Added configuration for the Redis connection and rate-limit key prefix.
  * Retained in-memory rate limiting when Redis is not configured.

* **Bug Fixes**
  * Ensured Redis-backed limits provide consistent quota tracking, retry timing, and reset behavior across application instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->