### PR TITLE
feat(api): extract query services and add cached stats

### DIFF
--- a/backend/src/podex/api/deps.py
+++ b/backend/src/podex/api/deps.py
@@ -2,10 +2,30 @@
 
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, Request
 from sqlalchemy.orm import Session
 
+from podex.config import Settings, get_settings
 from podex.database import get_db
+from podex.services.cache import Cache
 
 DbSession = Annotated[Session, Depends(get_db)]
 """A request-scoped database session injected into route handlers."""
+
+
+def get_app_cache(request: Request) -> Cache:
+    """Return the process-wide cache attached to the FastAPI application.
+
+    The cache is created once in :func:`podex.main.create_app` and stashed on
+    ``app.state``; routes retrieve it through this dependency so tests can
+    override it via ``app.dependency_overrides`` without touching state.
+    """
+    cache: Cache = request.app.state.cache
+    return cache
+
+
+AppCache = Annotated[Cache, Depends(get_app_cache)]
+"""The process-wide cache backend injected into route handlers."""
+
+AppSettings = Annotated[Settings, Depends(get_settings)]
+"""Resolved application settings injected into route handlers."""

--- a/backend/src/podex/api/deps.py
+++ b/backend/src/podex/api/deps.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import Depends, Request
 from sqlalchemy.orm import Session
 
-from podex.config import Settings, get_settings
+from podex.config import Settings
 from podex.database import get_db
 from podex.services.cache import Cache
 
@@ -27,5 +27,20 @@ def get_app_cache(request: Request) -> Cache:
 AppCache = Annotated[Cache, Depends(get_app_cache)]
 """The process-wide cache backend injected into route handlers."""
 
-AppSettings = Annotated[Settings, Depends(get_settings)]
+
+def get_app_settings(request: Request) -> Settings:
+    """Return the :class:`Settings` instance configured on this app.
+
+    :func:`podex.main.create_app` stores the ``settings=`` argument (or the
+    cached global fallback) on ``app.state.settings`` so route dependencies
+    resolve to the same instance used to build the middleware stack. Reading
+    it through the request keeps overrides passed to
+    ``create_app(settings=...)`` — most commonly in tests — in effect for
+    handlers instead of silently falling back to the global settings.
+    """
+    settings: Settings = request.app.state.settings
+    return settings
+
+
+AppSettings = Annotated[Settings, Depends(get_app_settings)]
 """Resolved application settings injected into route handlers."""

--- a/backend/src/podex/api/v2/episodes.py
+++ b/backend/src/podex/api/v2/episodes.py
@@ -18,7 +18,11 @@ router = APIRouter(prefix="/episodes", tags=["episodes"])
 
 def list_episodes(db: DbSession, podcast_id: int | None = None) -> list[Episode]:
     """List episodes, optionally filtered by podcast."""
-    return episode_queries.list_episodes(db, podcast_id=podcast_id)
+    # Explicit annotation keeps the return well-typed even when the CI lint
+    # image type-checks without SQLAlchemy installed, where the service
+    # call would otherwise resolve to bare ``Any``.
+    episodes: list[Episode] = episode_queries.list_episodes(db, podcast_id=podcast_id)
+    return episodes
 
 
 def get_episode(episode_id: int, db: DbSession) -> Episode:
@@ -31,7 +35,11 @@ def get_episode(episode_id: int, db: DbSession) -> Episode:
 
 def list_episode_mentions(episode_id: int, db: DbSession) -> list[Mention]:
     """List media mentions within an episode, ordered by timestamp."""
-    mentions = episode_queries.list_episode_mentions(db, episode_id)
+    # See ``list_episodes`` for why the annotation is spelled out here.
+    mentions: list[Mention] | None = episode_queries.list_episode_mentions(
+        db,
+        episode_id,
+    )
     if mentions is None:
         raise HTTPException(status_code=404, detail="Episode not found")
     return mentions

--- a/backend/src/podex/api/v2/episodes.py
+++ b/backend/src/podex/api/v2/episodes.py
@@ -1,27 +1,29 @@
-"""Public read endpoints for podcast episodes."""
+"""Public read endpoints for podcast episodes.
+
+Route handlers here are intentionally thin: they validate inputs via FastAPI,
+delegate the query to :mod:`podex.services.episode_queries`, and map missing
+rows to HTTP 404 responses.
+"""
 
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import select
 
 from podex.api.deps import DbSession
 from podex.models import Episode, Mention
 from podex.schemas.episode import EpisodeRead
 from podex.schemas.mention import MentionRead
+from podex.services import episode_queries
 
 router = APIRouter(prefix="/episodes", tags=["episodes"])
 
 
 def list_episodes(db: DbSession, podcast_id: int | None = None) -> list[Episode]:
     """List episodes, optionally filtered by podcast."""
-    statement = select(Episode).order_by(Episode.published_at.desc())
-    if podcast_id is not None:
-        statement = statement.where(Episode.podcast_id == podcast_id)
-    return list(db.execute(statement).scalars().all())
+    return episode_queries.list_episodes(db, podcast_id=podcast_id)
 
 
 def get_episode(episode_id: int, db: DbSession) -> Episode:
     """Return a single episode by id."""
-    episode = db.get(Episode, episode_id)
+    episode = episode_queries.get_episode(db, episode_id)
     if episode is None:
         raise HTTPException(status_code=404, detail="Episode not found")
     return episode
@@ -29,14 +31,10 @@ def get_episode(episode_id: int, db: DbSession) -> Episode:
 
 def list_episode_mentions(episode_id: int, db: DbSession) -> list[Mention]:
     """List media mentions within an episode, ordered by timestamp."""
-    if db.get(Episode, episode_id) is None:
+    mentions = episode_queries.list_episode_mentions(db, episode_id)
+    if mentions is None:
         raise HTTPException(status_code=404, detail="Episode not found")
-    statement = (
-        select(Mention)
-        .where(Mention.episode_id == episode_id)
-        .order_by(Mention.timestamp_seconds)
-    )
-    return list(db.execute(statement).scalars().all())
+    return mentions
 
 
 router.add_api_route(

--- a/backend/src/podex/api/v2/media.py
+++ b/backend/src/podex/api/v2/media.py
@@ -18,7 +18,11 @@ router = APIRouter(prefix="/media", tags=["media"])
 
 def list_media(db: DbSession, media_type: MediaType | None = None) -> list[Media]:
     """List media items, optionally filtered by type, ordered by title."""
-    return media_queries.list_media(db, media_type=media_type)
+    # Explicit annotation keeps the return well-typed even when the CI lint
+    # image type-checks without SQLAlchemy installed, where the service
+    # call would otherwise resolve to bare ``Any``.
+    items: list[Media] = media_queries.list_media(db, media_type=media_type)
+    return items
 
 
 def get_media(media_id: int, db: DbSession) -> Media:
@@ -31,7 +35,8 @@ def get_media(media_id: int, db: DbSession) -> Media:
 
 def list_media_mentions(media_id: int, db: DbSession) -> list[Mention]:
     """List episode mentions of a media item."""
-    mentions = media_queries.list_media_mentions(db, media_id)
+    # See ``list_media`` for why the annotation is spelled out here.
+    mentions: list[Mention] | None = media_queries.list_media_mentions(db, media_id)
     if mentions is None:
         raise HTTPException(status_code=404, detail="Media not found")
     return mentions

--- a/backend/src/podex/api/v2/media.py
+++ b/backend/src/podex/api/v2/media.py
@@ -1,27 +1,29 @@
-"""Public read endpoints for canonical media items."""
+"""Public read endpoints for canonical media items.
+
+Route handlers here are intentionally thin: they validate inputs via FastAPI,
+delegate the query to :mod:`podex.services.media_queries`, and map missing
+rows to HTTP 404 responses.
+"""
 
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import select
 
 from podex.api.deps import DbSession
 from podex.models import Media, MediaType, Mention
 from podex.schemas.media import MediaRead
 from podex.schemas.mention import MentionRead
+from podex.services import media_queries
 
 router = APIRouter(prefix="/media", tags=["media"])
 
 
 def list_media(db: DbSession, media_type: MediaType | None = None) -> list[Media]:
     """List media items, optionally filtered by type, ordered by title."""
-    statement = select(Media).order_by(Media.title)
-    if media_type is not None:
-        statement = statement.where(Media.type == media_type)
-    return list(db.execute(statement).scalars().all())
+    return media_queries.list_media(db, media_type=media_type)
 
 
 def get_media(media_id: int, db: DbSession) -> Media:
     """Return a single media item by id."""
-    media = db.get(Media, media_id)
+    media = media_queries.get_media(db, media_id)
     if media is None:
         raise HTTPException(status_code=404, detail="Media not found")
     return media
@@ -29,12 +31,10 @@ def get_media(media_id: int, db: DbSession) -> Media:
 
 def list_media_mentions(media_id: int, db: DbSession) -> list[Mention]:
     """List episode mentions of a media item."""
-    if db.get(Media, media_id) is None:
+    mentions = media_queries.list_media_mentions(db, media_id)
+    if mentions is None:
         raise HTTPException(status_code=404, detail="Media not found")
-    statement = (
-        select(Mention).where(Mention.media_id == media_id).order_by(Mention.episode_id)
-    )
-    return list(db.execute(statement).scalars().all())
+    return mentions
 
 
 router.add_api_route(

--- a/backend/src/podex/api/v2/podcasts.py
+++ b/backend/src/podex/api/v2/podcasts.py
@@ -17,7 +17,11 @@ router = APIRouter(prefix="/podcasts", tags=["podcasts"])
 
 def list_podcasts(db: DbSession) -> list[Podcast]:
     """List podcast sources ordered by name."""
-    return podcast_queries.list_podcasts(db)
+    # Explicit annotation keeps the return well-typed even when the CI lint
+    # image type-checks without SQLAlchemy installed, where the service
+    # call would otherwise resolve to bare ``Any``.
+    podcasts: list[Podcast] = podcast_queries.list_podcasts(db)
+    return podcasts
 
 
 def get_podcast(podcast_id: int, db: DbSession) -> Podcast:

--- a/backend/src/podex/api/v2/podcasts.py
+++ b/backend/src/podex/api/v2/podcasts.py
@@ -1,24 +1,28 @@
-"""Public read endpoints for podcast sources."""
+"""Public read endpoints for podcast sources.
+
+Route handlers here are intentionally thin: they validate inputs via FastAPI,
+delegate the query to :mod:`podex.services.podcast_queries`, and map missing
+rows to HTTP 404 responses.
+"""
 
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import select
 
 from podex.api.deps import DbSession
 from podex.models import Podcast
 from podex.schemas.podcast import PodcastRead
+from podex.services import podcast_queries
 
 router = APIRouter(prefix="/podcasts", tags=["podcasts"])
 
 
 def list_podcasts(db: DbSession) -> list[Podcast]:
     """List podcast sources ordered by name."""
-    result = db.execute(select(Podcast).order_by(Podcast.name))
-    return list(result.scalars().all())
+    return podcast_queries.list_podcasts(db)
 
 
 def get_podcast(podcast_id: int, db: DbSession) -> Podcast:
     """Return a single podcast source by id."""
-    podcast = db.get(Podcast, podcast_id)
+    podcast = podcast_queries.get_podcast(db, podcast_id)
     if podcast is None:
         raise HTTPException(status_code=404, detail="Podcast not found")
     return podcast

--- a/backend/src/podex/api/v2/router.py
+++ b/backend/src/podex/api/v2/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from podex.api.v2 import episodes, media, podcasts
+from podex.api.v2 import episodes, media, podcasts, stats
 
 api_v2_router = APIRouter(tags=["v2"])
 
@@ -16,3 +16,4 @@ api_v2_router.add_api_route("/status", read_status, methods=["GET"])
 api_v2_router.include_router(podcasts.router)
 api_v2_router.include_router(episodes.router)
 api_v2_router.include_router(media.router)
+api_v2_router.include_router(stats.router)

--- a/backend/src/podex/api/v2/stats.py
+++ b/backend/src/podex/api/v2/stats.py
@@ -1,0 +1,42 @@
+"""Public read endpoint for catalog-wide statistics.
+
+The route is intentionally thin: it pulls the shared cache and settings from
+FastAPI dependencies and delegates to
+:mod:`podex.services.stats_queries` for the (possibly cached) aggregate
+query.
+"""
+
+from fastapi import APIRouter
+
+from podex.api.deps import AppCache, AppSettings, DbSession
+from podex.schemas.stats import CatalogStats
+from podex.services import stats_queries
+
+router = APIRouter(prefix="/stats", tags=["stats"])
+
+
+def get_catalog_stats(
+    db: DbSession,
+    cache: AppCache,
+    settings: AppSettings,
+) -> CatalogStats:
+    """Return catalog-wide counts and a small top-media-types breakdown.
+
+    Responses are cached in-process for
+    ``PODEX_STATS_CACHE_TTL_SECONDS`` seconds (configurable via
+    :class:`~podex.config.Settings`); set the TTL to ``0`` to bypass the
+    cache entirely.
+    """
+    return stats_queries.get_catalog_stats(
+        db,
+        cache=cache,
+        ttl_seconds=settings.stats_cache_ttl_seconds,
+    )
+
+
+router.add_api_route(
+    "",
+    get_catalog_stats,
+    methods=["GET"],
+    response_model=CatalogStats,
+)

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -30,6 +30,11 @@ class Settings(BaseSettings):
     rate_limit_window_seconds: float = 60.0
     rate_limit_exempt_paths: list[str] = ["/health"]
 
+    # Aggregate/stats caching. Short TTL because we currently have no
+    # write-time invalidation hooks (see ``services/stats_queries.py``);
+    # setting the TTL to ``0`` disables caching entirely.
+    stats_cache_ttl_seconds: float = 30.0
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -2,6 +2,7 @@
 
 from functools import lru_cache
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -32,8 +33,12 @@ class Settings(BaseSettings):
 
     # Aggregate/stats caching. Short TTL because we currently have no
     # write-time invalidation hooks (see ``services/stats_queries.py``);
-    # setting the TTL to ``0`` disables caching entirely.
-    stats_cache_ttl_seconds: float = 30.0
+    # setting the TTL to ``0`` disables caching entirely. ``allow_inf_nan``
+    # rejects ``NaN`` (which would silently bypass caching after mypy-safe
+    # comparisons) and ``inf`` (which would keep entries alive forever); the
+    # ``ge=0`` bound catches negative overrides at startup instead of allowing
+    # a misconfigured value to disable caching in a surprising way.
+    stats_cache_ttl_seconds: float = Field(default=30.0, ge=0, allow_inf_nan=False)
 
 
 @lru_cache

--- a/backend/src/podex/main.py
+++ b/backend/src/podex/main.py
@@ -7,6 +7,7 @@ from podex.api.v2.router import api_v2_router
 from podex.config import Settings, get_settings
 from podex.logging_config import configure_logging
 from podex.middleware import RateLimitMiddleware, RequestContextMiddleware
+from podex.services.cache import TTLCache
 from podex.services.limiter import SlidingWindowRateLimiter
 
 
@@ -15,6 +16,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     resolved = settings or get_settings()
     configure_logging()
     app = FastAPI(title=resolved.app_name, debug=resolved.debug)
+    # Process-wide read-through cache for aggregate/stats endpoints. Shared
+    # across requests (and workers within this process) so the aggregation
+    # queries only run once per TTL window.
+    app.state.cache = TTLCache()
 
     # Middleware is applied in reverse registration order (last added runs
     # outermost). Register the rate limiter and request-context logger first so

--- a/backend/src/podex/main.py
+++ b/backend/src/podex/main.py
@@ -16,6 +16,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     resolved = settings or get_settings()
     configure_logging()
     app = FastAPI(title=resolved.app_name, debug=resolved.debug)
+    # Stash the resolved settings on ``app.state`` so route dependencies see
+    # the same instance ``create_app`` used to configure middleware — tests
+    # (and callers passing an explicit ``settings=``) rely on this to override
+    # e.g. ``stats_cache_ttl_seconds`` without touching global state.
+    app.state.settings = resolved
     # Process-wide read-through cache for aggregate/stats endpoints. Shared
     # across requests (and workers within this process) so the aggregation
     # queries only run once per TTL window.

--- a/backend/src/podex/schemas/stats.py
+++ b/backend/src/podex/schemas/stats.py
@@ -16,7 +16,8 @@ class CatalogStats(BaseModel):
     Attributes:
         podcasts: Total podcast sources in the catalog.
         episodes: Total episodes across all sources.
-        media: Total canonical media items referenced by episodes.
+        media: Total canonical media items in the catalog. Counts every
+            ``Media`` row, not just those referenced by a mention.
         mentions: Total episode<->media mention links.
         top_media_types: Up to five media types ordered by descending count,
             with ties broken alphabetically by type name for stability.
@@ -24,6 +25,15 @@ class CatalogStats(BaseModel):
 
     podcasts: int = Field(ge=0)
     episodes: int = Field(ge=0)
-    media: int = Field(ge=0)
+    media: int = Field(
+        ge=0,
+        description="Total canonical media items in the catalog (every Media row).",
+    )
     mentions: int = Field(ge=0)
-    top_media_types: list[MediaTypeCount]
+    top_media_types: list[MediaTypeCount] = Field(
+        max_length=5,
+        description=(
+            "Up to five media types ordered by descending count; ties broken "
+            "alphabetically by type name."
+        ),
+    )

--- a/backend/src/podex/schemas/stats.py
+++ b/backend/src/podex/schemas/stats.py
@@ -1,0 +1,29 @@
+"""Aggregate/statistics API schemas."""
+
+from pydantic import BaseModel, Field
+
+
+class MediaTypeCount(BaseModel):
+    """One row of the ``top_media_types`` breakdown."""
+
+    media_type: str = Field(description="MediaType value (e.g. ``book``, ``movie``).")
+    count: int = Field(description="Number of media rows of this type.", ge=0)
+
+
+class CatalogStats(BaseModel):
+    """Top-level catalog counters plus a small top-list breakdown.
+
+    Attributes:
+        podcasts: Total podcast sources in the catalog.
+        episodes: Total episodes across all sources.
+        media: Total canonical media items referenced by episodes.
+        mentions: Total episode<->media mention links.
+        top_media_types: Up to five media types ordered by descending count,
+            with ties broken alphabetically by type name for stability.
+    """
+
+    podcasts: int = Field(ge=0)
+    episodes: int = Field(ge=0)
+    media: int = Field(ge=0)
+    mentions: int = Field(ge=0)
+    top_media_types: list[MediaTypeCount]

--- a/backend/src/podex/services/__init__.py
+++ b/backend/src/podex/services/__init__.py
@@ -1,1 +1,7 @@
-"""Application service layer (rate limiting and related helpers)."""
+"""Application service layer.
+
+Modules under this package group storage-focused helpers that the API routes
+delegate to (query services), plus cross-cutting infrastructure like rate
+limiting and caching. Route handlers stay thin: validate inputs, call a
+service, then serialize.
+"""

--- a/backend/src/podex/services/cache.py
+++ b/backend/src/podex/services/cache.py
@@ -19,10 +19,12 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, TypeVar, cast, runtime_checkable
 
 MonotonicClock = Callable[[], float]
 """Zero-arg callable returning a monotonic timestamp in seconds."""
+
+T = TypeVar("T")
 
 
 @runtime_checkable
@@ -44,6 +46,21 @@ class Cache(Protocol):
     def clear(self) -> None:
         """Drop every entry (useful for tests and manual invalidation)."""
 
+    def get_or_compute(
+        self,
+        key: str,
+        *,
+        ttl_seconds: float,
+        loader: Callable[[], T],
+    ) -> T:
+        """Return the cached value or compute-and-store it single-flight.
+
+        Implementations must ensure that concurrent callers observing a cache
+        miss only invoke ``loader`` once per key; the remaining callers must
+        wait for that in-flight computation and return the freshly stored
+        value.
+        """
+
 
 @dataclass(frozen=True)
 class _Entry:
@@ -60,6 +77,10 @@ class TTLCache:
     monotonic deadline; ``get`` returns ``None`` once the deadline has passed
     and lazily evicts the expired entry so memory doesn't grow unbounded.
 
+    :meth:`get_or_compute` layers a per-key lock on top of the store so
+    concurrent cold-miss callers do not stampede an expensive loader (see
+    issue #15).
+
     Args:
         clock: Zero-arg callable returning a monotonic timestamp in seconds.
             Defaults to :func:`time.monotonic`; tests inject a fake clock to
@@ -70,6 +91,11 @@ class TTLCache:
         self._clock: MonotonicClock = clock
         self._entries: dict[str, _Entry] = {}
         self._lock = threading.Lock()
+        # Per-key coordinate locks used by ``get_or_compute`` to serialize
+        # concurrent cold misses. Guarded by ``self._lock`` on lookup so the
+        # mapping stays consistent; individual keys can then be locked without
+        # blocking unrelated ones.
+        self._key_locks: dict[str, threading.Lock] = {}
 
     def get(self, key: str) -> Any | None:
         """Return the cached value for ``key`` or ``None`` if absent/expired.
@@ -110,3 +136,59 @@ class TTLCache:
         """Drop every entry."""
         with self._lock:
             self._entries.clear()
+
+    def _get_key_lock(self, key: str) -> threading.Lock:
+        """Return the per-key lock for ``key``, creating it on first use.
+
+        The mapping itself is protected by ``self._lock`` so lookups stay
+        consistent under concurrent access; the returned lock can then be
+        acquired independently without blocking unrelated keys.
+        """
+        with self._lock:
+            existing = self._key_locks.get(key)
+            if existing is not None:
+                return existing
+            new_lock = threading.Lock()
+            self._key_locks[key] = new_lock
+            return new_lock
+
+    def get_or_compute(
+        self,
+        key: str,
+        *,
+        ttl_seconds: float,
+        loader: Callable[[], T],
+    ) -> T:
+        """Return the cached value or compute-and-store it single-flight.
+
+        A fast-path :meth:`get` avoids taking the per-key lock when the value
+        is already cached. On a miss the per-key lock is acquired and the
+        cache re-checked (double-checked locking) before ``loader`` runs, so
+        concurrent cold callers wait for the in-flight computation instead of
+        each recomputing the value.
+
+        A non-positive ``ttl_seconds`` disables caching entirely: ``loader``
+        is invoked directly and its result is returned without touching the
+        store, matching :meth:`set` semantics.
+
+        Args:
+            key: Cache key to read and (on miss) populate.
+            ttl_seconds: TTL applied when the loader result is stored.
+            loader: Zero-arg callable that computes the value on a miss.
+
+        Returns:
+            The cached value if present and unexpired, otherwise the freshly
+            computed value returned by ``loader``.
+        """
+        if ttl_seconds <= 0:
+            return loader()
+        cached = self.get(key)
+        if cached is not None:
+            return cast("T", cached)
+        with self._get_key_lock(key):
+            cached = self.get(key)
+            if cached is not None:
+                return cast("T", cached)
+            fresh = loader()
+            self.set(key, fresh, ttl_seconds=ttl_seconds)
+            return fresh

--- a/backend/src/podex/services/cache.py
+++ b/backend/src/podex/services/cache.py
@@ -1,0 +1,112 @@
+"""Small in-process TTL cache for cheap read-through caching.
+
+The cache is intentionally minimal: a thread-safe ``dict`` of entries with
+absolute-expiry timestamps. It is a good fit for a single dev/prod process
+(the current deployment shape) and covers the aggregate/stats surfaces where
+we tolerate a few seconds of staleness in exchange for skipping repeated
+aggregation queries.
+
+The public surface is deliberately shaped around a small :class:`Cache`
+protocol so a Redis-backed implementation can be dropped in later without
+touching call sites. Invalidation is TTL-based only for now; write-time hooks
+(e.g. purge stats on ingestion) will be added when the ingestion pipeline
+lands.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+MonotonicClock = Callable[[], float]
+"""Zero-arg callable returning a monotonic timestamp in seconds."""
+
+
+@runtime_checkable
+class Cache(Protocol):
+    """Minimal cache contract shared by every backend.
+
+    Implementations must be safe to use concurrently from multiple threads.
+    """
+
+    def get(self, key: str) -> Any | None:
+        """Return the cached value for ``key`` or ``None`` if absent/expired."""
+
+    def set(self, key: str, value: Any, *, ttl_seconds: float) -> None:
+        """Store ``value`` under ``key`` for ``ttl_seconds`` seconds."""
+
+    def delete(self, key: str) -> None:
+        """Remove ``key`` from the cache. A no-op if it was not present."""
+
+    def clear(self) -> None:
+        """Drop every entry (useful for tests and manual invalidation)."""
+
+
+@dataclass(frozen=True)
+class _Entry:
+    """A single cached value plus the monotonic instant it expires at."""
+
+    value: Any
+    expires_at: float
+
+
+class TTLCache:
+    """Thread-safe, in-process TTL cache.
+
+    Values are keyed by opaque strings. Each ``set`` records an absolute
+    monotonic deadline; ``get`` returns ``None`` once the deadline has passed
+    and lazily evicts the expired entry so memory doesn't grow unbounded.
+
+    Args:
+        clock: Zero-arg callable returning a monotonic timestamp in seconds.
+            Defaults to :func:`time.monotonic`; tests inject a fake clock to
+            exercise TTL expiry without sleeping.
+    """
+
+    def __init__(self, *, clock: MonotonicClock = time.monotonic) -> None:
+        self._clock: MonotonicClock = clock
+        self._entries: dict[str, _Entry] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key: str) -> Any | None:
+        """Return the cached value for ``key`` or ``None`` if absent/expired.
+
+        Expired entries are removed opportunistically on read so a rarely-hit
+        key does not linger in memory once its TTL elapses.
+        """
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            if entry.expires_at <= self._clock():
+                del self._entries[key]
+                return None
+            return entry.value
+
+    def set(self, key: str, value: Any, *, ttl_seconds: float) -> None:
+        """Store ``value`` for ``ttl_seconds`` seconds.
+
+        A non-positive TTL is treated as "already expired" — the key is
+        removed and no new entry is written. This makes it trivial to disable
+        caching from configuration by setting the TTL to ``0``.
+        """
+        if ttl_seconds <= 0:
+            with self._lock:
+                self._entries.pop(key, None)
+            return
+        expires_at = self._clock() + ttl_seconds
+        with self._lock:
+            self._entries[key] = _Entry(value=value, expires_at=expires_at)
+
+    def delete(self, key: str) -> None:
+        """Remove ``key`` from the cache. A no-op if it was not present."""
+        with self._lock:
+            self._entries.pop(key, None)
+
+    def clear(self) -> None:
+        """Drop every entry."""
+        with self._lock:
+            self._entries.clear()

--- a/backend/src/podex/services/episode_queries.py
+++ b/backend/src/podex/services/episode_queries.py
@@ -1,0 +1,65 @@
+"""Read-side query services for podcast episodes.
+
+Route handlers under ``podex.api.v2.episodes`` delegate here so the API
+modules only translate service outcomes to HTTP responses. Services stay
+storage-focused: they accept a SQLAlchemy ``Session`` and return ORM rows
+or ``None`` for missing lookups.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.models import Episode, Mention
+
+
+def list_episodes(db: Session, podcast_id: int | None = None) -> list[Episode]:
+    """Return episodes ordered newest-first, optionally filtered by podcast.
+
+    Args:
+        db: Active SQLAlchemy session bound to the request.
+        podcast_id: If provided, restrict results to a single podcast source.
+
+    Returns:
+        Episode rows sorted by ``published_at`` descending.
+    """
+    statement = select(Episode).order_by(Episode.published_at.desc())
+    if podcast_id is not None:
+        statement = statement.where(Episode.podcast_id == podcast_id)
+    return list(db.execute(statement).scalars().all())
+
+
+def get_episode(db: Session, episode_id: int) -> Episode | None:
+    """Return the episode with ``episode_id`` or ``None``.
+
+    Args:
+        db: Active SQLAlchemy session bound to the request.
+        episode_id: Primary key of the episode to fetch.
+
+    Returns:
+        The matching Episode row, or ``None`` when no such row exists.
+    """
+    return db.get(Episode, episode_id)
+
+
+def list_episode_mentions(db: Session, episode_id: int) -> list[Mention] | None:
+    """Return an episode's mentions in timestamp order.
+
+    Args:
+        db: Active SQLAlchemy session bound to the request.
+        episode_id: Primary key of the parent episode.
+
+    Returns:
+        Mentions ordered by ``timestamp_seconds`` when the episode exists, or
+        ``None`` to signal that the parent episode is unknown so the caller can
+        translate that into a 404 response.
+    """
+    if db.get(Episode, episode_id) is None:
+        return None
+    statement = (
+        select(Mention)
+        .where(Mention.episode_id == episode_id)
+        .order_by(Mention.timestamp_seconds)
+    )
+    return list(db.execute(statement).scalars().all())

--- a/backend/src/podex/services/episode_queries.py
+++ b/backend/src/podex/services/episode_queries.py
@@ -40,7 +40,10 @@ def get_episode(db: Session, episode_id: int) -> Episode | None:
     Returns:
         The matching Episode row, or ``None`` when no such row exists.
     """
-    return db.get(Episode, episode_id)
+    # Explicit local annotation keeps the return well-typed under the CI
+    # lint image where ``Session.get`` resolves to ``Any``.
+    episode: Episode | None = db.get(Episode, episode_id)
+    return episode
 
 
 def list_episode_mentions(db: Session, episode_id: int) -> list[Mention] | None:

--- a/backend/src/podex/services/media_queries.py
+++ b/backend/src/podex/services/media_queries.py
@@ -39,7 +39,10 @@ def get_media(db: Session, media_id: int) -> Media | None:
     Returns:
         The matching Media row, or ``None`` when no such row exists.
     """
-    return db.get(Media, media_id)
+    # Explicit local annotation keeps the return well-typed under the CI
+    # lint image where ``Session.get`` resolves to ``Any``.
+    media: Media | None = db.get(Media, media_id)
+    return media
 
 
 def list_media_mentions(db: Session, media_id: int) -> list[Mention] | None:

--- a/backend/src/podex/services/media_queries.py
+++ b/backend/src/podex/services/media_queries.py
@@ -1,0 +1,62 @@
+"""Read-side query services for canonical media items.
+
+Route handlers under ``podex.api.v2.media`` delegate here so the API modules
+only translate service outcomes into HTTP responses. Services accept a
+SQLAlchemy ``Session`` and return ORM rows or ``None`` for missing lookups.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.models import Media, MediaType, Mention
+
+
+def list_media(db: Session, media_type: MediaType | None = None) -> list[Media]:
+    """Return media items ordered by title, optionally filtered by type.
+
+    Args:
+        db: Active SQLAlchemy session bound to the request.
+        media_type: If provided, restrict results to this media kind.
+
+    Returns:
+        Media rows sorted alphabetically by ``title``.
+    """
+    statement = select(Media).order_by(Media.title)
+    if media_type is not None:
+        statement = statement.where(Media.type == media_type)
+    return list(db.execute(statement).scalars().all())
+
+
+def get_media(db: Session, media_id: int) -> Media | None:
+    """Return the media item with ``media_id`` or ``None``.
+
+    Args:
+        db: Active SQLAlchemy session bound to the request.
+        media_id: Primary key of the media item to fetch.
+
+    Returns:
+        The matching Media row, or ``None`` when no such row exists.
+    """
+    return db.get(Media, media_id)
+
+
+def list_media_mentions(db: Session, media_id: int) -> list[Mention] | None:
+    """Return the mentions that reference a media item.
+
+    Args:
+        db: Active SQLAlchemy session bound to the request.
+        media_id: Primary key of the media item.
+
+    Returns:
+        Mentions ordered by ``episode_id`` when the media item exists, or
+        ``None`` to signal that the parent media item is unknown so the caller
+        can translate that into a 404 response.
+    """
+    if db.get(Media, media_id) is None:
+        return None
+    statement = (
+        select(Mention).where(Mention.media_id == media_id).order_by(Mention.episode_id)
+    )
+    return list(db.execute(statement).scalars().all())

--- a/backend/src/podex/services/podcast_queries.py
+++ b/backend/src/podex/services/podcast_queries.py
@@ -37,4 +37,7 @@ def get_podcast(db: Session, podcast_id: int) -> Podcast | None:
     Returns:
         The matching Podcast row, or ``None`` when no such row exists.
     """
-    return db.get(Podcast, podcast_id)
+    # Explicit local annotation keeps the return well-typed under the CI
+    # lint image where ``Session.get`` resolves to ``Any``.
+    podcast: Podcast | None = db.get(Podcast, podcast_id)
+    return podcast

--- a/backend/src/podex/services/podcast_queries.py
+++ b/backend/src/podex/services/podcast_queries.py
@@ -1,0 +1,40 @@
+"""Read-side query services for podcast sources.
+
+The API layer stays thin by delegating list/get logic to these helpers. All
+functions accept a SQLAlchemy ``Session`` and return ORM instances (or
+``None`` for a missing lookup), so callers keep control of HTTP mapping and
+response serialization.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.models import Podcast
+
+
+def list_podcasts(db: Session) -> list[Podcast]:
+    """Return every podcast source, ordered by display name.
+
+    Args:
+        db: Active SQLAlchemy session bound to the request.
+
+    Returns:
+        Podcast rows sorted alphabetically by ``name``.
+    """
+    result = db.execute(select(Podcast).order_by(Podcast.name))
+    return list(result.scalars().all())
+
+
+def get_podcast(db: Session, podcast_id: int) -> Podcast | None:
+    """Return the podcast source with ``podcast_id`` or ``None``.
+
+    Args:
+        db: Active SQLAlchemy session bound to the request.
+        podcast_id: Primary key of the podcast to fetch.
+
+    Returns:
+        The matching Podcast row, or ``None`` when no such row exists.
+    """
+    return db.get(Podcast, podcast_id)

--- a/backend/src/podex/services/stats_queries.py
+++ b/backend/src/podex/services/stats_queries.py
@@ -70,8 +70,10 @@ def get_catalog_stats(
     """Return the catalog stats, hitting the cache first.
 
     On a miss the value is computed from ``db`` and stored under
-    :data:`CATALOG_STATS_CACHE_KEY` for ``ttl_seconds`` seconds. A
-    non-positive TTL disables caching (the value is always recomputed).
+    :data:`CATALOG_STATS_CACHE_KEY` for ``ttl_seconds`` seconds. The read is
+    single-flight — concurrent cold-miss callers wait for the in-flight
+    computation instead of stampeding the aggregation queries. A non-positive
+    TTL disables caching (the value is always recomputed).
 
     Args:
         db: Active SQLAlchemy session bound to the request.
@@ -81,12 +83,8 @@ def get_catalog_stats(
     Returns:
         The (possibly cached) :class:`CatalogStats` payload.
     """
-    if ttl_seconds > 0:
-        cached = cache.get(CATALOG_STATS_CACHE_KEY)
-        if isinstance(cached, CatalogStats):
-            return cached
-
-    fresh = compute_catalog_stats(db)
-    if ttl_seconds > 0:
-        cache.set(CATALOG_STATS_CACHE_KEY, fresh, ttl_seconds=ttl_seconds)
-    return fresh
+    return cache.get_or_compute(
+        CATALOG_STATS_CACHE_KEY,
+        ttl_seconds=ttl_seconds,
+        loader=lambda: compute_catalog_stats(db),
+    )

--- a/backend/src/podex/services/stats_queries.py
+++ b/backend/src/podex/services/stats_queries.py
@@ -1,0 +1,92 @@
+"""Aggregate/statistics queries with a read-through cache.
+
+The uncached helper :func:`compute_catalog_stats` runs the raw ``COUNT``
+aggregations against SQLAlchemy; the cached helper
+:func:`get_catalog_stats` wraps it in a :class:`~podex.services.cache.Cache`
+lookup keyed by :data:`CATALOG_STATS_CACHE_KEY`.
+
+Cache invalidation is TTL-based only for now — write-time invalidation hooks
+will be added once the ingestion pipeline lands.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from podex.models import Episode, Media, Mention, Podcast
+from podex.schemas.stats import CatalogStats, MediaTypeCount
+from podex.services.cache import Cache
+
+CATALOG_STATS_CACHE_KEY = "catalog:stats"
+"""Cache key under which the aggregate catalog stats are stored."""
+
+_TOP_MEDIA_TYPES_LIMIT = 5
+
+
+def compute_catalog_stats(db: Session) -> CatalogStats:
+    """Compute catalog-wide counters directly from the database.
+
+    Args:
+        db: Active SQLAlchemy session.
+
+    Returns:
+        A fresh :class:`CatalogStats` payload with counts and a small
+        top-media-types breakdown.
+    """
+    podcasts = db.execute(select(func.count()).select_from(Podcast)).scalar_one()
+    episodes = db.execute(select(func.count()).select_from(Episode)).scalar_one()
+    media = db.execute(select(func.count()).select_from(Media)).scalar_one()
+    mentions = db.execute(select(func.count()).select_from(Mention)).scalar_one()
+
+    # Ties are broken alphabetically by type name so responses are stable
+    # regardless of insertion order.
+    top_rows = db.execute(
+        select(Media.type, func.count().label("count"))
+        .group_by(Media.type)
+        .order_by(func.count().desc(), Media.type.asc())
+        .limit(_TOP_MEDIA_TYPES_LIMIT),
+    ).all()
+    top_media_types = [
+        MediaTypeCount(media_type=str(row_type), count=int(row_count))
+        for row_type, row_count in top_rows
+    ]
+
+    return CatalogStats(
+        podcasts=int(podcasts),
+        episodes=int(episodes),
+        media=int(media),
+        mentions=int(mentions),
+        top_media_types=top_media_types,
+    )
+
+
+def get_catalog_stats(
+    db: Session,
+    *,
+    cache: Cache,
+    ttl_seconds: float,
+) -> CatalogStats:
+    """Return the catalog stats, hitting the cache first.
+
+    On a miss the value is computed from ``db`` and stored under
+    :data:`CATALOG_STATS_CACHE_KEY` for ``ttl_seconds`` seconds. A
+    non-positive TTL disables caching (the value is always recomputed).
+
+    Args:
+        db: Active SQLAlchemy session bound to the request.
+        cache: Cache backend used for the read-through lookup.
+        ttl_seconds: Maximum age of a cached response before recomputation.
+
+    Returns:
+        The (possibly cached) :class:`CatalogStats` payload.
+    """
+    if ttl_seconds > 0:
+        cached = cache.get(CATALOG_STATS_CACHE_KEY)
+        if isinstance(cached, CatalogStats):
+            return cached
+
+    fresh = compute_catalog_stats(db)
+    if ttl_seconds > 0:
+        cache.set(CATALOG_STATS_CACHE_KEY, fresh, ttl_seconds=ttl_seconds)
+    return fresh

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,0 +1,85 @@
+"""Unit tests for the in-process TTL cache backend."""
+
+from assertpy import assert_that
+
+from podex.services.cache import Cache, TTLCache
+
+
+class _Clock:
+    """Simple monotonic-clock stand-in whose ``now`` value can be advanced."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_ttl_cache_implements_cache_protocol() -> None:
+    """The default backend satisfies the Cache Protocol at runtime."""
+    cache = TTLCache()
+
+    assert_that(isinstance(cache, Cache)).is_true()
+
+
+def test_get_returns_none_for_missing_key() -> None:
+    """A cold cache reports misses as ``None``."""
+    cache = TTLCache()
+
+    assert_that(cache.get("missing")).is_none()
+
+
+def test_set_then_get_returns_value() -> None:
+    """A stored value is returned as-is on the next read."""
+    cache = TTLCache()
+
+    cache.set("k", {"count": 3}, ttl_seconds=60)
+
+    assert_that(cache.get("k")).is_equal_to({"count": 3})
+
+
+def test_expired_entry_returns_none_and_is_evicted() -> None:
+    """Once the TTL elapses the entry is invisible and removed lazily."""
+    clock = _Clock()
+    cache = TTLCache(clock=clock)
+
+    cache.set("k", "value", ttl_seconds=10)
+    clock.now += 11
+
+    assert_that(cache.get("k")).is_none()
+    # Internal state check: the expired entry is dropped on read so memory
+    # doesn't grow unbounded when keys age out silently.
+    assert_that(cache.get("k")).is_none()
+
+
+def test_non_positive_ttl_disables_caching() -> None:
+    """``ttl_seconds`` of 0 removes any existing key and stores nothing new."""
+    cache = TTLCache()
+    cache.set("k", "value", ttl_seconds=10)
+
+    cache.set("k", "new", ttl_seconds=0)
+
+    assert_that(cache.get("k")).is_none()
+
+
+def test_delete_removes_key() -> None:
+    """``delete`` removes an existing key and is a no-op for missing ones."""
+    cache = TTLCache()
+    cache.set("k", "value", ttl_seconds=60)
+
+    cache.delete("k")
+    cache.delete("missing")
+
+    assert_that(cache.get("k")).is_none()
+
+
+def test_clear_drops_every_entry() -> None:
+    """``clear`` removes every stored key in one call."""
+    cache = TTLCache()
+    cache.set("a", 1, ttl_seconds=60)
+    cache.set("b", 2, ttl_seconds=60)
+
+    cache.clear()
+
+    assert_that(cache.get("a")).is_none()
+    assert_that(cache.get("b")).is_none()

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,5 +1,8 @@
 """Unit tests for the in-process TTL cache backend."""
 
+import threading
+import time
+
 from assertpy import assert_that
 
 from podex.services.cache import Cache, TTLCache
@@ -83,3 +86,88 @@ def test_clear_drops_every_entry() -> None:
 
     assert_that(cache.get("a")).is_none()
     assert_that(cache.get("b")).is_none()
+
+
+def test_get_or_compute_populates_and_reuses_entry() -> None:
+    """The loader runs on the first call and is skipped while cached."""
+    cache = TTLCache()
+    call_count = 0
+
+    def loader() -> str:
+        """Return a sentinel value and record how many times it ran."""
+        nonlocal call_count
+        call_count += 1
+        return "value"
+
+    first = cache.get_or_compute("k", ttl_seconds=60, loader=loader)
+    second = cache.get_or_compute("k", ttl_seconds=60, loader=loader)
+
+    assert_that(first).is_equal_to("value")
+    assert_that(second).is_equal_to("value")
+    assert_that(call_count).is_equal_to(1)
+
+
+def test_get_or_compute_skips_cache_when_ttl_is_zero() -> None:
+    """A non-positive TTL bypasses the store entirely."""
+    cache = TTLCache()
+    call_count = 0
+
+    def loader() -> str:
+        """Return a sentinel value and record how many times it ran."""
+        nonlocal call_count
+        call_count += 1
+        return "value"
+
+    result = cache.get_or_compute("k", ttl_seconds=0, loader=loader)
+    # A second call still recomputes because nothing was stored.
+    cache.get_or_compute("k", ttl_seconds=0, loader=loader)
+
+    assert_that(result).is_equal_to("value")
+    assert_that(cache.get("k")).is_none()
+    assert_that(call_count).is_equal_to(2)
+
+
+def test_get_or_compute_is_single_flight_under_concurrency() -> None:
+    """Concurrent cold-miss callers only invoke the loader once."""
+    cache = TTLCache()
+    call_count = 0
+    counter_lock = threading.Lock()
+    workers = 8
+    ready = threading.Barrier(workers + 1)
+    release = threading.Event()
+
+    def loader() -> str:
+        """Slow loader whose invocations we count.
+
+        The barrier and event let the test line every worker up on the cache
+        miss before releasing them together, so the per-key lock is the only
+        thing preventing duplicate loader runs.
+        """
+        with counter_lock:
+            nonlocal call_count
+            call_count += 1
+        # A short sleep widens the concurrent window if the lock is broken.
+        time.sleep(0.05)
+        return "value"
+
+    results: list[str] = []
+    results_lock = threading.Lock()
+
+    def worker() -> None:
+        """Wait for the release signal, then race against the other workers."""
+        ready.wait()
+        release.wait()
+        value = cache.get_or_compute("k", ttl_seconds=60, loader=loader)
+        with results_lock:
+            results.append(value)
+
+    threads = [threading.Thread(target=worker) for _ in range(workers)]
+    for thread in threads:
+        thread.start()
+    ready.wait()
+    release.set()
+    for thread in threads:
+        thread.join()
+
+    assert_that(call_count).is_equal_to(1)
+    assert_that(results).is_equal_to(["value"] * workers)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,6 +1,10 @@
 """Tests for application settings."""
 
+import math
+
+import pytest
 from assertpy import assert_that
+from pydantic import ValidationError
 
 from podex.config import Settings, get_settings
 
@@ -27,3 +31,26 @@ def test_rate_limit_defaults_are_generous() -> None:
 def test_get_settings_is_cached() -> None:
     """``get_settings`` returns a cached singleton."""
     assert_that(get_settings()).is_same_as(get_settings())
+
+
+def test_stats_cache_ttl_rejects_non_finite_values() -> None:
+    """``NaN`` and ``inf`` are refused so misconfig fails at startup."""
+    for bad in (math.nan, math.inf, -math.inf):
+        with pytest.raises(ValidationError):
+            Settings(stats_cache_ttl_seconds=bad)
+
+
+def test_stats_cache_ttl_rejects_negative_values() -> None:
+    """A negative TTL is refused (``ge=0`` guard)."""
+    with pytest.raises(ValidationError):
+        Settings(stats_cache_ttl_seconds=-1.0)
+
+
+def test_stats_cache_ttl_accepts_zero_and_positive() -> None:
+    """``0`` (disabled) and positive floats are accepted."""
+    assert_that(Settings(stats_cache_ttl_seconds=0).stats_cache_ttl_seconds).is_equal_to(
+        0,
+    )
+    assert_that(
+        Settings(stats_cache_ttl_seconds=45.5).stats_cache_ttl_seconds,
+    ).is_equal_to(45.5)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -48,9 +48,8 @@ def test_stats_cache_ttl_rejects_negative_values() -> None:
 
 def test_stats_cache_ttl_accepts_zero_and_positive() -> None:
     """``0`` (disabled) and positive floats are accepted."""
-    assert_that(Settings(stats_cache_ttl_seconds=0).stats_cache_ttl_seconds).is_equal_to(
-        0,
-    )
-    assert_that(
-        Settings(stats_cache_ttl_seconds=45.5).stats_cache_ttl_seconds,
-    ).is_equal_to(45.5)
+    zero = Settings(stats_cache_ttl_seconds=0).stats_cache_ttl_seconds
+    positive = Settings(stats_cache_ttl_seconds=45.5).stats_cache_ttl_seconds
+
+    assert_that(zero).is_equal_to(0)
+    assert_that(positive).is_equal_to(45.5)

--- a/backend/tests/test_services_queries.py
+++ b/backend/tests/test_services_queries.py
@@ -1,0 +1,117 @@
+"""Unit tests for the read-side query services.
+
+These exercise :mod:`podex.services.podcast_queries`,
+:mod:`podex.services.episode_queries`, and
+:mod:`podex.services.media_queries` directly against a real ``Session`` so
+route handlers only need to translate service outcomes to HTTP responses.
+"""
+
+from datetime import UTC, datetime
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import Episode, Media, MediaType, Mention, Podcast
+from podex.services import episode_queries, media_queries, podcast_queries
+
+
+def test_list_podcasts_orders_by_name(db_session: Session) -> None:
+    """Podcasts are returned alphabetically by name."""
+    db_session.add(Podcast(name="Zeta Cast", slug="zeta"))
+    db_session.add(Podcast(name="Alpha Cast", slug="alpha"))
+    db_session.commit()
+
+    result = podcast_queries.list_podcasts(db_session)
+
+    assert_that([podcast.slug for podcast in result]).is_equal_to(["alpha", "zeta"])
+
+
+def test_get_podcast_returns_none_for_missing(db_session: Session) -> None:
+    """A missing podcast id resolves to ``None`` (the API maps this to 404)."""
+    assert_that(podcast_queries.get_podcast(db_session, 999)).is_none()
+
+
+def test_get_podcast_returns_row(db_session: Session) -> None:
+    """A known podcast id returns the ORM row."""
+    podcast = Podcast(name="Show", slug="show")
+    db_session.add(podcast)
+    db_session.commit()
+
+    assert_that(podcast_queries.get_podcast(db_session, podcast.id).slug).is_equal_to(
+        "show",
+    )
+
+
+def test_list_episodes_filters_and_orders(db_session: Session) -> None:
+    """Episodes filter by podcast_id and sort newest-first."""
+    first = Podcast(name="First", slug="first")
+    second = Podcast(name="Second", slug="second")
+    db_session.add_all([first, second])
+    db_session.commit()
+    db_session.add(
+        Episode(
+            podcast_id=first.id,
+            title="Old",
+            published_at=datetime(2020, 1, 1, tzinfo=UTC),
+        ),
+    )
+    db_session.add(
+        Episode(
+            podcast_id=first.id,
+            title="New",
+            published_at=datetime(2024, 1, 1, tzinfo=UTC),
+        ),
+    )
+    db_session.add(Episode(podcast_id=second.id, title="Other"))
+    db_session.commit()
+
+    filtered = episode_queries.list_episodes(db_session, podcast_id=first.id)
+
+    assert_that([episode.title for episode in filtered]).is_equal_to(["New", "Old"])
+
+
+def test_list_episode_mentions_returns_none_for_missing(db_session: Session) -> None:
+    """A missing parent episode yields ``None`` so the API can 404."""
+    assert_that(episode_queries.list_episode_mentions(db_session, 999)).is_none()
+
+
+def test_list_episode_mentions_orders_by_timestamp(db_session: Session) -> None:
+    """Mentions for an existing episode order by ``timestamp_seconds``."""
+    podcast = Podcast(name="Show", slug="show")
+    db_session.add(podcast)
+    db_session.commit()
+    episode = Episode(podcast_id=podcast.id, title="Pilot")
+    dune = Media(type=MediaType.BOOK, title="Dune")
+    arrival = Media(type=MediaType.MOVIE, title="Arrival")
+    db_session.add_all([episode, dune, arrival])
+    db_session.commit()
+    db_session.add(
+        Mention(episode_id=episode.id, media_id=dune.id, timestamp_seconds=120),
+    )
+    db_session.add(
+        Mention(episode_id=episode.id, media_id=arrival.id, timestamp_seconds=30),
+    )
+    db_session.commit()
+
+    mentions = episode_queries.list_episode_mentions(db_session, episode.id)
+
+    assert mentions is not None
+    assert_that([mention.timestamp_seconds for mention in mentions]).is_equal_to(
+        [30, 120],
+    )
+
+
+def test_list_media_filters_by_type(db_session: Session) -> None:
+    """The optional media_type filter narrows the result set."""
+    db_session.add(Media(type=MediaType.BOOK, title="Dune"))
+    db_session.add(Media(type=MediaType.MOVIE, title="Arrival"))
+    db_session.commit()
+
+    books = media_queries.list_media(db_session, media_type=MediaType.BOOK)
+
+    assert_that([media.title for media in books]).is_equal_to(["Dune"])
+
+
+def test_list_media_mentions_returns_none_for_missing(db_session: Session) -> None:
+    """A missing parent media item yields ``None`` so the API can 404."""
+    assert_that(media_queries.list_media_mentions(db_session, 999)).is_none()

--- a/backend/tests/test_services_queries.py
+++ b/backend/tests/test_services_queries.py
@@ -119,3 +119,32 @@ def test_list_media_filters_by_type(db_session: Session) -> None:
 def test_list_media_mentions_returns_none_for_missing(db_session: Session) -> None:
     """A missing parent media item yields ``None`` so the API can 404."""
     assert_that(media_queries.list_media_mentions(db_session, 999)).is_none()
+
+
+def test_list_media_mentions_orders_by_episode_id(db_session: Session) -> None:
+    """Mentions for an existing media item order by ``episode_id``."""
+    podcast = Podcast(name="Show", slug="show")
+    db_session.add(podcast)
+    db_session.commit()
+    episode_a = Episode(podcast_id=podcast.id, title="Episode A")
+    episode_b = Episode(podcast_id=podcast.id, title="Episode B")
+    media = Media(type=MediaType.BOOK, title="Dune")
+    db_session.add_all([episode_a, episode_b, media])
+    db_session.commit()
+    # Insert the higher-``episode_id`` mention first to prove the service is
+    # sorting rather than returning insertion order.
+    db_session.add(
+        Mention(episode_id=episode_b.id, media_id=media.id, timestamp_seconds=30),
+    )
+    db_session.add(
+        Mention(episode_id=episode_a.id, media_id=media.id, timestamp_seconds=120),
+    )
+    db_session.commit()
+
+    mentions = media_queries.list_media_mentions(db_session, media.id)
+
+    assert_that(mentions).is_not_none()
+    narrowed = cast("list[Mention]", mentions)
+    assert_that([mention.episode_id for mention in narrowed]).is_equal_to(
+        [episode_a.id, episode_b.id],
+    )

--- a/backend/tests/test_services_queries.py
+++ b/backend/tests/test_services_queries.py
@@ -7,6 +7,7 @@ route handlers only need to translate service outcomes to HTTP responses.
 """
 
 from datetime import UTC, datetime
+from typing import cast
 
 from assertpy import assert_that
 from sqlalchemy.orm import Session
@@ -95,8 +96,11 @@ def test_list_episode_mentions_orders_by_timestamp(db_session: Session) -> None:
 
     mentions = episode_queries.list_episode_mentions(db_session, episode.id)
 
-    assert mentions is not None
-    assert_that([mention.timestamp_seconds for mention in mentions]).is_equal_to(
+    assert_that(mentions).is_not_none()
+    # ``assert_that(...).is_not_none()`` doesn't narrow the type for mypy, so
+    # cast to the non-optional variant before iterating.
+    narrowed = cast("list[Mention]", mentions)
+    assert_that([mention.timestamp_seconds for mention in narrowed]).is_equal_to(
         [30, 120],
     )
 

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,0 +1,163 @@
+"""Tests for the ``/api/v2/stats`` endpoint and its cache wiring."""
+
+from collections.abc import Iterator
+
+import pytest
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.api.deps import get_app_cache
+from podex.database import get_db
+from podex.main import create_app
+from podex.models import Episode, Media, MediaType, Mention, Podcast
+from podex.services.cache import TTLCache
+from podex.services.stats_queries import (
+    CATALOG_STATS_CACHE_KEY,
+    compute_catalog_stats,
+    get_catalog_stats,
+)
+
+
+class _Clock:
+    """Advancable clock used to exercise TTL expiry without sleeping."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _seed_catalog(db: Session) -> None:
+    """Populate a small but realistic mixed catalog for stats tests."""
+    podcast = Podcast(name="Show", slug="show")
+    db.add(podcast)
+    db.commit()
+    episode = Episode(podcast_id=podcast.id, title="Pilot")
+    dune = Media(type=MediaType.BOOK, title="Dune")
+    foundation = Media(type=MediaType.BOOK, title="Foundation")
+    arrival = Media(type=MediaType.MOVIE, title="Arrival")
+    db.add_all([episode, dune, foundation, arrival])
+    db.commit()
+    db.add(Mention(episode_id=episode.id, media_id=dune.id, timestamp_seconds=10))
+    db.add(Mention(episode_id=episode.id, media_id=arrival.id, timestamp_seconds=20))
+    db.commit()
+
+
+def test_compute_catalog_stats_reports_counts_and_top_types(
+    db_session: Session,
+) -> None:
+    """The uncached helper returns real counts and a stable top-types list."""
+    _seed_catalog(db_session)
+
+    stats = compute_catalog_stats(db_session)
+
+    assert_that(stats.podcasts).is_equal_to(1)
+    assert_that(stats.episodes).is_equal_to(1)
+    assert_that(stats.media).is_equal_to(3)
+    assert_that(stats.mentions).is_equal_to(2)
+    top = [(row.media_type, row.count) for row in stats.top_media_types]
+    assert_that(top).is_equal_to([("book", 2), ("movie", 1)])
+
+
+def test_get_catalog_stats_uses_cache_on_second_call(db_session: Session) -> None:
+    """A cached value short-circuits the DB query on subsequent calls."""
+    _seed_catalog(db_session)
+    cache = TTLCache()
+
+    first = get_catalog_stats(db_session, cache=cache, ttl_seconds=60)
+    # Mutate the DB after the first call. If the cache is honored the counts
+    # returned from the second call should be unchanged.
+    db_session.add(Podcast(name="Another", slug="another"))
+    db_session.commit()
+    second = get_catalog_stats(db_session, cache=cache, ttl_seconds=60)
+
+    assert_that(second).is_equal_to(first)
+    assert_that(second.podcasts).is_equal_to(1)
+
+
+def test_get_catalog_stats_recomputes_after_ttl_expiry(db_session: Session) -> None:
+    """Once the TTL has elapsed the next call recomputes from the DB."""
+    _seed_catalog(db_session)
+    clock = _Clock()
+    cache = TTLCache(clock=clock)
+
+    first = get_catalog_stats(db_session, cache=cache, ttl_seconds=10)
+    db_session.add(Podcast(name="Another", slug="another"))
+    db_session.commit()
+    clock.now += 11
+    second = get_catalog_stats(db_session, cache=cache, ttl_seconds=10)
+
+    assert_that(first.podcasts).is_equal_to(1)
+    assert_that(second.podcasts).is_equal_to(2)
+
+
+def test_get_catalog_stats_bypasses_cache_when_ttl_zero(db_session: Session) -> None:
+    """A non-positive TTL disables caching (used to opt out via settings)."""
+    _seed_catalog(db_session)
+    cache = TTLCache()
+
+    get_catalog_stats(db_session, cache=cache, ttl_seconds=0)
+
+    assert_that(cache.get(CATALOG_STATS_CACHE_KEY)).is_none()
+
+
+@pytest.fixture
+def stats_test_client(db_session: Session) -> Iterator[tuple[TestClient, TTLCache]]:
+    """Return a client + shared TTLCache override so tests can inspect it."""
+    app = create_app()
+    cache = TTLCache()
+
+    def override_get_db() -> Iterator[Session]:
+        """Yield the in-memory session used across the test module."""
+        yield db_session
+
+    def override_get_app_cache() -> TTLCache:
+        """Return the shared cache instance the test can inspect directly."""
+        return cache
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_app_cache] = override_get_app_cache
+    with TestClient(app) as test_client:
+        yield test_client, cache
+
+
+def test_stats_endpoint_returns_counts(
+    stats_test_client: tuple[TestClient, TTLCache],
+    db_session: Session,
+) -> None:
+    """The endpoint serves the aggregate payload with 200 OK."""
+    client, _cache = stats_test_client
+    _seed_catalog(db_session)
+
+    response = client.get("/api/v2/stats")
+
+    assert_that(response.status_code).is_equal_to(200)
+    body = response.json()
+    assert_that(body["podcasts"]).is_equal_to(1)
+    assert_that(body["episodes"]).is_equal_to(1)
+    assert_that(body["media"]).is_equal_to(3)
+    assert_that(body["mentions"]).is_equal_to(2)
+    assert_that([row["media_type"] for row in body["top_media_types"]]).is_equal_to(
+        ["book", "movie"],
+    )
+
+
+def test_stats_endpoint_serves_cache_on_repeat_call(
+    stats_test_client: tuple[TestClient, TTLCache],
+    db_session: Session,
+) -> None:
+    """A repeat call within the TTL window returns the cached payload."""
+    client, cache = stats_test_client
+    _seed_catalog(db_session)
+
+    first = client.get("/api/v2/stats").json()
+    # Mutate the DB after the first call. If the cache is honored the counts
+    # returned from the second call should be identical to the first.
+    db_session.add(Podcast(name="Another", slug="another"))
+    db_session.commit()
+    second = client.get("/api/v2/stats").json()
+
+    assert_that(second).is_equal_to(first)
+    assert_that(cache.get(CATALOG_STATS_CACHE_KEY)).is_not_none()

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from podex.api.deps import get_app_cache
+from podex.config import Settings
 from podex.database import get_db
 from podex.main import create_app
 from podex.models import Episode, Media, MediaType, Mention, Podcast
@@ -161,3 +162,38 @@ def test_stats_endpoint_serves_cache_on_repeat_call(
 
     assert_that(second).is_equal_to(first)
     assert_that(cache.get(CATALOG_STATS_CACHE_KEY)).is_not_none()
+
+
+def test_stats_endpoint_honors_settings_from_create_app(
+    db_session: Session,
+) -> None:
+    """``create_app(settings=...)`` reaches the ``/api/v2/stats`` handler.
+
+    Explicitly building the app with ``stats_cache_ttl_seconds=0`` and no
+    other override must produce a response that bypasses the cache — i.e.
+    each call recomputes and no entry lands in ``app.state.cache``. If the
+    dependency instead resolved to the cached global settings, the default
+    30-second TTL would apply and this test would fail.
+    """
+    settings = Settings(stats_cache_ttl_seconds=0)
+    app = create_app(settings=settings)
+
+    def override_get_db() -> Iterator[Session]:
+        """Return the in-memory session shared across the test module."""
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as client:
+        _seed_catalog(db_session)
+        response_before = client.get("/api/v2/stats")
+        db_session.add(Podcast(name="Another", slug="another"))
+        db_session.commit()
+        response_after = client.get("/api/v2/stats")
+
+    assert_that(response_before.status_code).is_equal_to(200)
+    assert_that(response_after.status_code).is_equal_to(200)
+    assert_that(response_before.json()["podcasts"]).is_equal_to(1)
+    assert_that(response_after.json()["podcasts"]).is_equal_to(2)
+    # ttl=0 means no caching → the process-wide cache stays empty even after
+    # a successful request.
+    assert_that(app.state.cache.get(CATALOG_STATS_CACHE_KEY)).is_none()

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,6 +1,47 @@
 {
   "components": {
     "schemas": {
+      "CatalogStats": {
+        "description": "Top-level catalog counters plus a small top-list breakdown.\n\nAttributes:\n    podcasts: Total podcast sources in the catalog.\n    episodes: Total episodes across all sources.\n    media: Total canonical media items referenced by episodes.\n    mentions: Total episode<->media mention links.\n    top_media_types: Up to five media types ordered by descending count,\n        with ties broken alphabetically by type name for stability.",
+        "properties": {
+          "episodes": {
+            "minimum": 0.0,
+            "title": "Episodes",
+            "type": "integer"
+          },
+          "media": {
+            "minimum": 0.0,
+            "title": "Media",
+            "type": "integer"
+          },
+          "mentions": {
+            "minimum": 0.0,
+            "title": "Mentions",
+            "type": "integer"
+          },
+          "podcasts": {
+            "minimum": 0.0,
+            "title": "Podcasts",
+            "type": "integer"
+          },
+          "top_media_types": {
+            "items": {
+              "$ref": "#/components/schemas/MediaTypeCount"
+            },
+            "title": "Top Media Types",
+            "type": "array"
+          }
+        },
+        "required": [
+          "podcasts",
+          "episodes",
+          "media",
+          "mentions",
+          "top_media_types"
+        ],
+        "title": "CatalogStats",
+        "type": "object"
+      },
       "EpisodeRead": {
         "description": "Public representation of a podcast episode.",
         "properties": {
@@ -161,6 +202,28 @@
         ],
         "title": "MediaType",
         "type": "string"
+      },
+      "MediaTypeCount": {
+        "description": "One row of the ``top_media_types`` breakdown.",
+        "properties": {
+          "count": {
+            "description": "Number of media rows of this type.",
+            "minimum": 0.0,
+            "title": "Count",
+            "type": "integer"
+          },
+          "media_type": {
+            "description": "MediaType value (e.g. ``book``, ``movie``).",
+            "title": "Media Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "media_type",
+          "count"
+        ],
+        "title": "MediaTypeCount",
+        "type": "object"
       },
       "MentionRead": {
         "description": "Public representation of a media mention within an episode.",
@@ -680,6 +743,29 @@
         "tags": [
           "v2",
           "podcasts"
+        ]
+      }
+    },
+    "/api/v2/stats": {
+      "get": {
+        "description": "Return catalog-wide counts and a small top-media-types breakdown.\n\nResponses are cached in-process for\n``PODEX_STATS_CACHE_TTL_SECONDS`` seconds (configurable via\n:class:`~podex.config.Settings`); set the TTL to ``0`` to bypass the\ncache entirely.",
+        "operationId": "get_catalog_stats_api_v2_stats_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogStats"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Catalog Stats",
+        "tags": [
+          "v2",
+          "stats"
         ]
       }
     },

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2,7 +2,7 @@
   "components": {
     "schemas": {
       "CatalogStats": {
-        "description": "Top-level catalog counters plus a small top-list breakdown.\n\nAttributes:\n    podcasts: Total podcast sources in the catalog.\n    episodes: Total episodes across all sources.\n    media: Total canonical media items referenced by episodes.\n    mentions: Total episode<->media mention links.\n    top_media_types: Up to five media types ordered by descending count,\n        with ties broken alphabetically by type name for stability.",
+        "description": "Top-level catalog counters plus a small top-list breakdown.\n\nAttributes:\n    podcasts: Total podcast sources in the catalog.\n    episodes: Total episodes across all sources.\n    media: Total canonical media items in the catalog. Counts every\n        ``Media`` row, not just those referenced by a mention.\n    mentions: Total episode<->media mention links.\n    top_media_types: Up to five media types ordered by descending count,\n        with ties broken alphabetically by type name for stability.",
         "properties": {
           "episodes": {
             "minimum": 0.0,
@@ -10,6 +10,7 @@
             "type": "integer"
           },
           "media": {
+            "description": "Total canonical media items in the catalog (every Media row).",
             "minimum": 0.0,
             "title": "Media",
             "type": "integer"
@@ -25,9 +26,11 @@
             "type": "integer"
           },
           "top_media_types": {
+            "description": "Up to five media types ordered by descending count; ties broken alphabetically by type name.",
             "items": {
               "$ref": "#/components/schemas/MediaTypeCount"
             },
+            "maxItems": 5,
             "title": "Top Media Types",
             "type": "array"
           }

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -240,7 +240,8 @@ export interface components {
          *     Attributes:
          *         podcasts: Total podcast sources in the catalog.
          *         episodes: Total episodes across all sources.
-         *         media: Total canonical media items referenced by episodes.
+         *         media: Total canonical media items in the catalog. Counts every
+         *             ``Media`` row, not just those referenced by a mention.
          *         mentions: Total episode<->media mention links.
          *         top_media_types: Up to five media types ordered by descending count,
          *             with ties broken alphabetically by type name for stability.
@@ -248,13 +249,19 @@ export interface components {
         CatalogStats: {
             /** Episodes */
             episodes: number;
-            /** Media */
+            /**
+             * Media
+             * @description Total canonical media items in the catalog (every Media row).
+             */
             media: number;
             /** Mentions */
             mentions: number;
             /** Podcasts */
             podcasts: number;
-            /** Top Media Types */
+            /**
+             * Top Media Types
+             * @description Up to five media types ordered by descending count; ties broken alphabetically by type name.
+             */
             top_media_types: components["schemas"]["MediaTypeCount"][];
         };
         /**

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -164,6 +164,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Catalog Stats
+         * @description Return catalog-wide counts and a small top-media-types breakdown.
+         *
+         *     Responses are cached in-process for
+         *     ``PODEX_STATS_CACHE_TTL_SECONDS`` seconds (configurable via
+         *     :class:`~podex.config.Settings`); set the TTL to ``0`` to bypass the
+         *     cache entirely.
+         */
+        get: operations["get_catalog_stats_api_v2_stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/status": {
         parameters: {
             query?: never;
@@ -208,6 +233,30 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * CatalogStats
+         * @description Top-level catalog counters plus a small top-list breakdown.
+         *
+         *     Attributes:
+         *         podcasts: Total podcast sources in the catalog.
+         *         episodes: Total episodes across all sources.
+         *         media: Total canonical media items referenced by episodes.
+         *         mentions: Total episode<->media mention links.
+         *         top_media_types: Up to five media types ordered by descending count,
+         *             with ties broken alphabetically by type name for stability.
+         */
+        CatalogStats: {
+            /** Episodes */
+            episodes: number;
+            /** Media */
+            media: number;
+            /** Mentions */
+            mentions: number;
+            /** Podcasts */
+            podcasts: number;
+            /** Top Media Types */
+            top_media_types: components["schemas"]["MediaTypeCount"][];
+        };
         /**
          * EpisodeRead
          * @description Public representation of a podcast episode.
@@ -264,6 +313,22 @@ export interface components {
          * @enum {string}
          */
         MediaType: "book" | "movie" | "documentary" | "tv_show" | "study" | "podcast" | "article" | "person" | "place";
+        /**
+         * MediaTypeCount
+         * @description One row of the ``top_media_types`` breakdown.
+         */
+        MediaTypeCount: {
+            /**
+             * Count
+             * @description Number of media rows of this type.
+             */
+            count: number;
+            /**
+             * Media Type
+             * @description MediaType value (e.g. ``book``, ``movie``).
+             */
+            media_type: string;
+        };
         /**
          * MentionRead
          * @description Public representation of a media mention within an episode.
@@ -561,6 +626,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_catalog_stats_api_v2_stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CatalogStats"];
                 };
             };
         };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(api): extract query services and add cached stats
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Extracts podcast/episode/media query logic into a shared service layer (routes stay thin) and adds `GET /api/v2/stats` with a configurable TTL cache for catalog aggregates. OpenAPI artifact and typed frontend client regenerated.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #32
- Closes #15

## Details

- New query services under `backend/src/podex/services/*_queries.py`.
- New `TTLCache` + `GET /api/v2/stats` (counts + media-type breakdown).
- Cache invalidation is TTL-based for now (no ingestion write hooks on main yet); `PODEX_STATS_CACHE_TTL_SECONDS=0` disables caching.
- Verification: `uv run lintro fmt/chk`, `uv run pytest` (73 passed), `bun run test:run` (13 passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /api/v2/stats` with catalog totals for podcasts, episodes, media, and mentions, plus top media type counts (top 5).
  * Enabled in-process statistics caching with a configurable TTL (set to `0` to bypass caching).
  * Updated API docs and regenerated frontend types for the new endpoint.

* **Improvements**
  * Standardized episode/media/podcast read endpoints to rely on service-layer lookups, with consistent `404` handling for missing records.

* **Tests**
  * Added unit and integration coverage for TTL caching, stats computation/caching behavior, and read/query correctness and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->