### PR TITLE
chore(ci): finish lint config scaffolding for lgtm-ci adoption

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+# actionlint configuration
+# See https://github.com/rhysd/actionlint/blob/main/docs/config.md
+---
+# Podex uses GitHub-hosted runners only; no self-hosted runner labels to declare.

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -41,6 +41,12 @@ jobs:
       contents: read
       pull-requests: write
 
+  # Coverage publishing (#200 / epic #114): no separate coverage.yml calling
+  # reusable-coverage.yml. test-coverage already collects coverage, enforces the
+  # 85% threshold, uploads artifacts, and publishes the PR summary via
+  # reusable-test-python. reusable-coverage would only add multi-artifact merge,
+  # badge generation, and optional GitHub Pages — not needed for this repo.
+  #
   # Coverage mode (lgtm-ci contract #340): single runtime with coverage
   # reporting and the PR test summary comment.
   test-coverage:

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,6 @@
+[sqlfluff]
+# Alembic migrations are dialect-agnostic DDL; SQLite is the local default.
+dialect = ansi
+
+[sqlfluff:rules:references.keywords]
+ignore_words = name, data, version

--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -1,0 +1,8 @@
+# Generated and local environments
+node_modules/
+.venv/
+venv/
+backend/.venv/
+
+# Alembic revision modules embed SQL via Python; not .sql sources for sqlfluff.
+backend/alembic/versions/

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,24 @@
+---
+extends: default
+
+ignore:
+  - node_modules/
+  - .venv/
+  - venv/
+  - .lintro/
+
+rules:
+  # GitHub Actions comments often don't follow indentation expectations
+  comments-indentation: disable
+
+  comments:
+    min-spaces-from-content: 1
+
+  truthy:
+    # Flag unquoted YAML 1.1 truthy/falsey scalars when used as keys.
+    check-keys: true
+
+  # Avoid noise on CI YAML with long pinned SHAs and long with: blocks
+  line-length:
+    max: 88
+    allow-non-breakable-inline-mappings: true

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,31 @@
+Third-Party Notices
+===================
+
+Podex
+-----
+
+Copyright (C) 2026 lgtm-hq
+
+Podex is licensed under the GNU Affero General Public License v3.0 only
+(AGPL-3.0-only). See the LICENSE and NOTICE files in this repository for the
+full license text and copyright statement.
+
+Dependency declarations
+-----------------------
+
+Runtime and development dependencies are declared in the project manifests and
+lockfiles:
+
+- Backend (Python): `backend/pyproject.toml`, `backend/uv.lock`
+- Frontend (JavaScript/TypeScript): `frontend/package.json`, `frontend/bun.lock`
+
+Each dependency is subject to its own license. Refer to the upstream package
+metadata or source for license terms. This file does not reproduce every
+transitive dependency license.
+
+Adapted or vendored code
+------------------------
+
+As of this writing, Podex does not ship adapted third-party source that requires
+separate attribution beyond the dependency declarations above. If that changes,
+add a section here describing the origin and license of the adapted material.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ci): finish lint config scaffolding for lgtm-ci adoption
  ```

- Type:
  - [x] chore / ci / style
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds remaining org-standard lint/governance scaffolding (`.yamllint`, `.sqlfluff` + ignore, `.github/actionlint.yaml`, `THIRD_PARTY_NOTICES`) and documents that coverage is already satisfied by the existing `test-coverage` job in `test-ci.yml` (no separate `reusable-coverage` workflow). Completes the scaffolding/coverage child of epic #114.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #200
- Relates to #114

## Details

- Coverage decision: keep inline `reusable-test-python` coverage in `test-ci.yml`; `reusable-coverage` is for multi-artifact merge/Pages and is not needed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

