### PR TITLE
feat(docker): build and publish backend and frontend images to GHCR

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,194 @@
+---
+name: CI - Docker Build & Publish
+# Builds and publishes the backend + frontend container images to GHCR via
+# the lgtm-ci reusable-docker workflow.
+#   - pull_request / push to main / merge_group: build only (push=false)
+#     using validate-on-pr for native per-arch validation.
+#   - push to tag v*.*.*:            publish semver + latest tags to
+#     ghcr.io/lgtm-hq/podex-backend and podex-frontend, cosign-signed,
+#     with SBOM + provenance attestations.
+#
+# There is no release: trigger — release-auto-tag.yml already creates the
+# GitHub Release from the tag, so a release trigger would rebuild the same
+# image a second time.
+
+"on":
+  push:
+    branches: [main]
+    tags: ['v*.*.*']
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+  workflow_dispatch:
+
+permissions: {}
+
+# Cancel superseded PR validate runs; never cancel main/tag publishes (a
+# cancelled publish leaves GHCR tags / signatures in a partial state).
+concurrency:
+  group: docker-ci-${{ github.ref }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Org ruleset (checks-podex): suggested add — docker-backend / 🐳 Backend Image
+  backend:
+    name: 🐳 Backend Image
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@0b8069a00cbda26514e00b8a551bad8e754d38d7  # v0.58.0
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+    with:
+      tooling-ref: '0b8069a00cbda26514e00b8a551bad8e754d38d7'  # v0.58.0
+      context: backend
+      file: backend/Dockerfile
+      image-name: lgtm-hq/podex-backend
+      # docker/metadata-action's `type=semver,pattern={{version}}` accepts the
+      # `v`-prefixed tag verbatim and emits bare-semver tags (e.g. 1.2.3,
+      # 1.2, 1) — no client-side strip needed. GitHub Actions expressions
+      # have no substring() function.
+      version: >-
+        ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+      push: >-
+        ${{ github.event_name != 'pull_request'
+        && github.event_name != 'merge_group'
+        && startsWith(github.ref, 'refs/tags/v') }}
+      validate-on-pr: >-
+        ${{ github.event_name == 'pull_request'
+        || github.event_name == 'merge_group' }}
+      # amd64 only for PR speed; publish multi-arch on tags.
+      platforms: >-
+        ${{ startsWith(github.ref, 'refs/tags/v')
+        && 'linux/amd64,linux/arm64'
+        || 'linux/amd64' }}
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      tag-latest: true
+      scan: true
+      # Advisory-only on non-tag; fail the tag publish on CRITICAL/HIGH.
+      scan-exit-code: >-
+        ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '0' }}
+      cosign-sign: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      cache-registry-ref: ghcr.io/lgtm-hq/podex-backend:cache
+      no-cache: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      # provenance/sbom generate manifest lists incompatible with the --load
+      # used during validate-on-pr; only emit on publish.
+      provenance: >-
+        ${{ github.event_name != 'pull_request'
+        && github.event_name != 'merge_group' }}
+      sbom: >-
+        ${{ github.event_name != 'pull_request'
+        && github.event_name != 'merge_group' }}
+      # harden-runner reads the raw workflow inputs (not resolved presets)
+      # BEFORE the allowlist resolver applies the docker preset, and since
+      # lgtm-ci v0.50.0 a caller-provided allowed-endpoints REPLACES the
+      # preset baseline. Full expanded list = docker preset defaults + trivy
+      # (get.trivy.dev; DB pulled from ghcr with mirror.gcr.io / ecr fallbacks)
+      # + sigstore hosts (cosign keyless signing on tag publish) + pypi hosts
+      # (uv sync in the builder stage resolves from pypi.org via the runner
+      # egress proxy under harden-runner).
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
+        docker.io:443
+        registry-1.docker.io:443
+        auth.docker.io:443
+        production.cloudflare.docker.com:443
+        production.cloudfront.docker.com:443
+        gcr.io:443
+        mirror.gcr.io:443
+        public.ecr.aws:443
+        get.trivy.dev:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        timestamp.sigstore.dev:443
+        pypi.org:443
+        files.pythonhosted.org:443
+
+  # Org ruleset (checks-podex): suggested add — docker-frontend / 🎨 Frontend
+  frontend:
+    name: 🎨 Frontend Image
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@0b8069a00cbda26514e00b8a551bad8e754d38d7  # v0.58.0
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+    with:
+      tooling-ref: '0b8069a00cbda26514e00b8a551bad8e754d38d7'  # v0.58.0
+      context: frontend
+      file: frontend/Dockerfile
+      image-name: lgtm-hq/podex-frontend
+      # See backend job comment — metadata-action strips the leading `v`.
+      version: >-
+        ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+      push: >-
+        ${{ github.event_name != 'pull_request'
+        && github.event_name != 'merge_group'
+        && startsWith(github.ref, 'refs/tags/v') }}
+      validate-on-pr: >-
+        ${{ github.event_name == 'pull_request'
+        || github.event_name == 'merge_group' }}
+      platforms: >-
+        ${{ startsWith(github.ref, 'refs/tags/v')
+        && 'linux/amd64,linux/arm64'
+        || 'linux/amd64' }}
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      tag-latest: true
+      scan: true
+      scan-exit-code: >-
+        ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '0' }}
+      cosign-sign: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      cache-registry-ref: ghcr.io/lgtm-hq/podex-frontend:cache
+      no-cache: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      provenance: >-
+        ${{ github.event_name != 'pull_request'
+        && github.event_name != 'merge_group' }}
+      sbom: >-
+        ${{ github.event_name != 'pull_request'
+        && github.event_name != 'merge_group' }}
+      # Same rationale as `backend.allowed-endpoints`. Frontend adds
+      # registry.npmjs.org (transitive npm packages resolved by
+      # `bun install`, which reaches out to the npm registry on cold cache).
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
+        docker.io:443
+        registry-1.docker.io:443
+        auth.docker.io:443
+        production.cloudflare.docker.com:443
+        production.cloudfront.docker.com:443
+        gcr.io:443
+        mirror.gcr.io:443
+        public.ecr.aws:443
+        get.trivy.dev:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        timestamp.sigstore.dev:443
+        registry.npmjs.org:443

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,55 @@
+---
+name: Maintenance - GHCR Registry Cleanup
+# Weekly untagged / build-cache image pruning for the two GHCR packages
+# published by docker-ci.yml (podex-backend, podex-frontend). Uses the
+# lgtm-ci reusable-ghcr-cleanup workflow; tagged retention is left to the
+# reusable's defaults (untagged only) — mirroring winnow, not Rustume, since
+# Podex does not (yet) publish a `main`/`sha-<commit>` fleet worth tag-aged
+# pruning.
+
+"on":
+  schedule:
+    # Mondays 03:00 UTC — same slot as Rustume to keep org-wide ops
+    # observability aligned.
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Dry run (log only, no deletions)
+        required: false
+        default: false
+        type: boolean
+      min_age_days:
+        description: Minimum age in days before deleting untagged images
+        required: false
+        default: 7
+        type: number
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: 🧹 Prune ${{ matrix.package }}
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [podex-backend, podex-frontend]
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@0b8069a00cbda26514e00b8a551bad8e754d38d7  # v0.58.0
+    permissions:
+      contents: read
+      packages: write
+    with:
+      package-name: ${{ matrix.package }}
+      min-age-days: ${{ inputs.min_age_days || 7 }}
+      dry-run: ${{ inputs.dry_run == true }}
+      tooling-ref: '0b8069a00cbda26514e00b8a551bad8e754d38d7'  # v0.58.0
+      egress-policy: block
+      egress-preset: github-tooling
+      runner-image: ubuntu-24.04
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,23 @@
+---
+# Hadolint configuration for Podex Dockerfiles
+# https://github.com/hadolint/hadolint
+#
+# Mirrors the org-standard config from lgtm-hq/Rustume: only trusted registries
+# are allowed for `FROM ...`, and DL3018 is ignored because our base images
+# (python:*-slim-bookworm, node:*-bookworm-slim, oven/bun:*) are Debian-based
+# and use `apt-get` when needed — but we also want the same file to remain
+# valid if a future stage swaps in an Alpine base (e.g. static-tool copies
+# from an alpine-based helper image), where Alpine's per-release package
+# versions make apk pinning impractical.
+
+trustedRegistries:
+  - docker.io
+  - gcr.io
+  - ghcr.io
+
+ignored:
+  # DL3018: Pin versions in `apk add`. Alpine ships one version of each
+  # package per release; pinning breaks whenever Renovate bumps a base
+  # image digest to a newer Alpine minor. The base image itself is already
+  # pinned by digest, which effectively pins the available packages.
+  - DL3018

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,30 @@
+# Never send the pre-built venv, caches, or local DBs to the daemon.
+.venv/
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# Local SQLite artefacts (alembic + app run in this dir by default; see
+# AGENTS.md — `podex.db` lives here at `sqlite:///./podex.db`).
+podex.db
+podex.db-*
+*.sqlite
+*.sqlite3
+
+# Editor / OS noise.
+.env
+.env.*
+.DS_Store
+
+# Tests + tooling don't belong in the production image.
+tests/
+.lintro-config.yaml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,84 @@
+# syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
+
+# =============================================================================
+# Podex backend — production image
+# -----------------------------------------------------------------------------
+# Multi-stage uv-based build. Stage 1 assembles the frozen virtualenv from
+# uv.lock (no dev group, no editable install of first-party sources); stage 2
+# copies just the resolved venv + application source onto a slim runtime.
+#
+# Base images are tag+digest pinned so Renovate can update both together
+# (matches org convention). Build context is `backend/` (see docker-ci.yml).
+# Migrations are NOT run at build or start time — operators run
+# `alembic upgrade head` out-of-band before rolling the new image.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Stage 1: builder — resolve dependencies with uv into /app/.venv
+# -----------------------------------------------------------------------------
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b AS builder
+
+# Copy the uv static binaries in from the official uv image (no apt install).
+# hadolint ignore=DL3022
+COPY --from=ghcr.io/astral-sh/uv:0.11.29@sha256:eb2843a1e56fd9e30c7276ce1a52cba86e64c7b385f5e3279a0e08e02dd058fc /uv /uvx /usr/local/bin/
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/app/.venv \
+    UV_PYTHON_DOWNLOADS=never \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install project dependencies first (cache-friendly): the layer only busts
+# when pyproject.toml / uv.lock change. `--no-install-project` skips the
+# first-party package so app source changes don't invalidate this layer.
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
+
+# Copy the application source and install the project itself (non-editable so
+# the runtime does not need the source tree to import `podex`; we still copy
+# `src/podex` and `alembic/` below so operators can invoke alembic via
+# `docker exec` if they want to).
+COPY src ./src
+COPY alembic.ini ./
+COPY alembic ./alembic
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable
+
+# -----------------------------------------------------------------------------
+# Stage 2: runtime — slim Python + non-root user, no build tooling
+# -----------------------------------------------------------------------------
+FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:${PATH}" \
+    PODEX_DATABASE_URL="sqlite:///./podex.db"
+
+# Non-root system user for the app. `--no-log-init` avoids a 32 GiB sparse
+# lastlog file on some base images (well-documented useradd quirk).
+# /app is chowned so the sqlite fallback (`sqlite:///./podex.db`) and any
+# other cwd-relative writes work when the container runs as `podex`.
+RUN groupadd --system --gid 1001 podex \
+    && useradd --system --uid 1001 --gid podex --home-dir /app --no-log-init --shell /usr/sbin/nologin podex \
+    && install -d -o podex -g podex /app
+
+WORKDIR /app
+
+# Copy the resolved venv and runtime code from the builder. Ownership is set
+# at copy time so we don't need a follow-up recursive chown layer.
+COPY --from=builder --chown=podex:podex /app/.venv /app/.venv
+COPY --from=builder --chown=podex:podex /app/alembic.ini /app/alembic.ini
+COPY --from=builder --chown=podex:podex /app/alembic /app/alembic
+COPY --from=builder --chown=podex:podex /app/src /app/src
+
+USER podex
+
+EXPOSE 8000
+
+# Uvicorn from the resolved venv (PATH-first). Migrations are intentionally
+# NOT invoked here — see file header.
+CMD ["uvicorn", "podex.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,18 @@
+# Never send local node_modules or build output — the builder stage produces
+# them cleanly from bun.lock / astro build.
+node_modules/
+dist/
+.astro/
+
+# Test + coverage artefacts.
+coverage/
+.vitest/
+
+# Environment / editor / OS noise.
+.env
+.env.*
+.DS_Store
+
+# The generated OpenAPI client typings are checked into git; keep the raw
+# schema out of the image (it's only used by the codegen script).
+openapi.json

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
+
+# =============================================================================
+# Podex frontend — production image
+# -----------------------------------------------------------------------------
+# Multi-stage build:
+#   Stage 1 (bun): install locked deps and produce the Astro Node standalone
+#                  bundle (`dist/server/entry.mjs`).
+#   Stage 2 (node): slim runtime that serves the built bundle as the built-in
+#                   `node` user.
+#
+# `PUBLIC_API_URL` is baked in at build time (Astro/Vite `PUBLIC_*` vars are
+# statically inlined into the client bundle during `astro build`). Compose /
+# k8s override at build time via `--build-arg PUBLIC_API_URL=...`; the runtime
+# fallback below is only for `docker run` sanity.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Stage 1: builder — bun install + astro build
+# -----------------------------------------------------------------------------
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS builder
+
+WORKDIR /app
+
+# Install dependencies first for cache reuse. Renovate keeps bun.lock in sync
+# with package.json; --frozen-lockfile fails the build if they diverge.
+COPY package.json bun.lock ./
+RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \
+    bun install --frozen-lockfile
+
+# Baked-in public API URL. Overridden per-environment at build time. The
+# default targets a same-host backend so `docker run` still starts cleanly
+# for smoke tests.
+ARG PUBLIC_API_URL="http://localhost:8000/api/v2"
+ENV PUBLIC_API_URL=${PUBLIC_API_URL} \
+    NODE_ENV=production
+
+COPY . .
+
+# `bun run build` == `astro check && astro build`, which emits the node
+# standalone server bundle at dist/server/entry.mjs.
+RUN bun run build
+
+# -----------------------------------------------------------------------------
+# Stage 2: runtime — slim Node LTS, non-root
+# -----------------------------------------------------------------------------
+FROM node:22.20.0-bookworm-slim@sha256:b21fe589dfbe5cc39365d0544b9be3f1f33f55f3c86c87a76ff65a02f8f5848e AS runtime
+
+WORKDIR /app
+
+ENV HOST=0.0.0.0 \
+    PORT=4321 \
+    NODE_ENV=production
+
+# `node:*-slim` ships a UID 1000 `node` user out of the box; use it directly.
+# Copy the built bundle and node_modules the adapter needs at runtime.
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/package.json ./package.json
+
+USER node
+
+EXPOSE 4321
+
+CMD ["node", "./dist/server/entry.mjs"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(docker): build and publish backend and frontend images to GHCR
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds production Dockerfiles for backend and frontend, hadolint config, `docker-ci.yml` (build on PR/main; publish multi-arch to GHCR on `v*` tags), and weekly GHCR cleanup for both packages. Completes the Docker/GHCR slice of epic #114.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #198
- Relates to #114
- Relates to #21

## Details

- Images: `ghcr.io/lgtm-hq/podex-backend`, `ghcr.io/lgtm-hq/podex-frontend`
- Job names for a future ruleset update: `docker-backend / 🐳 Backend Image`, `docker-frontend / 🎨 Frontend Image`
- Pin: lgtm-ci `0b8069a` (v0.58.0)
- Note: may overlap Dockerfiles with staging PR #203; this PR is the canonical production image path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

