### PR TITLE
fix(ci): grant contents: write to sbom caller job

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -29,8 +29,11 @@ jobs:
       egress-policy: block
       egress-preset: sbom
     permissions:
-      # read: checkout repository for Syft scan
-      contents: read
+      # write: reusable-sbom declares if-gated release-asset jobs with
+      # contents: write; GitHub validates every called job's permissions at
+      # startup regardless of if-conditions, so the caller must grant write
+      # even though report mode only reads (matches turbo-themes caller).
+      contents: write
       # write: upload Grype SARIF findings when upload-sarif is enabled
       security-events: write
       # write: OIDC token for SBOM attestation signing (create-attestation)


### PR DESCRIPTION
## What's Changing

`Security - SBOM Generation` ends in `startup_failure` on every push to `main` (run 29637534935): the caller job grants `contents: read`, but `reusable-sbom.yml` declares `if`-gated release-asset jobs with `contents: write`, and GitHub validates every called job's permissions at workflow startup regardless of `if` conditions.

Raise the caller grant to `contents: write`, matching the org-standard caller in `lgtm-hq/turbo-themes/.github/workflows/security-sbom.yml`. The elevated grant is only exercised by the release-asset jobs, which remain disabled (`mode: report`, no `upload-release-assets`).

## Verification

- `uv run lintro chk` — 0 issues
- Reference caller in turbo-themes runs green with the identical permission set

## Closes

- Fixes #209