### PR TITLE
feat(api): standardize v2 pagination, error envelope, and public IDs

### DIFF
--- a/backend/src/podex/api/deps.py
+++ b/backend/src/podex/api/deps.py
@@ -1,11 +1,48 @@
-"""Shared FastAPI dependencies for the API layer."""
+"""Shared FastAPI dependencies for the API layer.
 
-from typing import Annotated
+Route handlers pull their collaborators from this module rather than
+constructing them ad-hoc, so wiring choices (session lifetime, settings
+resolution, pagination parsing) stay in one place. Every declared alias
+returns a fully-typed :class:`typing.Annotated` value so route signatures
+remain concise while ``mypy --strict`` can still infer the injected type.
+"""
 
-from fastapi import Depends
+from __future__ import annotations
+
+from typing import Annotated, cast
+
+from fastapi import Depends, Request
 from sqlalchemy.orm import Session
 
+from podex.api.v2.schemas import PaginationParams, pagination_params
+from podex.config import Settings, get_settings
 from podex.database import get_db
 
 DbSession = Annotated[Session, Depends(get_db)]
 """A request-scoped database session injected into route handlers."""
+
+
+def get_app_settings(request: Request) -> Settings:
+    """Return the :class:`Settings` stored on ``app.state`` by ``create_app``.
+
+    Falling back to :func:`podex.config.get_settings` keeps ad-hoc test apps
+    working when they construct a FastAPI instance without going through
+    ``create_app``.
+
+    Args:
+        request: The active request, used to reach ``request.app.state``.
+
+    Returns:
+        The application's resolved :class:`Settings` instance.
+    """
+    state_settings = getattr(request.app.state, "settings", None)
+    if isinstance(state_settings, Settings):
+        return state_settings
+    return cast("Settings", get_settings())
+
+
+SettingsDep = Annotated[Settings, Depends(get_app_settings)]
+"""The application settings resolved once per request from ``app.state``."""
+
+Pagination = Annotated[PaginationParams, Depends(pagination_params)]
+"""Shared ``limit``/``offset`` query parameter parsing for list endpoints."""

--- a/backend/src/podex/api/v2/episodes.py
+++ b/backend/src/podex/api/v2/episodes.py
@@ -1,9 +1,10 @@
 """Public read endpoints for podcast episodes."""
 
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import select
+from sqlalchemy import func, select
 
-from podex.api.deps import DbSession
+from podex.api.deps import DbSession, Pagination
+from podex.api.v2.schemas import Page
 from podex.models import Episode, Mention
 from podex.schemas.episode import EpisodeRead
 from podex.schemas.mention import MentionRead
@@ -11,12 +12,26 @@ from podex.schemas.mention import MentionRead
 router = APIRouter(prefix="/episodes", tags=["episodes"])
 
 
-def list_episodes(db: DbSession, podcast_id: int | None = None) -> list[Episode]:
-    """List episodes, optionally filtered by podcast."""
+def list_episodes(
+    db: DbSession,
+    pagination: Pagination,
+    podcast_id: int | None = None,
+) -> Page[EpisodeRead]:
+    """List episodes, optionally filtered by podcast, paginated."""
+    count_stmt = select(func.count()).select_from(Episode)
     statement = select(Episode).order_by(Episode.published_at.desc())
     if podcast_id is not None:
+        count_stmt = count_stmt.where(Episode.podcast_id == podcast_id)
         statement = statement.where(Episode.podcast_id == podcast_id)
-    return list(db.execute(statement).scalars().all())
+    total = int(db.execute(count_stmt).scalar_one())
+    statement = statement.offset(pagination.offset).limit(pagination.limit)
+    rows = list(db.execute(statement).scalars().all())
+    return Page[EpisodeRead](
+        items=[EpisodeRead.model_validate(row) for row in rows],
+        total=total,
+        limit=pagination.limit,
+        offset=pagination.offset,
+    )
 
 
 def get_episode(episode_id: int, db: DbSession) -> Episode:
@@ -27,29 +42,48 @@ def get_episode(episode_id: int, db: DbSession) -> Episode:
     return episode
 
 
-def list_episode_mentions(episode_id: int, db: DbSession) -> list[Mention]:
-    """List media mentions within an episode, ordered by timestamp."""
+def list_episode_mentions(
+    episode_id: int,
+    db: DbSession,
+    pagination: Pagination,
+) -> Page[MentionRead]:
+    """List media mentions within an episode, ordered by timestamp, paginated."""
     if db.get(Episode, episode_id) is None:
         raise HTTPException(status_code=404, detail="Episode not found")
+    total = int(
+        db.execute(
+            select(func.count())
+            .select_from(Mention)
+            .where(Mention.episode_id == episode_id),
+        ).scalar_one(),
+    )
     statement = (
         select(Mention)
         .where(Mention.episode_id == episode_id)
         .order_by(Mention.timestamp_seconds)
+        .offset(pagination.offset)
+        .limit(pagination.limit)
     )
-    return list(db.execute(statement).scalars().all())
+    rows = list(db.execute(statement).scalars().all())
+    return Page[MentionRead](
+        items=[MentionRead.model_validate(row) for row in rows],
+        total=total,
+        limit=pagination.limit,
+        offset=pagination.offset,
+    )
 
 
 router.add_api_route(
     "",
     list_episodes,
     methods=["GET"],
-    response_model=list[EpisodeRead],
+    response_model=Page[EpisodeRead],
 )
 router.add_api_route(
     "/{episode_id}/mentions",
     list_episode_mentions,
     methods=["GET"],
-    response_model=list[MentionRead],
+    response_model=Page[MentionRead],
 )
 router.add_api_route(
     "/{episode_id}",

--- a/backend/src/podex/api/v2/errors.py
+++ b/backend/src/podex/api/v2/errors.py
@@ -1,0 +1,181 @@
+"""Exception handlers that normalise ``/api/v2`` error bodies.
+
+The v2 surface returns a single error envelope shape (see
+:class:`podex.api.v2.schemas.ErrorResponse`) for every failure mode: 404 from
+missing resources, 422 from request validation, 429 from the rate limiter,
+and 500 from unhandled server errors. The handlers preserve the original
+status code and any response headers that FastAPI or middleware attached
+(``WWW-Authenticate``, ``Retry-After``, ``X-RateLimit-*``, ...) while
+replacing the body with the standardised envelope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from podex.api.v2.schemas import ErrorBody, ErrorDetail, ErrorResponse
+
+STATUS_CODE_TO_ERROR_CODE: dict[int, str] = {
+    status.HTTP_400_BAD_REQUEST: "bad_request",
+    status.HTTP_401_UNAUTHORIZED: "unauthorized",
+    status.HTTP_403_FORBIDDEN: "forbidden",
+    status.HTTP_404_NOT_FOUND: "not_found",
+    status.HTTP_405_METHOD_NOT_ALLOWED: "method_not_allowed",
+    status.HTTP_409_CONFLICT: "conflict",
+    status.HTTP_410_GONE: "gone",
+    status.HTTP_422_UNPROCESSABLE_CONTENT: "unprocessable_entity",
+    status.HTTP_429_TOO_MANY_REQUESTS: "rate_limited",
+    status.HTTP_500_INTERNAL_SERVER_ERROR: "internal_server_error",
+    status.HTTP_502_BAD_GATEWAY: "bad_gateway",
+    status.HTTP_503_SERVICE_UNAVAILABLE: "service_unavailable",
+    status.HTTP_504_GATEWAY_TIMEOUT: "gateway_timeout",
+}
+
+
+def error_code_for_status(status_code: int) -> str:
+    """Return the canonical error ``code`` string for an HTTP status code.
+
+    Args:
+        status_code: The response status code being reported.
+
+    Returns:
+        The registered code, or a generic ``"http_<code>"`` fallback.
+    """
+    return STATUS_CODE_TO_ERROR_CODE.get(status_code, f"http_{status_code}")
+
+
+def _request_id(request: Request) -> str | None:
+    """Return the request id set by the request-context middleware, if any."""
+    return getattr(request.state, "request_id", None)
+
+
+def build_error_response(
+    *,
+    status_code: int,
+    message: str,
+    request: Request,
+    code: str | None = None,
+    details: list[ErrorDetail] | None = None,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    """Construct a :class:`JSONResponse` wrapping an :class:`ErrorResponse`.
+
+    Args:
+        status_code: The HTTP status to return.
+        message: The human-readable summary.
+        request: The active request (used to source the request id).
+        code: An override for the machine-readable code; defaults to the
+            canonical code for ``status_code``.
+        details: Optional per-field validation details.
+        headers: Optional response headers to preserve on the reply.
+
+    Returns:
+        A JSON response carrying the standard v2 error envelope.
+    """
+    payload = ErrorResponse(
+        error=ErrorBody(
+            code=code or error_code_for_status(status_code),
+            message=message,
+            request_id=_request_id(request),
+            details=details,
+        ),
+    )
+    return JSONResponse(
+        status_code=status_code,
+        content=payload.model_dump(exclude_none=True),
+        headers=headers,
+    )
+
+
+async def http_exception_handler(
+    request: Request,
+    exc: HTTPException,
+) -> JSONResponse:
+    """Wrap ``HTTPException.detail`` into the v2 error envelope."""
+    detail: Any = exc.detail
+    message: str
+    details: list[ErrorDetail] | None = None
+    code: str | None = None
+    if isinstance(detail, dict):
+        message = str(detail.get("message") or detail.get("detail") or "")
+        raw_code = detail.get("code")
+        if isinstance(raw_code, str):
+            code = raw_code
+        raw_details = detail.get("details")
+        if isinstance(raw_details, list):
+            details = [
+                ErrorDetail.model_validate(item)
+                for item in raw_details
+                if isinstance(item, dict)
+            ]
+    else:
+        message = str(detail) if detail is not None else ""
+    if not message:
+        message = error_code_for_status(exc.status_code).replace("_", " ")
+    return build_error_response(
+        status_code=exc.status_code,
+        message=message,
+        request=request,
+        code=code,
+        details=details,
+        headers=dict(exc.headers) if exc.headers else None,
+    )
+
+
+async def validation_exception_handler(
+    request: Request,
+    exc: RequestValidationError,
+) -> JSONResponse:
+    """Wrap ``RequestValidationError`` into the v2 error envelope."""
+    raw_errors = jsonable_encoder(exc.errors())
+    details: list[ErrorDetail] = []
+    for item in raw_errors:
+        if not isinstance(item, dict):
+            continue
+        loc_value = item.get("loc") or []
+        loc = [part for part in loc_value if isinstance(part, str | int)]
+        details.append(
+            ErrorDetail(
+                loc=loc,
+                msg=str(item.get("msg", "")),
+                type=str(item.get("type", "")),
+            ),
+        )
+    return build_error_response(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        message="Request validation failed.",
+        request=request,
+        details=details,
+    )
+
+
+async def unhandled_exception_handler(
+    request: Request,
+    exc: Exception,
+) -> JSONResponse:
+    """Return an opaque 500 envelope for otherwise unhandled exceptions."""
+    del exc
+    return build_error_response(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        message="Internal server error.",
+        request=request,
+    )
+
+
+def install_exception_handlers(app: FastAPI) -> None:
+    """Register the standardised exception handlers on ``app``.
+
+    Args:
+        app: The FastAPI application to configure.
+    """
+    app.add_exception_handler(HTTPException, http_exception_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(
+        RequestValidationError,
+        validation_exception_handler,  # type: ignore[arg-type]
+    )
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/backend/src/podex/api/v2/errors.py
+++ b/backend/src/podex/api/v2/errors.py
@@ -173,9 +173,15 @@ def install_exception_handlers(app: FastAPI) -> None:
     Args:
         app: The FastAPI application to configure.
     """
-    app.add_exception_handler(HTTPException, http_exception_handler)  # type: ignore[arg-type]
+    # Starlette's add_exception_handler is typed for a narrower handler
+    # signature than FastAPI actually accepts (it forwards FastAPI-typed
+    # exceptions/requests through unchanged). Suppress the resulting arg-type
+    # noise locally while also silencing the unused-ignore warning that the
+    # CI mypy image (which resolves fastapi/starlette to Any without runtime
+    # deps installed) would otherwise emit for the same lines.
+    app.add_exception_handler(HTTPException, http_exception_handler)  # type: ignore[arg-type, unused-ignore]
     app.add_exception_handler(
         RequestValidationError,
-        validation_exception_handler,  # type: ignore[arg-type]
+        validation_exception_handler,  # type: ignore[arg-type, unused-ignore]
     )
     app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/backend/src/podex/api/v2/identifiers.py
+++ b/backend/src/podex/api/v2/identifiers.py
@@ -1,0 +1,97 @@
+"""Opaque public identifier helpers for the v2 API.
+
+Integer primary keys stay internal to the database and ORM layer. The public
+API exposes prefixed, opaque identifiers (e.g. ``pod_ci``) alongside the
+numeric ids so that clients that treat identifiers as free-form tokens keep
+working when the internal identifier strategy changes.
+
+The encoding is intentionally simple and dependency-free: the integer is
+serialised as big-endian bytes and base32-encoded without padding, then
+concatenated with a short kind-specific prefix. It is *not* a cryptographic
+scheme — callers that need unpredictability should compose an HMAC on top.
+
+Example:
+
+    >>> encode("pod", 1)
+    'pod_ae'
+    >>> decode("pod", "pod_ae")
+    1
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+from typing import Final
+
+PODCAST_PREFIX: Final = "pod"
+EPISODE_PREFIX: Final = "epi"
+MEDIA_PREFIX: Final = "med"
+MENTION_PREFIX: Final = "men"
+
+_ALLOWED_PREFIX = re.compile(r"^[a-z][a-z0-9]{1,7}$")
+_ALLOWED_BODY = re.compile(r"^[a-z2-7]+$")
+
+
+def _validate_prefix(prefix: str) -> None:
+    """Raise ``ValueError`` when ``prefix`` is not a short lowercase token."""
+    if not _ALLOWED_PREFIX.match(prefix):
+        raise ValueError(
+            f"prefix must be 2-8 lowercase alphanumerics starting with a letter: "
+            f"{prefix!r}",
+        )
+
+
+def encode(prefix: str, value: int) -> str:
+    """Encode a non-negative integer id into a prefixed opaque token.
+
+    Args:
+        prefix: The short kind prefix (e.g. ``"pod"``).
+        value: The non-negative integer identifier to encode.
+
+    Returns:
+        The token ``"{prefix}_{body}"`` where ``body`` is the lowercase
+        unpadded base32 representation of ``value``'s big-endian bytes.
+
+    Raises:
+        ValueError: If ``prefix`` is not a short lowercase token or ``value``
+            is negative.
+    """
+    _validate_prefix(prefix)
+    if value < 0:
+        raise ValueError(f"value must be non-negative: {value!r}")
+    length = max(1, (value.bit_length() + 7) // 8)
+    body = base64.b32encode(value.to_bytes(length, "big")).decode("ascii")
+    return f"{prefix}_{body.rstrip('=').lower()}"
+
+
+def decode(prefix: str, token: str) -> int:
+    """Decode a prefixed opaque token back into its integer id.
+
+    Args:
+        prefix: The expected kind prefix; the token must start with
+            ``f"{prefix}_"``.
+        token: The opaque token to decode.
+
+    Returns:
+        The non-negative integer identifier originally passed to :func:`encode`.
+
+    Raises:
+        ValueError: If ``token`` is malformed, uses a different prefix, or
+            contains characters outside the base32 alphabet.
+    """
+    _validate_prefix(prefix)
+    expected_start = f"{prefix}_"
+    if not token.startswith(expected_start):
+        raise ValueError(
+            f"identifier does not start with {expected_start!r}: {token!r}",
+        )
+    body = token[len(expected_start) :]
+    if not body or not _ALLOWED_BODY.match(body):
+        raise ValueError(f"identifier body is not valid base32: {token!r}")
+    padding = "=" * ((-len(body)) % 8)
+    try:
+        raw = base64.b32decode(body.upper() + padding)
+    except (ValueError, base64.binascii.Error) as exc:  # type: ignore[attr-defined]
+        raise ValueError(f"identifier body is not valid base32: {token!r}") from exc
+    return int.from_bytes(raw, "big")

--- a/backend/src/podex/api/v2/media.py
+++ b/backend/src/podex/api/v2/media.py
@@ -1,9 +1,10 @@
 """Public read endpoints for canonical media items."""
 
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import select
+from sqlalchemy import func, select
 
-from podex.api.deps import DbSession
+from podex.api.deps import DbSession, Pagination
+from podex.api.v2.schemas import Page
 from podex.models import Media, MediaType, Mention
 from podex.schemas.media import MediaRead
 from podex.schemas.mention import MentionRead
@@ -11,12 +12,26 @@ from podex.schemas.mention import MentionRead
 router = APIRouter(prefix="/media", tags=["media"])
 
 
-def list_media(db: DbSession, media_type: MediaType | None = None) -> list[Media]:
-    """List media items, optionally filtered by type, ordered by title."""
+def list_media(
+    db: DbSession,
+    pagination: Pagination,
+    media_type: MediaType | None = None,
+) -> Page[MediaRead]:
+    """List media items, optionally filtered by type, paginated."""
+    count_stmt = select(func.count()).select_from(Media)
     statement = select(Media).order_by(Media.title)
     if media_type is not None:
+        count_stmt = count_stmt.where(Media.type == media_type)
         statement = statement.where(Media.type == media_type)
-    return list(db.execute(statement).scalars().all())
+    total = int(db.execute(count_stmt).scalar_one())
+    statement = statement.offset(pagination.offset).limit(pagination.limit)
+    rows = list(db.execute(statement).scalars().all())
+    return Page[MediaRead](
+        items=[MediaRead.model_validate(row) for row in rows],
+        total=total,
+        limit=pagination.limit,
+        offset=pagination.offset,
+    )
 
 
 def get_media(media_id: int, db: DbSession) -> Media:
@@ -27,27 +42,48 @@ def get_media(media_id: int, db: DbSession) -> Media:
     return media
 
 
-def list_media_mentions(media_id: int, db: DbSession) -> list[Mention]:
-    """List episode mentions of a media item."""
+def list_media_mentions(
+    media_id: int,
+    db: DbSession,
+    pagination: Pagination,
+) -> Page[MentionRead]:
+    """List episode mentions of a media item, paginated."""
     if db.get(Media, media_id) is None:
         raise HTTPException(status_code=404, detail="Media not found")
-    statement = (
-        select(Mention).where(Mention.media_id == media_id).order_by(Mention.episode_id)
+    total = int(
+        db.execute(
+            select(func.count())
+            .select_from(Mention)
+            .where(Mention.media_id == media_id),
+        ).scalar_one(),
     )
-    return list(db.execute(statement).scalars().all())
+    statement = (
+        select(Mention)
+        .where(Mention.media_id == media_id)
+        .order_by(Mention.episode_id)
+        .offset(pagination.offset)
+        .limit(pagination.limit)
+    )
+    rows = list(db.execute(statement).scalars().all())
+    return Page[MentionRead](
+        items=[MentionRead.model_validate(row) for row in rows],
+        total=total,
+        limit=pagination.limit,
+        offset=pagination.offset,
+    )
 
 
 router.add_api_route(
     "",
     list_media,
     methods=["GET"],
-    response_model=list[MediaRead],
+    response_model=Page[MediaRead],
 )
 router.add_api_route(
     "/{media_id}/mentions",
     list_media_mentions,
     methods=["GET"],
-    response_model=list[MentionRead],
+    response_model=Page[MentionRead],
 )
 router.add_api_route(
     "/{media_id}",

--- a/backend/src/podex/api/v2/podcasts.py
+++ b/backend/src/podex/api/v2/podcasts.py
@@ -1,19 +1,32 @@
 """Public read endpoints for podcast sources."""
 
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import select
+from sqlalchemy import func, select
 
-from podex.api.deps import DbSession
+from podex.api.deps import DbSession, Pagination
+from podex.api.v2.schemas import Page
 from podex.models import Podcast
 from podex.schemas.podcast import PodcastRead
 
 router = APIRouter(prefix="/podcasts", tags=["podcasts"])
 
 
-def list_podcasts(db: DbSession) -> list[Podcast]:
-    """List podcast sources ordered by name."""
-    result = db.execute(select(Podcast).order_by(Podcast.name))
-    return list(result.scalars().all())
+def list_podcasts(db: DbSession, pagination: Pagination) -> Page[PodcastRead]:
+    """List podcast sources ordered by name, paginated by ``limit``/``offset``."""
+    total = int(db.execute(select(func.count()).select_from(Podcast)).scalar_one())
+    statement = (
+        select(Podcast)
+        .order_by(Podcast.name)
+        .offset(pagination.offset)
+        .limit(pagination.limit)
+    )
+    rows = list(db.execute(statement).scalars().all())
+    return Page[PodcastRead](
+        items=[PodcastRead.model_validate(row) for row in rows],
+        total=total,
+        limit=pagination.limit,
+        offset=pagination.offset,
+    )
 
 
 def get_podcast(podcast_id: int, db: DbSession) -> Podcast:
@@ -28,7 +41,7 @@ router.add_api_route(
     "",
     list_podcasts,
     methods=["GET"],
-    response_model=list[PodcastRead],
+    response_model=Page[PodcastRead],
 )
 router.add_api_route(
     "/{podcast_id}",

--- a/backend/src/podex/api/v2/schemas.py
+++ b/backend/src/podex/api/v2/schemas.py
@@ -1,0 +1,134 @@
+"""Shared v2 API conventions: pagination inputs, page envelope, error envelope.
+
+Every list endpoint under ``/api/v2`` accepts the same ``limit``/``offset``
+query parameters (see :class:`PaginationParams`) and returns a
+:class:`Page` envelope so that clients can page uniformly and know the total
+count without an extra round-trip. Errors returned by the v2 surface are
+wrapped in :class:`ErrorResponse` with a machine-readable ``code`` and the
+request id, so callers can correlate failures with server logs.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Generic, TypeVar
+
+from fastapi import Query
+from pydantic import BaseModel, ConfigDict, Field
+
+DEFAULT_LIMIT: int = 50
+MAX_LIMIT: int = 200
+
+ItemT = TypeVar("ItemT")
+
+
+class PaginationParams(BaseModel):
+    """Normalised pagination inputs shared by every v2 list endpoint.
+
+    Attributes:
+        limit: Maximum number of items to return; clamped to
+            ``[1, MAX_LIMIT]``.
+        offset: Number of items to skip before returning results;
+            non-negative.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    limit: Annotated[
+        int,
+        Field(
+            ge=1,
+            le=MAX_LIMIT,
+            description="Maximum number of items to return.",
+        ),
+    ] = DEFAULT_LIMIT
+    offset: Annotated[
+        int,
+        Field(ge=0, description="Number of items to skip."),
+    ] = 0
+
+
+def pagination_params(
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=MAX_LIMIT,
+            description="Maximum number of items to return.",
+        ),
+    ] = DEFAULT_LIMIT,
+    offset: Annotated[
+        int,
+        Query(ge=0, description="Number of items to skip."),
+    ] = 0,
+) -> PaginationParams:
+    """FastAPI dependency that parses shared ``limit``/``offset`` query params.
+
+    Args:
+        limit: The requested page size, validated by FastAPI to be within
+            ``[1, MAX_LIMIT]``.
+        offset: The number of items to skip, validated to be non-negative.
+
+    Returns:
+        The parsed :class:`PaginationParams` instance.
+    """
+    return PaginationParams(limit=limit, offset=offset)
+
+
+class Page(BaseModel, Generic[ItemT]):
+    """A single page of results plus paging metadata.
+
+    Attributes:
+        items: The items belonging to this page, in the endpoint's natural
+            order.
+        total: The total number of items matching the query, ignoring
+            pagination.
+        limit: The ``limit`` that produced this page.
+        offset: The ``offset`` that produced this page.
+    """
+
+    items: list[ItemT]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
+class ErrorDetail(BaseModel):
+    """A single field-level validation problem.
+
+    Attributes:
+        loc: The path to the offending field within the request payload.
+        msg: A human-readable description of the problem.
+        type: The pydantic/FastAPI error type discriminator.
+    """
+
+    loc: list[str | int]
+    msg: str
+    type: str
+
+
+class ErrorBody(BaseModel):
+    """The ``error`` object embedded in an :class:`ErrorResponse`.
+
+    Attributes:
+        code: A stable, machine-readable error code (e.g. ``"not_found"``).
+        message: Human-readable summary safe to surface to end users.
+        request_id: The request id assigned by the request-context middleware,
+            for cross-referencing with server logs.
+        details: Optional field-level breakdown, populated for validation
+            failures.
+    """
+
+    code: str
+    message: str
+    request_id: str | None = None
+    details: list[ErrorDetail] | None = None
+
+
+class ErrorResponse(BaseModel):
+    """The uniform error envelope returned by ``/api/v2`` failures.
+
+    Attributes:
+        error: The :class:`ErrorBody` describing the failure.
+    """
+
+    error: ErrorBody

--- a/backend/src/podex/main.py
+++ b/backend/src/podex/main.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from podex.api.v2.errors import install_exception_handlers
 from podex.api.v2.router import api_v2_router
 from podex.config import Settings, get_settings
 from podex.logging_config import configure_logging
@@ -15,6 +16,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     resolved = settings or get_settings()
     configure_logging()
     app = FastAPI(title=resolved.app_name, debug=resolved.debug)
+    app.state.settings = resolved
+
+    install_exception_handlers(app)
 
     # Middleware is applied in reverse registration order (last added runs
     # outermost). Register the rate limiter and request-context logger first so

--- a/backend/src/podex/middleware.py
+++ b/backend/src/podex/middleware.py
@@ -9,10 +9,13 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
+from podex.api.v2.errors import error_code_for_status
+from podex.api.v2.schemas import ErrorBody, ErrorResponse
 from podex.logging_config import get_logger
 from podex.services.limiter import SlidingWindowRateLimiter
 
 REQUEST_ID_HEADER = "X-Request-ID"
+RATE_LIMIT_MESSAGE = "Rate limit exceeded. Try again later."
 
 _access_logger = get_logger("podex.access")
 
@@ -160,9 +163,17 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if not decision.allowed:
             retry_after = math.ceil(decision.retry_after)
             headers["Retry-After"] = str(retry_after)
+            request_id = getattr(request.state, "request_id", None)
+            envelope = ErrorResponse(
+                error=ErrorBody(
+                    code=error_code_for_status(429),
+                    message=RATE_LIMIT_MESSAGE,
+                    request_id=request_id,
+                ),
+            )
             return JSONResponse(
                 status_code=429,
-                content={"detail": "Rate limit exceeded. Try again later."},
+                content=envelope.model_dump(exclude_none=True),
                 headers=headers,
             )
 

--- a/backend/src/podex/schemas/episode.py
+++ b/backend/src/podex/schemas/episode.py
@@ -1,8 +1,11 @@
 """Episode API schemas."""
 
 from datetime import datetime
+from typing import cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
+
+from podex.api.v2.identifiers import EPISODE_PREFIX, PODCAST_PREFIX, encode
 
 
 class EpisodeRead(BaseModel):
@@ -16,3 +19,15 @@ class EpisodeRead(BaseModel):
     episode_number: int | None
     published_at: datetime | None
     created_at: datetime
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def public_id(self) -> str:
+        """The opaque, prefixed public identifier for this episode."""
+        return cast("str", encode(EPISODE_PREFIX, self.id))
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def podcast_public_id(self) -> str:
+        """The opaque public identifier of the owning podcast."""
+        return cast("str", encode(PODCAST_PREFIX, self.podcast_id))

--- a/backend/src/podex/schemas/media.py
+++ b/backend/src/podex/schemas/media.py
@@ -1,9 +1,11 @@
 """Media API schemas."""
 
 from datetime import datetime
+from typing import cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
 
+from podex.api.v2.identifiers import MEDIA_PREFIX, encode
 from podex.models.media import MediaType
 
 
@@ -20,3 +22,9 @@ class MediaRead(BaseModel):
     description: str | None
     cover_url: str | None
     created_at: datetime
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def public_id(self) -> str:
+        """The opaque, prefixed public identifier for this media item."""
+        return cast("str", encode(MEDIA_PREFIX, self.id))

--- a/backend/src/podex/schemas/mention.py
+++ b/backend/src/podex/schemas/mention.py
@@ -1,8 +1,16 @@
 """Mention API schemas."""
 
 from datetime import datetime
+from typing import cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
+
+from podex.api.v2.identifiers import (
+    EPISODE_PREFIX,
+    MEDIA_PREFIX,
+    MENTION_PREFIX,
+    encode,
+)
 
 
 class MentionRead(BaseModel):
@@ -17,3 +25,21 @@ class MentionRead(BaseModel):
     context: str | None
     confidence: float | None
     created_at: datetime
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def public_id(self) -> str:
+        """The opaque, prefixed public identifier for this mention."""
+        return cast("str", encode(MENTION_PREFIX, self.id))
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def episode_public_id(self) -> str:
+        """The opaque public identifier of the referenced episode."""
+        return cast("str", encode(EPISODE_PREFIX, self.episode_id))
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def media_public_id(self) -> str:
+        """The opaque public identifier of the referenced media item."""
+        return cast("str", encode(MEDIA_PREFIX, self.media_id))

--- a/backend/src/podex/schemas/podcast.py
+++ b/backend/src/podex/schemas/podcast.py
@@ -1,8 +1,11 @@
 """Podcast API schemas."""
 
 from datetime import datetime
+from typing import cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
+
+from podex.api.v2.identifiers import PODCAST_PREFIX, encode
 
 
 class PodcastRead(BaseModel):
@@ -15,3 +18,9 @@ class PodcastRead(BaseModel):
     slug: str
     description: str | None
     created_at: datetime
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def public_id(self) -> str:
+        """The opaque, prefixed public identifier for this podcast."""
+        return cast("str", encode(PODCAST_PREFIX, self.id))

--- a/backend/tests/test_api_smoke.py
+++ b/backend/tests/test_api_smoke.py
@@ -89,7 +89,8 @@ def test_podcast_resource_smoke(client: TestClient, db_session: Session) -> None
 
     listed = client.get("/api/v2/podcasts")
     assert_that(listed.status_code).is_equal_to(200)
-    assert_that([item["id"] for item in listed.json()]).contains(graph.podcast_id)
+    listed_items = listed.json()["items"]
+    assert_that([item["id"] for item in listed_items]).contains(graph.podcast_id)
 
     fetched = client.get(f"/api/v2/podcasts/{graph.podcast_id}")
     assert_that(fetched.status_code).is_equal_to(200)
@@ -105,11 +106,13 @@ def test_episode_resource_smoke(client: TestClient, db_session: Session) -> None
 
     listed = client.get("/api/v2/episodes")
     assert_that(listed.status_code).is_equal_to(200)
-    assert_that([item["id"] for item in listed.json()]).contains(graph.episode_id)
+    listed_items = listed.json()["items"]
+    assert_that([item["id"] for item in listed_items]).contains(graph.episode_id)
 
     filtered = client.get("/api/v2/episodes", params={"podcast_id": graph.podcast_id})
     assert_that(filtered.status_code).is_equal_to(200)
-    assert_that([item["id"] for item in filtered.json()]).is_equal_to(
+    filtered_items = filtered.json()["items"]
+    assert_that([item["id"] for item in filtered_items]).is_equal_to(
         [graph.episode_id],
     )
 
@@ -119,7 +122,8 @@ def test_episode_resource_smoke(client: TestClient, db_session: Session) -> None
 
     mentions = client.get(f"/api/v2/episodes/{graph.episode_id}/mentions")
     assert_that(mentions.status_code).is_equal_to(200)
-    assert_that([item["id"] for item in mentions.json()]).is_equal_to(
+    mention_items = mentions.json()["items"]
+    assert_that([item["id"] for item in mention_items]).is_equal_to(
         [graph.mention_id],
     )
 
@@ -133,15 +137,17 @@ def test_media_resource_smoke(client: TestClient, db_session: Session) -> None:
 
     listed = client.get("/api/v2/media")
     assert_that(listed.status_code).is_equal_to(200)
-    assert_that([item["id"] for item in listed.json()]).contains(graph.media_id)
+    listed_items = listed.json()["items"]
+    assert_that([item["id"] for item in listed_items]).contains(graph.media_id)
 
     filtered = client.get("/api/v2/media", params={"media_type": "book"})
     assert_that(filtered.status_code).is_equal_to(200)
-    assert_that([item["id"] for item in filtered.json()]).is_equal_to([graph.media_id])
+    filtered_items = filtered.json()["items"]
+    assert_that([item["id"] for item in filtered_items]).is_equal_to([graph.media_id])
 
     empty = client.get("/api/v2/media", params={"media_type": "movie"})
     assert_that(empty.status_code).is_equal_to(200)
-    assert_that(empty.json()).is_equal_to([])
+    assert_that(empty.json()["items"]).is_equal_to([])
 
     fetched = client.get(f"/api/v2/media/{graph.media_id}")
     assert_that(fetched.status_code).is_equal_to(200)
@@ -149,7 +155,8 @@ def test_media_resource_smoke(client: TestClient, db_session: Session) -> None:
 
     mentions = client.get(f"/api/v2/media/{graph.media_id}/mentions")
     assert_that(mentions.status_code).is_equal_to(200)
-    assert_that([item["id"] for item in mentions.json()]).is_equal_to(
+    mention_items = mentions.json()["items"]
+    assert_that([item["id"] for item in mention_items]).is_equal_to(
         [graph.mention_id],
     )
 
@@ -172,12 +179,12 @@ def test_full_graph_walk_via_http(client: TestClient, db_session: Session) -> No
     episodes = client.get(
         "/api/v2/episodes",
         params={"podcast_id": graph.podcast_id},
-    ).json()
+    ).json()["items"]
     assert_that(episodes).is_length(1)
     episode = episodes[0]
     assert_that(episode["podcast_id"]).is_equal_to(graph.podcast_id)
 
-    mentions = client.get(f"/api/v2/episodes/{episode['id']}/mentions").json()
+    mentions = client.get(f"/api/v2/episodes/{episode['id']}/mentions").json()["items"]
     assert_that(mentions).is_length(1)
     mention = mentions[0]
     assert_that(mention["episode_id"]).is_equal_to(episode["id"])
@@ -188,7 +195,7 @@ def test_full_graph_walk_via_http(client: TestClient, db_session: Session) -> No
     assert_that(media["id"]).is_equal_to(graph.media_id)
     assert_that(media["title"]).is_equal_to("Dune")
 
-    back_reference = client.get(f"/api/v2/media/{media['id']}/mentions").json()
+    back_reference = client.get(f"/api/v2/media/{media['id']}/mentions").json()["items"]
     assert_that([item["id"] for item in back_reference]).is_equal_to(
         [graph.mention_id],
     )

--- a/backend/tests/test_episodes.py
+++ b/backend/tests/test_episodes.py
@@ -32,11 +32,13 @@ def _seed_podcast(
 
 
 def test_list_episodes_empty(client: TestClient) -> None:
-    """An empty catalog returns an empty list."""
+    """An empty catalog returns an empty page envelope."""
     response = client.get("/api/v2/episodes")
 
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(response.json()).is_equal_to([])
+    body = response.json()
+    assert_that(body["items"]).is_equal_to([])
+    assert_that(body["total"]).is_equal_to(0)
 
 
 def test_list_and_get_episode(client: TestClient, db_session: Session) -> None:
@@ -48,10 +50,11 @@ def test_list_and_get_episode(client: TestClient, db_session: Session) -> None:
     listed = client.get("/api/v2/episodes")
     assert_that(listed.status_code).is_equal_to(200)
     body = listed.json()
-    assert_that(body).is_length(1)
-    assert_that(body[0]["title"]).is_equal_to("Pilot")
+    assert_that(body["items"]).is_length(1)
+    assert_that(body["items"][0]["title"]).is_equal_to("Pilot")
+    assert_that(body["items"][0]).contains_key("public_id", "podcast_public_id")
 
-    episode_id = body[0]["id"]
+    episode_id = body["items"][0]["id"]
     fetched = client.get(f"/api/v2/episodes/{episode_id}")
     assert_that(fetched.status_code).is_equal_to(200)
     assert_that(fetched.json()["title"]).is_equal_to("Pilot")
@@ -72,8 +75,9 @@ def test_list_episodes_filtered_by_podcast(
 
     assert_that(response.status_code).is_equal_to(200)
     body = response.json()
-    assert_that(body).is_length(1)
-    assert_that(body[0]["title"]).is_equal_to("A")
+    assert_that(body["items"]).is_length(1)
+    assert_that(body["items"][0]["title"]).is_equal_to("A")
+    assert_that(body["total"]).is_equal_to(1)
 
 
 def test_list_episodes_newest_first(client: TestClient, db_session: Session) -> None:
@@ -97,11 +101,15 @@ def test_list_episodes_newest_first(client: TestClient, db_session: Session) -> 
 
     body = client.get("/api/v2/episodes").json()
 
-    assert_that([episode["title"] for episode in body]).is_equal_to(["Newer", "Older"])
+    titles = [episode["title"] for episode in body["items"]]
+    assert_that(titles).is_equal_to(["Newer", "Older"])
 
 
 def test_get_episode_not_found(client: TestClient) -> None:
-    """An unknown episode id returns 404."""
+    """An unknown episode id returns the v2 error envelope."""
     response = client.get("/api/v2/episodes/999")
 
     assert_that(response.status_code).is_equal_to(404)
+    body = response.json()
+    assert_that(body["error"]["code"]).is_equal_to("not_found")
+    assert_that(body["error"]["message"]).is_equal_to("Episode not found")

--- a/backend/tests/test_error_envelope.py
+++ b/backend/tests/test_error_envelope.py
@@ -1,0 +1,110 @@
+"""Tests for the unified v2 error envelope."""
+
+import logging
+
+import pytest
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+
+from podex.api.v2.errors import (
+    STATUS_CODE_TO_ERROR_CODE,
+    error_code_for_status,
+)
+from podex.config import Settings
+from podex.main import create_app
+from podex.middleware import REQUEST_ID_HEADER
+
+
+def test_not_found_returns_error_envelope(client: TestClient) -> None:
+    """404 responses use the standard envelope with ``not_found`` code."""
+    response = client.get("/api/v2/podcasts/9999")
+
+    assert_that(response.status_code).is_equal_to(404)
+    body = response.json()
+    assert_that(body).contains_key("error")
+    error = body["error"]
+    assert_that(error["code"]).is_equal_to("not_found")
+    assert_that(error["message"]).is_equal_to("Podcast not found")
+    assert_that(error["request_id"]).is_equal_to(response.headers[REQUEST_ID_HEADER])
+
+
+def test_validation_error_returns_details(client: TestClient) -> None:
+    """422 responses include per-field details in the envelope."""
+    response = client.get("/api/v2/podcasts", params={"limit": 0})
+
+    assert_that(response.status_code).is_equal_to(422)
+    body = response.json()
+    assert_that(body["error"]["code"]).is_equal_to("unprocessable_entity")
+    assert_that(body["error"]["details"]).is_not_empty()
+    loc_paths = [tuple(item["loc"]) for item in body["error"]["details"]]
+    assert_that(loc_paths).contains(("query", "limit"))
+
+
+def test_unhandled_exception_returns_500_envelope(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unhandled route errors are wrapped in an opaque 500 envelope."""
+    app = create_app(Settings(rate_limit_enabled=False))
+
+    async def _boom() -> None:
+        """Route handler that always fails."""
+        raise RuntimeError("boom")
+
+    app.add_api_route("/boom", _boom, methods=["GET"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with caplog.at_level(logging.INFO, logger="podex.access"):
+            response = client.get("/boom", headers={REQUEST_ID_HEADER: "err-1"})
+
+    assert_that(response.status_code).is_equal_to(500)
+    body = response.json()
+    assert_that(body["error"]["code"]).is_equal_to("internal_server_error")
+    assert_that(body["error"]["message"]).is_equal_to("Internal server error.")
+    assert_that(body["error"]["request_id"]).is_equal_to("err-1")
+
+
+def test_error_code_for_status_uses_registered_map() -> None:
+    """The status-to-code map yields registered strings for known codes."""
+    for status_code, code in STATUS_CODE_TO_ERROR_CODE.items():
+        assert_that(error_code_for_status(status_code)).is_equal_to(code)
+
+
+def test_error_code_for_status_falls_back_to_generic() -> None:
+    """Unknown status codes get a stable ``http_<code>`` fallback."""
+    assert_that(error_code_for_status(418)).is_equal_to("http_418")
+
+
+def test_http_exception_with_structured_detail_preserves_code(
+    client: TestClient,
+) -> None:
+    """Structured ``HTTPException.detail`` dicts propagate ``code``/``details``."""
+    from fastapi import HTTPException
+
+    from podex.main import app as _base_app
+
+    del _base_app
+    app = create_app(Settings(rate_limit_enabled=False))
+
+    async def _custom() -> None:
+        """Raise a structured HTTPException to exercise the handler."""
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "custom_conflict",
+                "message": "already exists",
+                "details": [
+                    {"loc": ["body", "slug"], "msg": "duplicate", "type": "conflict"},
+                ],
+            },
+        )
+
+    app.add_api_route("/custom-conflict", _custom, methods=["GET"])
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/custom-conflict")
+
+    assert_that(response.status_code).is_equal_to(409)
+    error = response.json()["error"]
+    assert_that(error["code"]).is_equal_to("custom_conflict")
+    assert_that(error["message"]).is_equal_to("already exists")
+    assert_that(error["details"][0]["loc"]).is_equal_to(["body", "slug"])

--- a/backend/tests/test_identifiers.py
+++ b/backend/tests/test_identifiers.py
@@ -1,0 +1,74 @@
+"""Unit tests for the v2 opaque identifier helpers."""
+
+import pytest
+from assertpy import assert_that
+
+from podex.api.v2.identifiers import (
+    EPISODE_PREFIX,
+    MEDIA_PREFIX,
+    MENTION_PREFIX,
+    PODCAST_PREFIX,
+    decode,
+    encode,
+)
+
+
+@pytest.mark.parametrize("value", [0, 1, 2, 31, 32, 100, 1000, 123456789, 2**63])
+def test_encode_decode_round_trip(value: int) -> None:
+    """``decode(prefix, encode(prefix, n))`` returns the original integer."""
+    token = encode(PODCAST_PREFIX, value)
+
+    assert_that(token).starts_with(f"{PODCAST_PREFIX}_")
+    assert_that(decode(PODCAST_PREFIX, token)).is_equal_to(value)
+
+
+def test_encode_uses_short_lowercase_body() -> None:
+    """Encoded tokens use lowercase base32 without padding."""
+    token = encode(PODCAST_PREFIX, 42)
+
+    assert_that(token).matches(r"^pod_[a-z2-7]+$")
+
+
+def test_encode_rejects_negative() -> None:
+    """Negative integers cannot be encoded."""
+    assert_that(encode).raises(ValueError).when_called_with(PODCAST_PREFIX, -1)
+
+
+def test_encode_rejects_invalid_prefix() -> None:
+    """Prefixes must be short lowercase alphanumeric tokens."""
+    for bad in ("", "A", "12", "way_too_long_prefix", "PO"):
+        assert_that(encode).raises(ValueError).when_called_with(bad, 1)
+
+
+def test_decode_rejects_wrong_prefix() -> None:
+    """A token encoded for one prefix cannot be decoded under another."""
+    token = encode(PODCAST_PREFIX, 7)
+
+    assert_that(decode).raises(ValueError).when_called_with(EPISODE_PREFIX, token)
+
+
+def test_decode_rejects_missing_body() -> None:
+    """A token with an empty body is not accepted."""
+    assert_that(decode).raises(ValueError).when_called_with(
+        PODCAST_PREFIX,
+        "pod_",
+    )
+
+
+def test_decode_rejects_non_base32_characters() -> None:
+    """Uppercase or otherwise-invalid characters are rejected."""
+    assert_that(decode).raises(ValueError).when_called_with(
+        PODCAST_PREFIX,
+        "pod_AE",
+    )
+    assert_that(decode).raises(ValueError).when_called_with(
+        PODCAST_PREFIX,
+        "pod_9!",
+    )
+
+
+def test_prefixes_are_distinct() -> None:
+    """Every well-known prefix is unique so tokens never collide by mistake."""
+    prefixes = {PODCAST_PREFIX, EPISODE_PREFIX, MEDIA_PREFIX, MENTION_PREFIX}
+
+    assert_that(prefixes).is_length(4)

--- a/backend/tests/test_media.py
+++ b/backend/tests/test_media.py
@@ -8,11 +8,13 @@ from podex.models import Media, MediaType
 
 
 def test_list_media_empty(client: TestClient) -> None:
-    """An empty catalog returns an empty list."""
+    """An empty catalog returns an empty page envelope."""
     response = client.get("/api/v2/media")
 
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(response.json()).is_equal_to([])
+    body = response.json()
+    assert_that(body["items"]).is_equal_to([])
+    assert_that(body["total"]).is_equal_to(0)
 
 
 def test_list_and_get_media(client: TestClient, db_session: Session) -> None:
@@ -23,11 +25,12 @@ def test_list_and_get_media(client: TestClient, db_session: Session) -> None:
     listed = client.get("/api/v2/media")
     assert_that(listed.status_code).is_equal_to(200)
     body = listed.json()
-    assert_that(body).is_length(1)
-    assert_that(body[0]["type"]).is_equal_to("book")
-    assert_that(body[0]["title"]).is_equal_to("Dune")
+    assert_that(body["items"]).is_length(1)
+    assert_that(body["items"][0]["type"]).is_equal_to("book")
+    assert_that(body["items"][0]["title"]).is_equal_to("Dune")
+    assert_that(body["items"][0]).contains_key("public_id")
 
-    media_id = body[0]["id"]
+    media_id = body["items"][0]["id"]
     fetched = client.get(f"/api/v2/media/{media_id}")
     assert_that(fetched.status_code).is_equal_to(200)
     assert_that(fetched.json()["author"]).is_equal_to("Herbert")
@@ -43,12 +46,16 @@ def test_list_media_filtered_by_type(client: TestClient, db_session: Session) ->
 
     assert_that(response.status_code).is_equal_to(200)
     body = response.json()
-    assert_that(body).is_length(1)
-    assert_that(body[0]["title"]).is_equal_to("Arrival")
+    assert_that(body["items"]).is_length(1)
+    assert_that(body["items"][0]["title"]).is_equal_to("Arrival")
+    assert_that(body["total"]).is_equal_to(1)
 
 
 def test_get_media_not_found(client: TestClient) -> None:
-    """An unknown media id returns 404."""
+    """An unknown media id returns the v2 error envelope."""
     response = client.get("/api/v2/media/999")
 
     assert_that(response.status_code).is_equal_to(404)
+    body = response.json()
+    assert_that(body["error"]["code"]).is_equal_to("not_found")
+    assert_that(body["error"]["message"]).is_equal_to("Media not found")

--- a/backend/tests/test_mentions.py
+++ b/backend/tests/test_mentions.py
@@ -37,32 +37,38 @@ def _seed_mention(db: Session) -> Mention:
 
 
 def test_episode_mentions(client: TestClient, db_session: Session) -> None:
-    """An episode's mentions are listed."""
+    """An episode's mentions are listed inside a page envelope."""
     mention = _seed_mention(db_session)
 
     response = client.get(f"/api/v2/episodes/{mention.episode_id}/mentions")
 
     assert_that(response.status_code).is_equal_to(200)
     body = response.json()
-    assert_that(body).is_length(1)
-    assert_that(body[0]["media_id"]).is_equal_to(mention.media_id)
-    assert_that(body[0]["timestamp_seconds"]).is_equal_to(42)
+    assert_that(body["items"]).is_length(1)
+    assert_that(body["items"][0]["media_id"]).is_equal_to(mention.media_id)
+    assert_that(body["items"][0]["timestamp_seconds"]).is_equal_to(42)
+    assert_that(body["items"][0]).contains_key(
+        "public_id",
+        "media_public_id",
+        "episode_public_id",
+    )
+    assert_that(body["total"]).is_equal_to(1)
 
 
 def test_media_mentions(client: TestClient, db_session: Session) -> None:
-    """A media item's mentions are listed."""
+    """A media item's mentions are listed inside a page envelope."""
     mention = _seed_mention(db_session)
 
     response = client.get(f"/api/v2/media/{mention.media_id}/mentions")
 
     assert_that(response.status_code).is_equal_to(200)
     body = response.json()
-    assert_that(body).is_length(1)
-    assert_that(body[0]["episode_id"]).is_equal_to(mention.episode_id)
+    assert_that(body["items"]).is_length(1)
+    assert_that(body["items"][0]["episode_id"]).is_equal_to(mention.episode_id)
 
 
 def test_episode_mentions_empty(client: TestClient, db_session: Session) -> None:
-    """An episode with no mentions returns an empty list."""
+    """An episode with no mentions returns an empty page envelope."""
     podcast = Podcast(name="The Show", slug="the-show")
     db_session.add(podcast)
     db_session.commit()
@@ -73,18 +79,22 @@ def test_episode_mentions_empty(client: TestClient, db_session: Session) -> None
     response = client.get(f"/api/v2/episodes/{episode.id}/mentions")
 
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(response.json()).is_equal_to([])
+    body = response.json()
+    assert_that(body["items"]).is_equal_to([])
+    assert_that(body["total"]).is_equal_to(0)
 
 
 def test_episode_mentions_not_found(client: TestClient) -> None:
-    """Mentions for an unknown episode return 404."""
+    """Mentions for an unknown episode return a 404 envelope."""
     response = client.get("/api/v2/episodes/999/mentions")
 
     assert_that(response.status_code).is_equal_to(404)
+    assert_that(response.json()["error"]["code"]).is_equal_to("not_found")
 
 
 def test_media_mentions_not_found(client: TestClient) -> None:
-    """Mentions for an unknown media item return 404."""
+    """Mentions for an unknown media item return a 404 envelope."""
     response = client.get("/api/v2/media/999/mentions")
 
     assert_that(response.status_code).is_equal_to(404)
+    assert_that(response.json()["error"]["code"]).is_equal_to("not_found")

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -81,7 +81,12 @@ def test_blocks_requests_over_limit_with_429(tight_client: TestClient) -> None:
     assert_that(blocked.status_code).is_equal_to(429)
     assert_that(blocked.headers).contains_key("Retry-After")
     assert_that(blocked.headers["X-RateLimit-Remaining"]).is_equal_to("0")
-    assert_that(blocked.json()["detail"]).contains("Rate limit")
+    body = blocked.json()
+    assert_that(body["error"]["code"]).is_equal_to("rate_limited")
+    assert_that(body["error"]["message"]).contains("Rate limit")
+    assert_that(body["error"]["request_id"]).is_equal_to(
+        blocked.headers[REQUEST_ID_HEADER],
+    )
     assert_that(blocked.headers).contains_key(REQUEST_ID_HEADER)
 
 

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -1,0 +1,136 @@
+"""Tests for the shared v2 pagination convention."""
+
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.api.v2.schemas import DEFAULT_LIMIT, MAX_LIMIT
+from podex.models import Episode, Media, MediaType, Mention, Podcast
+
+
+def _seed_podcasts(db: Session, count: int) -> None:
+    """Insert ``count`` podcast rows with predictable, sortable names.
+
+    Args:
+        db: Active database session.
+        count: Number of podcast rows to insert.
+    """
+    for index in range(count):
+        db.add(Podcast(name=f"Show {index:03d}", slug=f"show-{index:03d}"))
+    db.commit()
+
+
+def test_default_pagination_returns_default_limit(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Without query params, list endpoints use the default limit."""
+    _seed_podcasts(db_session, count=DEFAULT_LIMIT + 5)
+
+    response = client.get("/api/v2/podcasts")
+
+    assert_that(response.status_code).is_equal_to(200)
+    body = response.json()
+    assert_that(body["items"]).is_length(DEFAULT_LIMIT)
+    assert_that(body["total"]).is_equal_to(DEFAULT_LIMIT + 5)
+    assert_that(body["limit"]).is_equal_to(DEFAULT_LIMIT)
+    assert_that(body["offset"]).is_equal_to(0)
+
+
+def test_pagination_offset_slices_results(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """The ``offset`` parameter skips the requested number of items."""
+    _seed_podcasts(db_session, count=5)
+
+    first = client.get("/api/v2/podcasts", params={"limit": 2, "offset": 0}).json()
+    second = client.get("/api/v2/podcasts", params={"limit": 2, "offset": 2}).json()
+
+    first_ids = [item["id"] for item in first["items"]]
+    second_ids = [item["id"] for item in second["items"]]
+    assert_that(first_ids).is_length(2)
+    assert_that(second_ids).is_length(2)
+    assert_that(set(first_ids).intersection(second_ids)).is_empty()
+    assert_that(first["total"]).is_equal_to(5)
+    assert_that(first["limit"]).is_equal_to(2)
+    assert_that(second["offset"]).is_equal_to(2)
+
+
+def test_pagination_rejects_out_of_range_limit(client: TestClient) -> None:
+    """A ``limit`` above the maximum yields a validation-error envelope."""
+    response = client.get("/api/v2/podcasts", params={"limit": MAX_LIMIT + 1})
+
+    assert_that(response.status_code).is_equal_to(422)
+    body = response.json()
+    assert_that(body["error"]["code"]).is_equal_to("unprocessable_entity")
+    loc_paths = [tuple(item["loc"]) for item in body["error"]["details"]]
+    assert_that(loc_paths).contains(("query", "limit"))
+
+
+def test_pagination_rejects_negative_offset(client: TestClient) -> None:
+    """A negative ``offset`` yields a validation-error envelope."""
+    response = client.get("/api/v2/podcasts", params={"offset": -1})
+
+    assert_that(response.status_code).is_equal_to(422)
+    body = response.json()
+    assert_that(body["error"]["code"]).is_equal_to("unprocessable_entity")
+
+
+def test_pagination_applies_to_episode_and_media_lists(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """The shared pagination shape is honoured across every list endpoint."""
+    podcast = Podcast(name="Show", slug="show")
+    db_session.add(podcast)
+    db_session.commit()
+    for index in range(3):
+        db_session.add(Episode(podcast_id=podcast.id, title=f"Ep {index}"))
+    for index in range(3):
+        db_session.add(Media(type=MediaType.BOOK, title=f"Book {index}"))
+    db_session.commit()
+
+    episodes = client.get("/api/v2/episodes", params={"limit": 2}).json()
+    media = client.get("/api/v2/media", params={"limit": 2}).json()
+
+    assert_that(episodes["items"]).is_length(2)
+    assert_that(episodes["total"]).is_equal_to(3)
+    assert_that(episodes["limit"]).is_equal_to(2)
+    assert_that(media["items"]).is_length(2)
+    assert_that(media["total"]).is_equal_to(3)
+    assert_that(media["limit"]).is_equal_to(2)
+
+
+def test_pagination_applies_to_mention_lists(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Nested mention lists share the same pagination envelope."""
+    podcast = Podcast(name="Show", slug="show")
+    db_session.add(podcast)
+    db_session.commit()
+    episode = Episode(podcast_id=podcast.id, title="Pilot")
+    media = Media(type=MediaType.BOOK, title="Dune")
+    db_session.add_all([episode, media])
+    db_session.commit()
+    for index in range(4):
+        db_session.add(
+            Mention(
+                episode_id=episode.id,
+                media_id=media.id,
+                timestamp_seconds=index,
+            ),
+        )
+    db_session.commit()
+
+    response = client.get(
+        f"/api/v2/episodes/{episode.id}/mentions",
+        params={"limit": 2, "offset": 1},
+    )
+
+    assert_that(response.status_code).is_equal_to(200)
+    body = response.json()
+    assert_that(body["items"]).is_length(2)
+    assert_that(body["total"]).is_equal_to(4)
+    assert_that(body["offset"]).is_equal_to(1)

--- a/backend/tests/test_podcasts.py
+++ b/backend/tests/test_podcasts.py
@@ -4,15 +4,20 @@ from assertpy import assert_that
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from podex.api.v2.identifiers import PODCAST_PREFIX, encode
 from podex.models import Podcast
 
 
 def test_list_podcasts_empty(client: TestClient) -> None:
-    """An empty catalog returns an empty list."""
+    """An empty catalog returns an empty page envelope."""
     response = client.get("/api/v2/podcasts")
 
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(response.json()).is_equal_to([])
+    body = response.json()
+    assert_that(body["items"]).is_equal_to([])
+    assert_that(body["total"]).is_equal_to(0)
+    assert_that(body["limit"]).is_equal_to(50)
+    assert_that(body["offset"]).is_equal_to(0)
 
 
 def test_list_and_get_podcast(client: TestClient, db_session: Session) -> None:
@@ -25,17 +30,25 @@ def test_list_and_get_podcast(client: TestClient, db_session: Session) -> None:
     listed = client.get("/api/v2/podcasts")
     assert_that(listed.status_code).is_equal_to(200)
     body = listed.json()
-    assert_that(body).is_length(1)
-    assert_that(body[0]["slug"]).is_equal_to("example-show")
+    assert_that(body["items"]).is_length(1)
+    assert_that(body["items"][0]["slug"]).is_equal_to("example-show")
+    assert_that(body["total"]).is_equal_to(1)
 
-    podcast_id = body[0]["id"]
+    podcast_id = body["items"][0]["id"]
+    assert_that(body["items"][0]["public_id"]).is_equal_to(
+        encode(PODCAST_PREFIX, podcast_id),
+    )
     fetched = client.get(f"/api/v2/podcasts/{podcast_id}")
     assert_that(fetched.status_code).is_equal_to(200)
     assert_that(fetched.json()["name"]).is_equal_to("The Example Show")
 
 
 def test_get_podcast_not_found(client: TestClient) -> None:
-    """An unknown podcast id returns 404."""
+    """An unknown podcast id returns the v2 error envelope."""
     response = client.get("/api/v2/podcasts/999")
 
     assert_that(response.status_code).is_equal_to(404)
+    body = response.json()
+    assert_that(body["error"]["code"]).is_equal_to("not_found")
+    assert_that(body["error"]["message"]).is_equal_to("Podcast not found")
+    assert_that(body["error"]["request_id"]).is_not_empty()

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -28,6 +28,18 @@
             "title": "Podcast Id",
             "type": "integer"
           },
+          "podcast_public_id": {
+            "description": "The opaque public identifier of the owning podcast.",
+            "readOnly": true,
+            "title": "Podcast Public Id",
+            "type": "string"
+          },
+          "public_id": {
+            "description": "The opaque, prefixed public identifier for this episode.",
+            "readOnly": true,
+            "title": "Public Id",
+            "type": "string"
+          },
           "published_at": {
             "anyOf": [
               {
@@ -51,7 +63,9 @@
           "title",
           "episode_number",
           "published_at",
-          "created_at"
+          "created_at",
+          "public_id",
+          "podcast_public_id"
         ],
         "title": "EpisodeRead",
         "type": "object"
@@ -114,6 +128,12 @@
             "title": "Id",
             "type": "integer"
           },
+          "public_id": {
+            "description": "The opaque, prefixed public identifier for this media item.",
+            "readOnly": true,
+            "title": "Public Id",
+            "type": "string"
+          },
           "title": {
             "title": "Title",
             "type": "string"
@@ -141,7 +161,8 @@
           "year",
           "description",
           "cover_url",
-          "created_at"
+          "created_at",
+          "public_id"
         ],
         "title": "MediaRead",
         "type": "object"
@@ -196,6 +217,12 @@
             "title": "Episode Id",
             "type": "integer"
           },
+          "episode_public_id": {
+            "description": "The opaque public identifier of the referenced episode.",
+            "readOnly": true,
+            "title": "Episode Public Id",
+            "type": "string"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -203,6 +230,18 @@
           "media_id": {
             "title": "Media Id",
             "type": "integer"
+          },
+          "media_public_id": {
+            "description": "The opaque public identifier of the referenced media item.",
+            "readOnly": true,
+            "title": "Media Public Id",
+            "type": "string"
+          },
+          "public_id": {
+            "description": "The opaque, prefixed public identifier for this mention.",
+            "readOnly": true,
+            "title": "Public Id",
+            "type": "string"
           },
           "timestamp_seconds": {
             "anyOf": [
@@ -223,9 +262,148 @@
           "timestamp_seconds",
           "context",
           "confidence",
-          "created_at"
+          "created_at",
+          "public_id",
+          "episode_public_id",
+          "media_public_id"
         ],
         "title": "MentionRead",
+        "type": "object"
+      },
+      "Page_EpisodeRead_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/EpisodeRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "minimum": 0.0,
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "Page[EpisodeRead]",
+        "type": "object"
+      },
+      "Page_MediaRead_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/MediaRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "minimum": 0.0,
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "Page[MediaRead]",
+        "type": "object"
+      },
+      "Page_MentionRead_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/MentionRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "minimum": 0.0,
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "Page[MentionRead]",
+        "type": "object"
+      },
+      "Page_PodcastRead_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PodcastRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "minimum": 0.0,
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "Page[PodcastRead]",
         "type": "object"
       },
       "PodcastRead": {
@@ -255,6 +433,12 @@
             "title": "Name",
             "type": "string"
           },
+          "public_id": {
+            "description": "The opaque, prefixed public identifier for this podcast.",
+            "readOnly": true,
+            "title": "Public Id",
+            "type": "string"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -265,7 +449,8 @@
           "name",
           "slug",
           "description",
-          "created_at"
+          "created_at",
+          "public_id"
         ],
         "title": "PodcastRead",
         "type": "object"
@@ -320,7 +505,7 @@
   "paths": {
     "/api/v2/episodes": {
       "get": {
-        "description": "List episodes, optionally filtered by podcast.",
+        "description": "List episodes, optionally filtered by podcast, paginated.",
         "operationId": "list_episodes_api_v2_episodes_get",
         "parameters": [
           {
@@ -338,6 +523,33 @@
               ],
               "title": "Podcast Id"
             }
+          },
+          {
+            "description": "Maximum number of items to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Maximum number of items to return.",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items to skip.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of items to skip.",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -345,11 +557,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/EpisodeRead"
-                  },
-                  "title": "Response List Episodes Api V2 Episodes Get",
-                  "type": "array"
+                  "$ref": "#/components/schemas/Page_EpisodeRead_"
                 }
               }
             },
@@ -419,7 +627,7 @@
     },
     "/api/v2/episodes/{episode_id}/mentions": {
       "get": {
-        "description": "List media mentions within an episode, ordered by timestamp.",
+        "description": "List media mentions within an episode, ordered by timestamp, paginated.",
         "operationId": "list_episode_mentions_api_v2_episodes__episode_id__mentions_get",
         "parameters": [
           {
@@ -430,6 +638,33 @@
               "title": "Episode Id",
               "type": "integer"
             }
+          },
+          {
+            "description": "Maximum number of items to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Maximum number of items to return.",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items to skip.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of items to skip.",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -437,11 +672,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/MentionRead"
-                  },
-                  "title": "Response List Episode Mentions Api V2 Episodes  Episode Id  Mentions Get",
-                  "type": "array"
+                  "$ref": "#/components/schemas/Page_MentionRead_"
                 }
               }
             },
@@ -467,7 +698,7 @@
     },
     "/api/v2/media": {
       "get": {
-        "description": "List media items, optionally filtered by type, ordered by title.",
+        "description": "List media items, optionally filtered by type, paginated.",
         "operationId": "list_media_api_v2_media_get",
         "parameters": [
           {
@@ -485,6 +716,33 @@
               ],
               "title": "Media Type"
             }
+          },
+          {
+            "description": "Maximum number of items to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Maximum number of items to return.",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items to skip.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of items to skip.",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -492,11 +750,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/MediaRead"
-                  },
-                  "title": "Response List Media Api V2 Media Get",
-                  "type": "array"
+                  "$ref": "#/components/schemas/Page_MediaRead_"
                 }
               }
             },
@@ -566,7 +820,7 @@
     },
     "/api/v2/media/{media_id}/mentions": {
       "get": {
-        "description": "List episode mentions of a media item.",
+        "description": "List episode mentions of a media item, paginated.",
         "operationId": "list_media_mentions_api_v2_media__media_id__mentions_get",
         "parameters": [
           {
@@ -577,6 +831,33 @@
               "title": "Media Id",
               "type": "integer"
             }
+          },
+          {
+            "description": "Maximum number of items to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Maximum number of items to return.",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items to skip.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of items to skip.",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -584,11 +865,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/MentionRead"
-                  },
-                  "title": "Response List Media Mentions Api V2 Media  Media Id  Mentions Get",
-                  "type": "array"
+                  "$ref": "#/components/schemas/Page_MentionRead_"
                 }
               }
             },
@@ -614,22 +891,57 @@
     },
     "/api/v2/podcasts": {
       "get": {
-        "description": "List podcast sources ordered by name.",
+        "description": "List podcast sources ordered by name, paginated by ``limit``/``offset``.",
         "operationId": "list_podcasts_api_v2_podcasts_get",
+        "parameters": [
+          {
+            "description": "Maximum number of items to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Maximum number of items to return.",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items to skip.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of items to skip.",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/PodcastRead"
-                  },
-                  "title": "Response List Podcasts Api V2 Podcasts Get",
-                  "type": "array"
+                  "$ref": "#/components/schemas/Page_PodcastRead_"
                 }
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "List Podcasts",

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,29 +1,81 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { fetchPodcasts } from "./api";
-import type { Podcast } from "./types";
+import { fetchPodcastPage, fetchPodcasts } from "./api";
+import type { Podcast, PodcastPage } from "./types";
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("fetchPodcasts", () => {
-  it("returns the parsed podcast list", async () => {
-    const podcasts: Podcast[] = [
-      {
-        id: 1,
-        name: "The Example Show",
-        slug: "example-show",
-        description: null,
-        created_at: "2026-01-01T00:00:00Z",
-      },
-    ];
+function buildPodcast(overrides: Partial<Podcast> = {}): Podcast {
+  return {
+    id: 1,
+    name: "The Example Show",
+    slug: "example-show",
+    description: null,
+    created_at: "2026-01-01T00:00:00Z",
+    public_id: "pod_ae",
+    ...overrides,
+  };
+}
+
+describe("fetchPodcastPage", () => {
+  it("returns the parsed page envelope", async () => {
+    const page: PodcastPage = {
+      items: [buildPodcast()],
+      total: 1,
+      limit: 50,
+      offset: 0,
+    };
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          new Response(JSON.stringify(podcasts), { status: 200 }),
-      ),
+      vi.fn(async () => new Response(JSON.stringify(page), { status: 200 })),
+    );
+
+    await expect(fetchPodcastPage()).resolves.toEqual(page);
+  });
+
+  it("passes limit and offset as query params", async () => {
+    let capturedUrl = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        capturedUrl = url;
+        return new Response(
+          JSON.stringify({ items: [], total: 0, limit: 5, offset: 10 }),
+          { status: 200 },
+        );
+      }),
+    );
+
+    await fetchPodcastPage({ limit: 5, offset: 10 });
+
+    expect(capturedUrl).toContain("limit=5");
+    expect(capturedUrl).toContain("offset=10");
+  });
+
+  it("throws on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 500 })),
+    );
+
+    await expect(fetchPodcastPage()).rejects.toThrow(/500/);
+  });
+});
+
+describe("fetchPodcasts", () => {
+  it("returns just the items from the first page", async () => {
+    const podcasts: Podcast[] = [buildPodcast()];
+    const page: PodcastPage = {
+      items: podcasts,
+      total: podcasts.length,
+      limit: 50,
+      offset: 0,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(page), { status: 200 })),
     );
 
     await expect(fetchPodcasts()).resolves.toEqual(podcasts);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,11 +1,36 @@
 import { API_BASE_URL } from "./config";
-import type { Podcast } from "./types";
+import type { Podcast, PodcastPage } from "./types";
 
-/** Fetch the list of podcasts from the Podex API. */
-export async function fetchPodcasts(): Promise<Podcast[]> {
-  const response = await fetch(`${API_BASE_URL}/podcasts`);
+/**
+ * Fetch a page of podcasts from the Podex API.
+ *
+ * @param params - Optional pagination overrides. ``limit`` clamps to the
+ *   backend's maximum page size; ``offset`` skips that many items.
+ * @returns The parsed page envelope containing items plus paging metadata.
+ * @throws {Error} When the API responds with a non-OK status.
+ */
+export async function fetchPodcastPage(
+  params: { limit?: number; offset?: number } = {},
+): Promise<PodcastPage> {
+  const search = new URLSearchParams();
+  if (params.limit !== undefined) search.set("limit", String(params.limit));
+  if (params.offset !== undefined) search.set("offset", String(params.offset));
+  const query = search.toString();
+  const url = `${API_BASE_URL}/podcasts${query ? `?${query}` : ""}`;
+
+  const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`Failed to fetch podcasts: ${response.status}`);
   }
-  return (await response.json()) as Podcast[];
+  return (await response.json()) as PodcastPage;
+}
+
+/**
+ * Convenience wrapper that returns only the items from the first page.
+ *
+ * Prefer :func:`fetchPodcastPage` when the caller needs paging metadata.
+ */
+export async function fetchPodcasts(): Promise<Podcast[]> {
+  const page = await fetchPodcastPage();
+  return page.items;
 }

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -13,7 +13,7 @@ export interface paths {
         };
         /**
          * List Episodes
-         * @description List episodes, optionally filtered by podcast.
+         * @description List episodes, optionally filtered by podcast, paginated.
          */
         get: operations["list_episodes_api_v2_episodes_get"];
         put?: never;
@@ -53,7 +53,7 @@ export interface paths {
         };
         /**
          * List Episode Mentions
-         * @description List media mentions within an episode, ordered by timestamp.
+         * @description List media mentions within an episode, ordered by timestamp, paginated.
          */
         get: operations["list_episode_mentions_api_v2_episodes__episode_id__mentions_get"];
         put?: never;
@@ -73,7 +73,7 @@ export interface paths {
         };
         /**
          * List Media
-         * @description List media items, optionally filtered by type, ordered by title.
+         * @description List media items, optionally filtered by type, paginated.
          */
         get: operations["list_media_api_v2_media_get"];
         put?: never;
@@ -113,7 +113,7 @@ export interface paths {
         };
         /**
          * List Media Mentions
-         * @description List episode mentions of a media item.
+         * @description List episode mentions of a media item, paginated.
          */
         get: operations["list_media_mentions_api_v2_media__media_id__mentions_get"];
         put?: never;
@@ -133,7 +133,7 @@ export interface paths {
         };
         /**
          * List Podcasts
-         * @description List podcast sources ordered by name.
+         * @description List podcast sources ordered by name, paginated by ``limit``/``offset``.
          */
         get: operations["list_podcasts_api_v2_podcasts_get"];
         put?: never;
@@ -224,6 +224,16 @@ export interface components {
             id: number;
             /** Podcast Id */
             podcast_id: number;
+            /**
+             * Podcast Public Id
+             * @description The opaque public identifier of the owning podcast.
+             */
+            readonly podcast_public_id: string;
+            /**
+             * Public Id
+             * @description The opaque, prefixed public identifier for this episode.
+             */
+            readonly public_id: string;
             /** Published At */
             published_at: string | null;
             /** Title */
@@ -252,6 +262,11 @@ export interface components {
             description: string | null;
             /** Id */
             id: number;
+            /**
+             * Public Id
+             * @description The opaque, prefixed public identifier for this media item.
+             */
+            readonly public_id: string;
             /** Title */
             title: string;
             type: components["schemas"]["MediaType"];
@@ -280,12 +295,71 @@ export interface components {
             created_at: string;
             /** Episode Id */
             episode_id: number;
+            /**
+             * Episode Public Id
+             * @description The opaque public identifier of the referenced episode.
+             */
+            readonly episode_public_id: string;
             /** Id */
             id: number;
             /** Media Id */
             media_id: number;
+            /**
+             * Media Public Id
+             * @description The opaque public identifier of the referenced media item.
+             */
+            readonly media_public_id: string;
+            /**
+             * Public Id
+             * @description The opaque, prefixed public identifier for this mention.
+             */
+            readonly public_id: string;
             /** Timestamp Seconds */
             timestamp_seconds: number | null;
+        };
+        /** Page[EpisodeRead] */
+        Page_EpisodeRead_: {
+            /** Items */
+            items: components["schemas"]["EpisodeRead"][];
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Total */
+            total: number;
+        };
+        /** Page[MediaRead] */
+        Page_MediaRead_: {
+            /** Items */
+            items: components["schemas"]["MediaRead"][];
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Total */
+            total: number;
+        };
+        /** Page[MentionRead] */
+        Page_MentionRead_: {
+            /** Items */
+            items: components["schemas"]["MentionRead"][];
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Total */
+            total: number;
+        };
+        /** Page[PodcastRead] */
+        Page_PodcastRead_: {
+            /** Items */
+            items: components["schemas"]["PodcastRead"][];
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Total */
+            total: number;
         };
         /**
          * PodcastRead
@@ -303,6 +377,11 @@ export interface components {
             id: number;
             /** Name */
             name: string;
+            /**
+             * Public Id
+             * @description The opaque, prefixed public identifier for this podcast.
+             */
+            readonly public_id: string;
             /** Slug */
             slug: string;
         };
@@ -332,6 +411,10 @@ export interface operations {
         parameters: {
             query?: {
                 podcast_id?: number | null;
+                /** @description Maximum number of items to return. */
+                limit?: number;
+                /** @description Number of items to skip. */
+                offset?: number;
             };
             header?: never;
             path?: never;
@@ -345,7 +428,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["EpisodeRead"][];
+                    "application/json": components["schemas"]["Page_EpisodeRead_"];
                 };
             };
             /** @description Validation Error */
@@ -392,7 +475,12 @@ export interface operations {
     };
     list_episode_mentions_api_v2_episodes__episode_id__mentions_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return. */
+                limit?: number;
+                /** @description Number of items to skip. */
+                offset?: number;
+            };
             header?: never;
             path: {
                 episode_id: number;
@@ -407,7 +495,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MentionRead"][];
+                    "application/json": components["schemas"]["Page_MentionRead_"];
                 };
             };
             /** @description Validation Error */
@@ -425,6 +513,10 @@ export interface operations {
         parameters: {
             query?: {
                 media_type?: components["schemas"]["MediaType"] | null;
+                /** @description Maximum number of items to return. */
+                limit?: number;
+                /** @description Number of items to skip. */
+                offset?: number;
             };
             header?: never;
             path?: never;
@@ -438,7 +530,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MediaRead"][];
+                    "application/json": components["schemas"]["Page_MediaRead_"];
                 };
             };
             /** @description Validation Error */
@@ -485,7 +577,12 @@ export interface operations {
     };
     list_media_mentions_api_v2_media__media_id__mentions_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return. */
+                limit?: number;
+                /** @description Number of items to skip. */
+                offset?: number;
+            };
             header?: never;
             path: {
                 media_id: number;
@@ -500,7 +597,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MentionRead"][];
+                    "application/json": components["schemas"]["Page_MentionRead_"];
                 };
             };
             /** @description Validation Error */
@@ -516,7 +613,12 @@ export interface operations {
     };
     list_podcasts_api_v2_podcasts_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return. */
+                limit?: number;
+                /** @description Number of items to skip. */
+                offset?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -529,7 +631,16 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PodcastRead"][];
+                    "application/json": components["schemas"]["Page_PodcastRead_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2,3 +2,21 @@ import type { components } from "./types.gen";
 
 /** A podcast source in the catalog. */
 export type Podcast = components["schemas"]["PodcastRead"];
+
+/** A single page of podcasts returned by the v2 list endpoint. */
+export type PodcastPage = components["schemas"]["Page_PodcastRead_"];
+
+/** The uniform error envelope returned by ``/api/v2`` failures. */
+export type ApiError = {
+  code: string;
+  message: string;
+  request_id?: string | null;
+  details?: {
+    loc: (string | number)[];
+    msg: string;
+    type: string;
+  }[];
+};
+
+/** The wrapper carrying an :class:`ApiError` body from ``/api/v2``. */
+export type ApiErrorResponse = { error: ApiError };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(api): standardize v2 pagination, error envelope, and public IDs
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [x] `!` in title or `BREAKING CHANGE:` footer included

  List endpoints now return a `Page` envelope; error bodies use `{error:{code,message,request_id}}` instead of `{detail}`. Pre-1.0 surface; in-repo frontend updated in the same PR.

## What's Changing

Completes residual v2 API foundation from #31 on current main: opaque public ID helpers (serialized on read DTOs), shared pagination (`Page` envelope on all list routes), and consistent JSON error handlers. Regenerates OpenAPI + typed client; homepage consumes the new envelope.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #31

## Details

- Path params remain ints; opaque IDs are additive (`public_id` fields).
- Follow-up stack: coverage expansion and SEO/legal PRs rebase onto this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5858b61d-75f5-4f10-8e79-10c8f0f94838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

