### PR TITLE
fix(docker): unblock tag-publish Trivy gate on unfixed base CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,36 @@
+# Trivy suppressions for the tag-publish vulnerability gate (docker-ci.yml).
+#
+# Policy (#220): only CRITICAL/HIGH CVEs with NO fixed Debian 12 package may
+# be listed here. Each entry names the affected package(s); prune entries as
+# Debian ships fixes — Renovate base-image digest bumps re-run the scan and
+# will fail if an entry stops matching a fixed package. Never list a CVE that
+# has a fixed version available; fix the image instead.
+
+# zlib1g — integer overflow in zipOpenNewFileInZip4_64 (contrib/minizip; not
+# shipped as a runtime code path for this app).
+CVE-2023-45853
+
+# libsqlite3-0 — SQLite integer overflow.
+CVE-2025-7458
+
+# perl-base — perl core / Archive-Tar / IO-Compress issues; perl-base is an
+# essential dpkg dependency in bookworm and cannot be removed from slim images.
+CVE-2026-8376
+CVE-2026-13221
+CVE-2026-42496
+CVE-2026-42497
+CVE-2026-48962
+CVE-2026-57432
+CVE-2026-9538
+
+# ncurses (ncurses-base/ncurses-bin/libtinfo6) — buffer overflow.
+CVE-2025-69720
+
+# util-linux / libblkid / libuuid1 / mount — integer overflow in dos.c.
+CVE-2026-53615
+
+# gzip — no fixed version.
+CVE-2026-41992
+
+# libacl1 — no fixed version.
+CVE-2026-54369

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -66,6 +66,11 @@ RUN groupadd --system --gid 1001 podex \
     && useradd --system --uid 1001 --gid podex --home-dir /app --no-log-init --shell /usr/sbin/nologin podex \
     && install -d -o podex -g podex /app
 
+# Drop the base image's system pip: the app runs from the uv-built venv and
+# never installs packages at runtime, and the bundled pip trips the tag-publish
+# Trivy gate whenever it lags a fixable CVE (#220).
+RUN python -m pip uninstall --yes pip
+
 WORKDIR /app
 
 # Copy the resolved venv and runtime code from the builder. Ownership is set


### PR DESCRIPTION
## What's Changing

The v0.12.0 tag publish (run 29638531211) failed at the Trivy scan gate in both image jobs. Every flagged CRITICAL/HIGH CVE except one lives in Debian 12 base packages with **no fixed version** (zlib1g, libsqlite3-0, perl-base ×7, ncurses, util-linux, gzip, libacl1), so the tag gate could never pass.

- Add a root `.trivyignore` listing only those unfixed CRITICAL/HIGH CVE IDs, each with the affected package and rationale. The stock `aquasecurity/trivy-action` used by `reusable-docker` honors this file from the workspace root.
- Uninstall the base image's system pip from the backend runtime stage rather than suppressing its **fixable** CVE-2026-8643 — the app runs from the uv-built venv and never needs pip at runtime.
- `scan-exit-code: 1` on tags is unchanged; the gate still blocks actionable findings.

## Verification

- `uv run lintro chk` — hadolint PASS on the modified Dockerfile (remaining reported issues are pre-existing in untouched files and green in CI)
- Gate behavior is exercised on the next tag publish (first release after this merges)

## Closes

- Fixes #220