### PR TITLE
fix(ci): make docker scan gate advisory until suppressions can load

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -69,9 +69,12 @@ jobs:
       runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
       tag-latest: true
       scan: true
-      # Advisory-only on non-tag; fail the tag publish on CRITICAL/HIGH.
-      scan-exit-code: >-
-        ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '0' }}
+      # Advisory-only everywhere for now: reusable-docker's scan job never
+      # checks out this repo and hardcodes ignore-unfixed, so .trivyignore
+      # cannot load on the tag path and unfixed base CVEs would fail every
+      # release (#223). Restore '1' on tags once lgtm-hq/lgtm-ci#626 ships a
+      # scan-ignore-unfixed input (or caller checkout).
+      scan-exit-code: '0'
       cosign-sign: ${{ startsWith(github.ref, 'refs/tags/v') }}
       cache-registry-ref: ghcr.io/lgtm-hq/podex-backend:cache
       no-cache: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -152,8 +155,9 @@ jobs:
       runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
       tag-latest: true
       scan: true
-      scan-exit-code: >-
-        ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '0' }}
+      # Advisory-only everywhere for now — see backend job comment (#223,
+      # lgtm-hq/lgtm-ci#626).
+      scan-exit-code: '0'
       cosign-sign: ${{ startsWith(github.ref, 'refs/tags/v') }}
       cache-registry-ref: ghcr.io/lgtm-hq/podex-frontend:cache
       no-cache: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
## What's Changing

v0.12.1's tag publish failed at the Trivy gate despite `.trivyignore` (#221): `reusable-docker`'s scan job sparse-checks-out only the lgtm-ci tooling — this repo's files are never in the workspace — and hardcodes `ignore-unfixed: false`. Suppressions structurally cannot apply on the tag path, so unfixed Debian 12 base CVEs fail every release.

Set `scan-exit-code: '0'` for both image jobs (advisory: SARIF still uploads to code scanning; OSV audit and dependency review gates unchanged). A comment links the upstream fix — restore `'1'` on tags once lgtm-hq/lgtm-ci#626 ships `scan-ignore-unfixed` (or caller checkout). `.trivyignore` stays for the PR-path scan and the future re-enabled gate.

## Verification

- `uv run lintro chk` on the workflow — 0 issues
- Failing runs analyzed: 29638531211 (v0.12.0), 29639037706 (v0.12.1); scan job logs show `sparse-checkout: .github/actions/checkout-and-harden` only and `ignore-unfixed: false`

## Closes

- Fixes #223