### PR TITLE
chore(lint): enforce #29 prompt boundary with repo-local semgrep rule

### DIFF
--- a/.github/workflows/quality-ci.yml
+++ b/.github/workflows/quality-ci.yml
@@ -28,6 +28,10 @@ jobs:
       job-name: '🛠️ Lintro Code Quality'
       tooling-ref: '443a687caa93b3afa306a066aae8d8a2b4e60c3c'  # v0.59.0
       working-directory: backend
+      # Route semgrep to the repo-local #29 prompt-boundary rules (issue #236)
+      # instead of the registry "auto" config, which egress-blocked CI cannot
+      # reach anyway.
+      lintro-tool-options: 'semgrep:config=.semgrep/prompt-boundary.yaml'
       # yamllint disable-line rule:line-length
       lintro-image: ghcr.io/lgtm-hq/py-lintro@sha256:95b9fd9d62c3ca1227447467767ec915e78a7eef62282dd18c0b1c02ee4d3887
       egress-policy: block

--- a/backend/.lintro-config.yaml
+++ b/backend/.lintro-config.yaml
@@ -51,6 +51,8 @@ tools:
     enabled: true
   osv_scanner:
     enabled: true
+  semgrep:
+    enabled: true
 
 ai:
   enabled: false

--- a/backend/.semgrep/prompt-boundary.yaml
+++ b/backend/.semgrep/prompt-boundary.yaml
@@ -1,0 +1,42 @@
+---
+# Enforces the #29 open/closed prompt boundary (see issue #236).
+#
+# LLM prompt text may exist in exactly one public module:
+# src/podex/services/prompts_default.py (generic fallbacks only).
+# Tuned prompts are podex-ops data injected at runtime via the
+# prompt_config seam and must never be committed to this repo.
+rules:
+  - id: podex-prompt-constant-outside-designated-module
+    languages: [python]
+    severity: ERROR
+    message: >
+      Assignment to a *_PROMPT identifier outside the designated fallback
+      module. Prompt text is podex-ops data (issue #29): load it via the
+      prompt_config injection seam, or add a generic fallback to
+      src/podex/services/prompts_default.py.
+    patterns:
+      - pattern: $NAME = $VALUE
+      - metavariable-regex:
+          metavariable: $NAME
+          regex: '.*_PROMPT$'
+    paths:
+      exclude:
+        - '**/services/prompts_default.py'
+
+  - id: podex-prompt-marker-text-outside-designated-module
+    languages: [generic]
+    severity: ERROR
+    message: >
+      Prompt-shaped text ("<role>", "You are a", "Your task is to") outside
+      the designated fallback module. Prompt text is podex-ops data (issue
+      #29): load it via the prompt_config injection seam, or add a generic
+      fallback to src/podex/services/prompts_default.py.
+    pattern-either:
+      - pattern: <role>
+      - pattern: You are a
+      - pattern: Your task is to
+    paths:
+      include:
+        - '*.py'
+      exclude:
+        - '**/services/prompts_default.py'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `chore(lint): enforce #29 prompt boundary with repo-local semgrep rule`

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Makes the #29 "load-don't-embed" prompt boundary a failing CI check instead of a convention, ahead of the extraction work (split PR3 in #108) where the risk becomes real. The rule is inert today — `main` contains no prompt code — so the guard predates the risk.

- `backend/.semgrep/prompt-boundary.yaml`: two ERROR-severity rules —
  1. assignments to `*_PROMPT` identifiers (also covers `*_SYSTEM_PROMPT`) in Python;
  2. prompt-marker text (`<role>`, `You are a`, `Your task is to`) in `*.py` files.

  Allowlist is exactly `**/services/prompts_default.py`, the designated generic-fallback module (arrives with the prompts refactor; tuned prompts remain podex-ops data injected via the `prompt_config` seam).
- `backend/.lintro-config.yaml`: enable the semgrep tool.
- `.github/workflows/quality-ci.yml`: pass `lintro-tool-options: 'semgrep:config=.semgrep/prompt-boundary.yaml'` so semgrep uses the repo-local rules — the default registry `auto` config is unreachable under the job's blocked egress anyway.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #236
- Relates to #108

(#236 stays open until the designated `prompts_default.py` module and injection-seam resolution land with the extraction slice.)

## Details

Verification (local, lintro 0.81.0 / semgrep 1.169.0):

- Canary file with `EXTRACTION_SYSTEM_PROMPT = "You are a …"` → both rules fire (2 findings, semgrep FAIL).
- Same content copied to `src/podex/services/prompts_default.py` → excluded (0 findings from that file).
- Clean tree → semgrep PASS, 0 findings; yamllint/actionlint pass on all touched files; `uv run lintro tst` green (143 passed).
- The pinned py-lintro CI image ships the semgrep binary (verified in py-lintro Dockerfile), so blocked egress does not affect the run.