### PR TITLE
fix(cache): distinguish cached None from a miss in get_or_compute

### DIFF
--- a/backend/src/podex/services/cache.py
+++ b/backend/src/podex/services/cache.py
@@ -19,12 +19,15 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Protocol, TypeVar, cast, runtime_checkable
+from typing import Any, Final, Protocol, TypeVar, cast, runtime_checkable
 
 MonotonicClock = Callable[[], float]
 """Zero-arg callable returning a monotonic timestamp in seconds."""
 
 T = TypeVar("T")
+
+_MISSING: Final = object()
+"""Internal sentinel distinguishing "no entry" from a cached ``None``."""
 
 
 @runtime_checkable
@@ -58,7 +61,8 @@ class Cache(Protocol):
         Implementations must ensure that concurrent callers observing a cache
         miss only invoke ``loader`` once per key; the remaining callers must
         wait for that in-flight computation and return the freshly stored
-        value.
+        value. A ``loader`` returning ``None`` is a valid cached result and
+        must be served from the store for the full TTL, not recomputed.
         """
 
 
@@ -100,16 +104,26 @@ class TTLCache:
     def get(self, key: str) -> Any | None:
         """Return the cached value for ``key`` or ``None`` if absent/expired.
 
+        ``None`` is ambiguous here by design (a cached ``None`` and a miss
+        look identical); :meth:`get_or_compute` uses the sentinel-based
+        :meth:`_lookup` internally so it never confuses the two.
+        """
+        value = self._lookup(key)
+        return None if value is _MISSING else value
+
+    def _lookup(self, key: str) -> Any:
+        """Return the live value for ``key`` or ``_MISSING`` if absent/expired.
+
         Expired entries are removed opportunistically on read so a rarely-hit
         key does not linger in memory once its TTL elapses.
         """
         with self._lock:
             entry = self._entries.get(key)
             if entry is None:
-                return None
+                return _MISSING
             if entry.expires_at <= self._clock():
                 del self._entries[key]
-                return None
+                return _MISSING
             return entry.value
 
     def set(self, key: str, value: Any, *, ttl_seconds: float) -> None:
@@ -161,11 +175,13 @@ class TTLCache:
     ) -> T:
         """Return the cached value or compute-and-store it single-flight.
 
-        A fast-path :meth:`get` avoids taking the per-key lock when the value
-        is already cached. On a miss the per-key lock is acquired and the
-        cache re-checked (double-checked locking) before ``loader`` runs, so
-        concurrent cold callers wait for the in-flight computation instead of
-        each recomputing the value.
+        A fast-path :meth:`_lookup` avoids taking the per-key lock when the
+        value is already cached. On a miss the per-key lock is acquired and
+        the cache re-checked (double-checked locking) before ``loader`` runs,
+        so concurrent cold callers wait for the in-flight computation instead
+        of each recomputing the value. Hits are detected with an internal
+        sentinel rather than ``None``, so a loader that legitimately returns
+        ``None`` has that result cached and served for the full TTL.
 
         A non-positive ``ttl_seconds`` disables caching entirely: ``loader``
         is invoked directly and its result is returned without touching the
@@ -182,12 +198,12 @@ class TTLCache:
         """
         if ttl_seconds <= 0:
             return loader()
-        cached = self.get(key)
-        if cached is not None:
+        cached = self._lookup(key)
+        if cached is not _MISSING:
             return cast("T", cached)
         with self._get_key_lock(key):
-            cached = self.get(key)
-            if cached is not None:
+            cached = self._lookup(key)
+            if cached is not _MISSING:
                 return cast("T", cached)
             fresh = loader()
             self.set(key, fresh, ttl_seconds=ttl_seconds)

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -107,6 +107,45 @@ def test_get_or_compute_populates_and_reuses_entry() -> None:
     assert_that(call_count).is_equal_to(1)
 
 
+def test_get_or_compute_caches_none_results() -> None:
+    """A loader returning ``None`` is cached and not recomputed within TTL."""
+    cache = TTLCache()
+    call_count = 0
+
+    def loader() -> None:
+        """Return ``None`` and record how many times it ran."""
+        nonlocal call_count
+        call_count += 1
+        return None
+
+    first = cache.get_or_compute("k", ttl_seconds=60, loader=loader)
+    second = cache.get_or_compute("k", ttl_seconds=60, loader=loader)
+
+    assert_that(first).is_none()
+    assert_that(second).is_none()
+    assert_that(call_count).is_equal_to(1)
+
+
+def test_get_or_compute_recomputes_none_after_expiry() -> None:
+    """A cached ``None`` still honours the TTL and is recomputed once stale."""
+    clock = _Clock()
+    cache = TTLCache(clock=clock)
+    call_count = 0
+
+    def loader() -> None:
+        """Return ``None`` and record how many times it ran."""
+        nonlocal call_count
+        call_count += 1
+        return None
+
+    cache.get_or_compute("k", ttl_seconds=10, loader=loader)
+    clock.now += 11
+    result = cache.get_or_compute("k", ttl_seconds=10, loader=loader)
+
+    assert_that(result).is_none()
+    assert_that(call_count).is_equal_to(2)
+
+
 def test_get_or_compute_skips_cache_when_ttl_is_zero() -> None:
     """A non-positive TTL bypasses the store entirely."""
     cache = TTLCache()
@@ -167,7 +206,10 @@ def test_get_or_compute_is_single_flight_under_concurrency() -> None:
     ready.wait()
     release.set()
     for thread in threads:
-        thread.join()
+        # A bounded join keeps a future locking regression from hanging the
+        # suite; a still-alive worker means get_or_compute deadlocked.
+        thread.join(timeout=2)
+        assert_that(thread.is_alive()).is_false()
 
     assert_that(call_count).is_equal_to(1)
     assert_that(results).is_equal_to(["value"] * workers)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `fix(cache): distinguish cached None from a miss in get_or_compute`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`TTLCache.get_or_compute` detected hits with `is not None`, so a loader that legitimately returns `None` was recomputed on every call — silently defeating both the TTL and the single-flight guarantee for that key (latent today; no current loader is nullable).

- `backend/src/podex/services/cache.py`: internal hit checks now use a module-private `_MISSING` sentinel via a new `_lookup` helper; a cached `None` is served for its full TTL. The public `get` keeps its `None`-means-miss shape, and the `Cache` protocol docstring now states the nullable-loader contract.
- `backend/tests/test_cache.py`: new tests for caching a `None` result (single loader invocation within TTL) and recomputing it after expiry; the single-flight concurrency test now joins workers with a 2s timeout plus a liveness assertion (#233) so a locking regression fails fast instead of hanging CI.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #232
- Closes #233

## Details

Surfaced by CodeRabbit review on PR #204. Verified with `uv run lintro tst` (145 passed, including the two new cases) and ruff/mypy/pydoclint clean on the touched files.