### PR TITLE
refactor(api): replace identifier prefix constants with an IdentifierKind StrEnum

### DIFF
--- a/backend/src/podex/api/v2/identifiers.py
+++ b/backend/src/podex/api/v2/identifiers.py
@@ -12,9 +12,9 @@ scheme — callers that need unpredictability should compose an HMAC on top.
 
 Example:
 
-    >>> encode("pod", 1)
+    >>> encode(IdentifierKind.PODCAST, 1)
     'pod_ae'
-    >>> decode("pod", "pod_ae")
+    >>> decode(IdentifierKind.PODCAST, "pod_ae")
     1
 """
 
@@ -22,12 +22,23 @@ from __future__ import annotations
 
 import base64
 import re
-from typing import Final
+from enum import StrEnum, unique
 
-PODCAST_PREFIX: Final = "pod"
-EPISODE_PREFIX: Final = "epi"
-MEDIA_PREFIX: Final = "med"
-MENTION_PREFIX: Final = "men"
+
+@unique
+class IdentifierKind(StrEnum):
+    """Public identifier prefix for each exposed resource kind.
+
+    The enum is the single closed vocabulary of identifier kinds: adding a
+    new public resource means adding a member here, and ``@unique`` rejects
+    duplicate prefixes at import time.
+    """
+
+    PODCAST = "pod"
+    EPISODE = "epi"
+    MEDIA = "med"
+    MENTION = "men"
+
 
 _ALLOWED_PREFIX = re.compile(r"^[a-z][a-z0-9]{1,7}$")
 _ALLOWED_BODY = re.compile(r"^[a-z2-7]+$")
@@ -42,11 +53,11 @@ def _validate_prefix(prefix: str) -> None:
         )
 
 
-def encode(prefix: str, value: int) -> str:
+def encode(kind: IdentifierKind, value: int) -> str:
     """Encode a non-negative integer id into a prefixed opaque token.
 
     Args:
-        prefix: The short kind prefix (e.g. ``"pod"``).
+        kind: The identifier kind whose prefix the token carries.
         value: The non-negative integer identifier to encode.
 
     Returns:
@@ -54,34 +65,34 @@ def encode(prefix: str, value: int) -> str:
         unpadded base32 representation of ``value``'s big-endian bytes.
 
     Raises:
-        ValueError: If ``prefix`` is not a short lowercase token or ``value``
-            is negative.
+        ValueError: If ``kind``'s prefix is not a short lowercase token or
+            ``value`` is negative.
     """
-    _validate_prefix(prefix)
+    _validate_prefix(kind)
     if value < 0:
         raise ValueError(f"value must be non-negative: {value!r}")
     length = max(1, (value.bit_length() + 7) // 8)
     body = base64.b32encode(value.to_bytes(length, "big")).decode("ascii")
-    return f"{prefix}_{body.rstrip('=').lower()}"
+    return f"{kind}_{body.rstrip('=').lower()}"
 
 
-def decode(prefix: str, token: str) -> int:
+def decode(kind: IdentifierKind, token: str) -> int:
     """Decode a prefixed opaque token back into its integer id.
 
     Args:
-        prefix: The expected kind prefix; the token must start with
-            ``f"{prefix}_"``.
+        kind: The expected identifier kind; the token must start with
+            ``f"{kind}_"``.
         token: The opaque token to decode.
 
     Returns:
         The non-negative integer identifier originally passed to :func:`encode`.
 
     Raises:
-        ValueError: If ``token`` is malformed, uses a different prefix, or
-            contains characters outside the base32 alphabet.
+        ValueError: If ``token`` is malformed, uses a different kind's prefix,
+            or contains characters outside the base32 alphabet.
     """
-    _validate_prefix(prefix)
-    expected_start = f"{prefix}_"
+    _validate_prefix(kind)
+    expected_start = f"{kind}_"
     if not token.startswith(expected_start):
         raise ValueError(
             f"identifier does not start with {expected_start!r}: {token!r}",

--- a/backend/src/podex/schemas/episode.py
+++ b/backend/src/podex/schemas/episode.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from pydantic import BaseModel, ConfigDict, computed_field
 
-from podex.api.v2.identifiers import EPISODE_PREFIX, PODCAST_PREFIX, encode
+from podex.api.v2.identifiers import IdentifierKind, encode
 
 
 class EpisodeRead(BaseModel):
@@ -24,10 +24,10 @@ class EpisodeRead(BaseModel):
     @property
     def public_id(self) -> str:
         """The opaque, prefixed public identifier for this episode."""
-        return cast("str", encode(EPISODE_PREFIX, self.id))
+        return cast("str", encode(IdentifierKind.EPISODE, self.id))
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def podcast_public_id(self) -> str:
         """The opaque public identifier of the owning podcast."""
-        return cast("str", encode(PODCAST_PREFIX, self.podcast_id))
+        return cast("str", encode(IdentifierKind.PODCAST, self.podcast_id))

--- a/backend/src/podex/schemas/media.py
+++ b/backend/src/podex/schemas/media.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from pydantic import BaseModel, ConfigDict, computed_field
 
-from podex.api.v2.identifiers import MEDIA_PREFIX, encode
+from podex.api.v2.identifiers import IdentifierKind, encode
 from podex.models.media import MediaType
 
 
@@ -27,4 +27,4 @@ class MediaRead(BaseModel):
     @property
     def public_id(self) -> str:
         """The opaque, prefixed public identifier for this media item."""
-        return cast("str", encode(MEDIA_PREFIX, self.id))
+        return cast("str", encode(IdentifierKind.MEDIA, self.id))

--- a/backend/src/podex/schemas/mention.py
+++ b/backend/src/podex/schemas/mention.py
@@ -5,12 +5,7 @@ from typing import cast
 
 from pydantic import BaseModel, ConfigDict, computed_field
 
-from podex.api.v2.identifiers import (
-    EPISODE_PREFIX,
-    MEDIA_PREFIX,
-    MENTION_PREFIX,
-    encode,
-)
+from podex.api.v2.identifiers import IdentifierKind, encode
 
 
 class MentionRead(BaseModel):
@@ -30,16 +25,16 @@ class MentionRead(BaseModel):
     @property
     def public_id(self) -> str:
         """The opaque, prefixed public identifier for this mention."""
-        return cast("str", encode(MENTION_PREFIX, self.id))
+        return cast("str", encode(IdentifierKind.MENTION, self.id))
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def episode_public_id(self) -> str:
         """The opaque public identifier of the referenced episode."""
-        return cast("str", encode(EPISODE_PREFIX, self.episode_id))
+        return cast("str", encode(IdentifierKind.EPISODE, self.episode_id))
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def media_public_id(self) -> str:
         """The opaque public identifier of the referenced media item."""
-        return cast("str", encode(MEDIA_PREFIX, self.media_id))
+        return cast("str", encode(IdentifierKind.MEDIA, self.media_id))

--- a/backend/src/podex/schemas/podcast.py
+++ b/backend/src/podex/schemas/podcast.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from pydantic import BaseModel, ConfigDict, computed_field
 
-from podex.api.v2.identifiers import PODCAST_PREFIX, encode
+from podex.api.v2.identifiers import IdentifierKind, encode
 
 
 class PodcastRead(BaseModel):
@@ -23,4 +23,4 @@ class PodcastRead(BaseModel):
     @property
     def public_id(self) -> str:
         """The opaque, prefixed public identifier for this podcast."""
-        return cast("str", encode(PODCAST_PREFIX, self.id))
+        return cast("str", encode(IdentifierKind.PODCAST, self.id))

--- a/backend/tests/test_identifiers.py
+++ b/backend/tests/test_identifiers.py
@@ -3,54 +3,53 @@
 import pytest
 from assertpy import assert_that
 
-from podex.api.v2.identifiers import (
-    EPISODE_PREFIX,
-    MEDIA_PREFIX,
-    MENTION_PREFIX,
-    PODCAST_PREFIX,
-    decode,
-    encode,
-)
+from podex.api.v2.identifiers import IdentifierKind, decode, encode
 
 
 @pytest.mark.parametrize("value", [0, 1, 2, 31, 32, 100, 1000, 123456789, 2**63])
 def test_encode_decode_round_trip(value: int) -> None:
-    """``decode(prefix, encode(prefix, n))`` returns the original integer."""
-    token = encode(PODCAST_PREFIX, value)
+    """``decode(kind, encode(kind, n))`` returns the original integer."""
+    token = encode(IdentifierKind.PODCAST, value)
 
-    assert_that(token).starts_with(f"{PODCAST_PREFIX}_")
-    assert_that(decode(PODCAST_PREFIX, token)).is_equal_to(value)
+    assert_that(token).starts_with(f"{IdentifierKind.PODCAST}_")
+    assert_that(decode(IdentifierKind.PODCAST, token)).is_equal_to(value)
 
 
 def test_encode_uses_short_lowercase_body() -> None:
     """Encoded tokens use lowercase base32 without padding."""
-    token = encode(PODCAST_PREFIX, 42)
+    token = encode(IdentifierKind.PODCAST, 42)
 
     assert_that(token).matches(r"^pod_[a-z2-7]+$")
 
 
 def test_encode_rejects_negative() -> None:
     """Negative integers cannot be encoded."""
-    assert_that(encode).raises(ValueError).when_called_with(PODCAST_PREFIX, -1)
+    assert_that(encode).raises(ValueError).when_called_with(
+        IdentifierKind.PODCAST,
+        -1,
+    )
 
 
-def test_encode_rejects_invalid_prefix() -> None:
-    """Prefixes must be short lowercase alphanumeric tokens."""
-    for bad in ("", "A", "12", "way_too_long_prefix", "PO"):
-        assert_that(encode).raises(ValueError).when_called_with(bad, 1)
+def test_every_kind_uses_a_valid_prefix() -> None:
+    """Each enum member's prefix is a short lowercase alphanumeric token."""
+    for kind in IdentifierKind:
+        assert_that(str(kind)).matches(r"^[a-z][a-z0-9]{1,7}$")
 
 
-def test_decode_rejects_wrong_prefix() -> None:
-    """A token encoded for one prefix cannot be decoded under another."""
-    token = encode(PODCAST_PREFIX, 7)
+def test_decode_rejects_wrong_kind() -> None:
+    """A token encoded for one kind cannot be decoded under another."""
+    token = encode(IdentifierKind.PODCAST, 7)
 
-    assert_that(decode).raises(ValueError).when_called_with(EPISODE_PREFIX, token)
+    assert_that(decode).raises(ValueError).when_called_with(
+        IdentifierKind.EPISODE,
+        token,
+    )
 
 
 def test_decode_rejects_missing_body() -> None:
     """A token with an empty body is not accepted."""
     assert_that(decode).raises(ValueError).when_called_with(
-        PODCAST_PREFIX,
+        IdentifierKind.PODCAST,
         "pod_",
     )
 
@@ -58,17 +57,17 @@ def test_decode_rejects_missing_body() -> None:
 def test_decode_rejects_non_base32_characters() -> None:
     """Uppercase or otherwise-invalid characters are rejected."""
     assert_that(decode).raises(ValueError).when_called_with(
-        PODCAST_PREFIX,
+        IdentifierKind.PODCAST,
         "pod_AE",
     )
     assert_that(decode).raises(ValueError).when_called_with(
-        PODCAST_PREFIX,
+        IdentifierKind.PODCAST,
         "pod_9!",
     )
 
 
-def test_prefixes_are_distinct() -> None:
-    """Every well-known prefix is unique so tokens never collide by mistake."""
-    prefixes = {PODCAST_PREFIX, EPISODE_PREFIX, MEDIA_PREFIX, MENTION_PREFIX}
-
-    assert_that(prefixes).is_length(4)
+def test_kinds_cover_expected_prefixes() -> None:
+    """The closed vocabulary exposes exactly the four public resource kinds."""
+    assert_that({str(kind) for kind in IdentifierKind}).is_equal_to(
+        {"pod", "epi", "med", "men"},
+    )

--- a/backend/tests/test_podcasts.py
+++ b/backend/tests/test_podcasts.py
@@ -4,7 +4,7 @@ from assertpy import assert_that
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from podex.api.v2.identifiers import PODCAST_PREFIX, encode
+from podex.api.v2.identifiers import IdentifierKind, encode
 from podex.models import Podcast
 
 
@@ -36,7 +36,7 @@ def test_list_and_get_podcast(client: TestClient, db_session: Session) -> None:
 
     podcast_id = body["items"][0]["id"]
     assert_that(body["items"][0]["public_id"]).is_equal_to(
-        encode(PODCAST_PREFIX, podcast_id),
+        encode(IdentifierKind.PODCAST, podcast_id),
     )
     fetched = client.get(f"/api/v2/podcasts/{podcast_id}")
     assert_that(fetched.status_code).is_equal_to(200)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `refactor(api): replace identifier prefix constants with an IdentifierKind StrEnum`

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The four loose `*_PREFIX` `Final` constants in `backend/src/podex/api/v2/identifiers.py` become a single `@unique IdentifierKind(StrEnum)` — the closed, enumerable vocabulary of public identifier kinds (per the stand-py StrEnum convention).

- `encode`/`decode` now take an `IdentifierKind` instead of an arbitrary `str`, so a typo'd kind is a type error rather than a runtime surprise; `@unique` rejects duplicate prefixes at import time. Runtime prefix validation is retained as defense in depth.
- Call sites in `schemas/{podcast,episode,media,mention}.py` and tests updated to `IdentifierKind.X`.
- `tests/test_identifiers.py`: the invalid-prefix and distinctness tests are recast against the enum (every member matches the allowed pattern; the vocabulary is exactly `pod`/`epi`/`med`/`men`).

No wire-format change — emitted tokens are byte-identical.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #234

## Details

Verified with `uv run lintro tst` (143 passed) and ruff/mypy/pydoclint clean on the touched files.