### PR TITLE
refactor(api): adopt RFC 9457 Problem Details for the v2 error envelope

### DIFF
--- a/backend/src/podex/api/v2/errors.py
+++ b/backend/src/podex/api/v2/errors.py
@@ -1,24 +1,32 @@
 """Exception handlers that normalise ``/api/v2`` error bodies.
 
-The v2 surface returns a single error envelope shape (see
-:class:`podex.api.v2.schemas.ErrorResponse`) for every failure mode: 404 from
-missing resources, 422 from request validation, 429 from the rate limiter,
-and 500 from unhandled server errors. The handlers preserve the original
-status code and any response headers that FastAPI or middleware attached
+The v2 surface returns an RFC 9457 problem-details body (see
+:class:`podex.api.v2.schemas.ProblemDetails`, served as
+``application/problem+json``) for every failure mode: 404 from missing
+resources, 422 from request validation, 429 from the rate limiter, and 500
+from unhandled server errors. The handlers preserve the original status code
+and any response headers that FastAPI or middleware attached
 (``WWW-Authenticate``, ``Retry-After``, ``X-RateLimit-*``, ...) while
-replacing the body with the standardised envelope.
+replacing the body with the standardised shape.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from http import HTTPStatus
+from typing import Any, Final
 
 from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
-from podex.api.v2.schemas import ErrorBody, ErrorDetail, ErrorResponse
+from podex.api.v2.schemas import ErrorDetail, ProblemDetails
+
+PROBLEM_JSON_MEDIA_TYPE: Final = "application/problem+json"
+"""The RFC 9457 media type every v2 error response is served with."""
+
+PROBLEM_TYPE_BASE: Final = "https://podex.example/problems/"
+"""Base URI for problem ``type`` members; the code slug is appended."""
 
 STATUS_CODE_TO_ERROR_CODE: dict[int, str] = {
     status.HTTP_400_BAD_REQUEST: "bad_request",
@@ -49,6 +57,55 @@ def error_code_for_status(status_code: int) -> str:
     return STATUS_CODE_TO_ERROR_CODE.get(status_code, f"http_{status_code}")
 
 
+def _title_for_status(status_code: int) -> str:
+    """Return the HTTP reason phrase for ``status_code``.
+
+    Args:
+        status_code: The response status code being reported.
+
+    Returns:
+        The standard reason phrase, or ``"Error"`` for unregistered codes.
+    """
+    try:
+        return HTTPStatus(status_code).phrase
+    except ValueError:
+        return "Error"
+
+
+def build_problem(
+    *,
+    status_code: int,
+    detail: str | None,
+    code: str | None = None,
+    request_id: str | None = None,
+    errors: list[ErrorDetail] | None = None,
+) -> ProblemDetails:
+    """Construct the RFC 9457 body shared by handlers and middleware.
+
+    Args:
+        status_code: The HTTP status of this occurrence.
+        detail: Occurrence-specific human-readable explanation, or ``None``
+            when the ``title`` alone suffices.
+        code: An override for the machine-readable code; defaults to the
+            canonical code for ``status_code``.
+        request_id: The request id to echo for log correlation.
+        errors: Optional per-field validation breakdown.
+
+    Returns:
+        The populated :class:`ProblemDetails` model.
+    """
+    resolved_code = code or error_code_for_status(status_code)
+    return ProblemDetails(
+        type=f"{PROBLEM_TYPE_BASE}{resolved_code}",
+        title=_title_for_status(status_code),
+        status=status_code,
+        detail=detail or None,
+        code=resolved_code,
+        request_id=request_id,
+        errors=errors,
+    )
+
+
 def _request_id(request: Request) -> str | None:
     """Return the request id set by the request-context middleware, if any."""
     return getattr(request.state, "request_id", None)
@@ -57,38 +114,39 @@ def _request_id(request: Request) -> str | None:
 def build_error_response(
     *,
     status_code: int,
-    message: str,
+    detail: str | None,
     request: Request,
     code: str | None = None,
-    details: list[ErrorDetail] | None = None,
+    errors: list[ErrorDetail] | None = None,
     headers: dict[str, str] | None = None,
 ) -> JSONResponse:
-    """Construct a :class:`JSONResponse` wrapping an :class:`ErrorResponse`.
+    """Construct a problem-details :class:`JSONResponse`.
 
     Args:
         status_code: The HTTP status to return.
-        message: The human-readable summary.
+        detail: The occurrence-specific human-readable explanation.
         request: The active request (used to source the request id).
         code: An override for the machine-readable code; defaults to the
             canonical code for ``status_code``.
-        details: Optional per-field validation details.
+        errors: Optional per-field validation details.
         headers: Optional response headers to preserve on the reply.
 
     Returns:
-        A JSON response carrying the standard v2 error envelope.
+        A JSON response carrying the RFC 9457 body with the
+        ``application/problem+json`` media type.
     """
-    payload = ErrorResponse(
-        error=ErrorBody(
-            code=code or error_code_for_status(status_code),
-            message=message,
-            request_id=_request_id(request),
-            details=details,
-        ),
+    payload = build_problem(
+        status_code=status_code,
+        detail=detail,
+        code=code,
+        request_id=_request_id(request),
+        errors=errors,
     )
     return JSONResponse(
         status_code=status_code,
         content=payload.model_dump(exclude_none=True),
         headers=headers,
+        media_type=PROBLEM_JSON_MEDIA_TYPE,
     )
 
 
@@ -96,33 +154,31 @@ async def http_exception_handler(
     request: Request,
     exc: HTTPException,
 ) -> JSONResponse:
-    """Wrap ``HTTPException.detail`` into the v2 error envelope."""
-    detail: Any = exc.detail
-    message: str
-    details: list[ErrorDetail] | None = None
+    """Wrap ``HTTPException.detail`` into the problem-details body."""
+    raw: Any = exc.detail
+    detail: str | None
+    errors: list[ErrorDetail] | None = None
     code: str | None = None
-    if isinstance(detail, dict):
-        message = str(detail.get("message") or detail.get("detail") or "")
-        raw_code = detail.get("code")
+    if isinstance(raw, dict):
+        detail = str(raw.get("message") or raw.get("detail") or "") or None
+        raw_code = raw.get("code")
         if isinstance(raw_code, str):
             code = raw_code
-        raw_details = detail.get("details")
+        raw_details = raw.get("details")
         if isinstance(raw_details, list):
-            details = [
+            errors = [
                 ErrorDetail.model_validate(item)
                 for item in raw_details
                 if isinstance(item, dict)
             ]
     else:
-        message = str(detail) if detail is not None else ""
-    if not message:
-        message = error_code_for_status(exc.status_code).replace("_", " ")
+        detail = str(raw) if raw is not None else None
     return build_error_response(
         status_code=exc.status_code,
-        message=message,
+        detail=detail,
         request=request,
         code=code,
-        details=details,
+        errors=errors,
         headers=dict(exc.headers) if exc.headers else None,
     )
 
@@ -131,15 +187,15 @@ async def validation_exception_handler(
     request: Request,
     exc: RequestValidationError,
 ) -> JSONResponse:
-    """Wrap ``RequestValidationError`` into the v2 error envelope."""
+    """Wrap ``RequestValidationError`` into the problem-details body."""
     raw_errors = jsonable_encoder(exc.errors())
-    details: list[ErrorDetail] = []
+    errors: list[ErrorDetail] = []
     for item in raw_errors:
         if not isinstance(item, dict):
             continue
         loc_value = item.get("loc") or []
         loc = [part for part in loc_value if isinstance(part, str | int)]
-        details.append(
+        errors.append(
             ErrorDetail(
                 loc=loc,
                 msg=str(item.get("msg", "")),
@@ -148,9 +204,9 @@ async def validation_exception_handler(
         )
     return build_error_response(
         status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-        message="Request validation failed.",
+        detail="Request validation failed.",
         request=request,
-        details=details,
+        errors=errors,
     )
 
 
@@ -158,11 +214,11 @@ async def unhandled_exception_handler(
     request: Request,
     exc: Exception,
 ) -> JSONResponse:
-    """Return an opaque 500 envelope for otherwise unhandled exceptions."""
+    """Return an opaque 500 problem body for otherwise unhandled exceptions."""
     del exc
     return build_error_response(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        message="Internal server error.",
+        detail="Internal server error.",
         request=request,
     )
 

--- a/backend/src/podex/api/v2/schemas.py
+++ b/backend/src/podex/api/v2/schemas.py
@@ -4,8 +4,9 @@ Every list endpoint under ``/api/v2`` accepts the same ``limit``/``offset``
 query parameters (see :class:`PaginationParams`) and returns a
 :class:`Page` envelope so that clients can page uniformly and know the total
 count without an extra round-trip. Errors returned by the v2 surface are
-wrapped in :class:`ErrorResponse` with a machine-readable ``code`` and the
-request id, so callers can correlate failures with server logs.
+RFC 9457 problem-details bodies (see :class:`ProblemDetails`) carrying a
+machine-readable ``code`` and the request id, so callers can correlate
+failures with server logs.
 """
 
 from __future__ import annotations
@@ -106,29 +107,31 @@ class ErrorDetail(BaseModel):
     type: str
 
 
-class ErrorBody(BaseModel):
-    """The ``error`` object embedded in an :class:`ErrorResponse`.
+class ProblemDetails(BaseModel):
+    """RFC 9457 problem-details body returned by ``/api/v2`` failures.
+
+    Serialized with ``Content-Type: application/problem+json``. The first
+    four attributes are the standard RFC 9457 members; ``code``,
+    ``request_id`` and ``errors`` are podex extension members.
 
     Attributes:
+        type: A URI reference identifying the problem type.
+        title: Short human-readable summary of the problem type (the HTTP
+            reason phrase).
+        status: The HTTP status code of this occurrence.
+        detail: Human-readable explanation specific to this occurrence,
+            safe to surface to end users.
         code: A stable, machine-readable error code (e.g. ``"not_found"``).
-        message: Human-readable summary safe to surface to end users.
         request_id: The request id assigned by the request-context middleware,
             for cross-referencing with server logs.
-        details: Optional field-level breakdown, populated for validation
+        errors: Optional field-level breakdown, populated for validation
             failures.
     """
 
+    type: str
+    title: str
+    status: int
+    detail: str | None = None
     code: str
-    message: str
     request_id: str | None = None
-    details: list[ErrorDetail] | None = None
-
-
-class ErrorResponse(BaseModel):
-    """The uniform error envelope returned by ``/api/v2`` failures.
-
-    Attributes:
-        error: The :class:`ErrorBody` describing the failure.
-    """
-
-    error: ErrorBody
+    errors: list[ErrorDetail] | None = None

--- a/backend/src/podex/middleware.py
+++ b/backend/src/podex/middleware.py
@@ -9,8 +9,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
-from podex.api.v2.errors import error_code_for_status
-from podex.api.v2.schemas import ErrorBody, ErrorResponse
+from podex.api.v2.errors import PROBLEM_JSON_MEDIA_TYPE, build_problem
 from podex.logging_config import get_logger
 from podex.services.limiter import RateLimiter
 
@@ -167,17 +166,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             retry_after = math.ceil(decision.retry_after)
             headers["Retry-After"] = str(retry_after)
             request_id = getattr(request.state, "request_id", None)
-            envelope = ErrorResponse(
-                error=ErrorBody(
-                    code=error_code_for_status(429),
-                    message=RATE_LIMIT_MESSAGE,
-                    request_id=request_id,
-                ),
+            problem = build_problem(
+                status_code=429,
+                detail=RATE_LIMIT_MESSAGE,
+                request_id=request_id,
             )
             return JSONResponse(
                 status_code=429,
-                content=envelope.model_dump(exclude_none=True),
+                content=problem.model_dump(exclude_none=True),
                 headers=headers,
+                media_type=PROBLEM_JSON_MEDIA_TYPE,
             )
 
         response = await call_next(request)

--- a/backend/tests/test_acceptance_catalog.py
+++ b/backend/tests/test_acceptance_catalog.py
@@ -196,10 +196,10 @@ def test_not_found_responses_use_error_envelope(client: TestClient) -> None:
         response = client.get(path)
         assert_that(response.status_code).is_equal_to(404)
         body = response.json()
-        assert_that(body).contains_key("error")
-        error = body["error"]
+        assert_that(body).contains_key("title")
+        error = body
         assert_that(error["code"]).is_equal_to("not_found")
-        assert_that(error["message"]).is_instance_of(str)
+        assert_that(error["detail"]).is_instance_of(str)
         assert_that(error["request_id"]).is_not_empty()
 
 

--- a/backend/tests/test_api_smoke.py
+++ b/backend/tests/test_api_smoke.py
@@ -53,9 +53,9 @@ def test_podcast_resource_smoke(client: TestClient, seeded_graph: SeededGraph) -
 
     missing = client.get("/api/v2/podcasts/999")
     assert_that(missing.status_code).is_equal_to(404)
-    error = missing.json()["error"]
+    error = missing.json()
     assert_that(error["code"]).is_equal_to("not_found")
-    assert_that(error["message"]).is_equal_to("Podcast not found")
+    assert_that(error["detail"]).is_equal_to("Podcast not found")
 
 
 def test_episode_resource_smoke(client: TestClient, seeded_graph: SeededGraph) -> None:
@@ -94,13 +94,13 @@ def test_episode_resource_smoke(client: TestClient, seeded_graph: SeededGraph) -
 
     missing = client.get("/api/v2/episodes/999")
     assert_that(missing.status_code).is_equal_to(404)
-    error = missing.json()["error"]
+    error = missing.json()
     assert_that(error["code"]).is_equal_to("not_found")
-    assert_that(error["message"]).is_equal_to("Episode not found")
+    assert_that(error["detail"]).is_equal_to("Episode not found")
 
     missing_mentions = client.get("/api/v2/episodes/999/mentions")
     assert_that(missing_mentions.status_code).is_equal_to(404)
-    assert_that(missing_mentions.json()["error"]["code"]).is_equal_to("not_found")
+    assert_that(missing_mentions.json()["code"]).is_equal_to("not_found")
 
 
 def test_media_resource_smoke(client: TestClient, seeded_graph: SeededGraph) -> None:
@@ -134,13 +134,13 @@ def test_media_resource_smoke(client: TestClient, seeded_graph: SeededGraph) -> 
 
     missing = client.get("/api/v2/media/999")
     assert_that(missing.status_code).is_equal_to(404)
-    error = missing.json()["error"]
+    error = missing.json()
     assert_that(error["code"]).is_equal_to("not_found")
-    assert_that(error["message"]).is_equal_to("Media not found")
+    assert_that(error["detail"]).is_equal_to("Media not found")
 
     missing_mentions = client.get("/api/v2/media/999/mentions")
     assert_that(missing_mentions.status_code).is_equal_to(404)
-    assert_that(missing_mentions.json()["error"]["code"]).is_equal_to("not_found")
+    assert_that(missing_mentions.json()["code"]).is_equal_to("not_found")
 
 
 def test_full_graph_walk_via_http(

--- a/backend/tests/test_episodes.py
+++ b/backend/tests/test_episodes.py
@@ -111,5 +111,5 @@ def test_get_episode_not_found(client: TestClient) -> None:
 
     assert_that(response.status_code).is_equal_to(404)
     body = response.json()
-    assert_that(body["error"]["code"]).is_equal_to("not_found")
-    assert_that(body["error"]["message"]).is_equal_to("Episode not found")
+    assert_that(body["code"]).is_equal_to("not_found")
+    assert_that(body["detail"]).is_equal_to("Episode not found")

--- a/backend/tests/test_error_envelope.py
+++ b/backend/tests/test_error_envelope.py
@@ -1,4 +1,4 @@
-"""Tests for the unified v2 error envelope."""
+"""Tests for the v2 RFC 9457 problem-details error bodies."""
 
 import logging
 
@@ -7,6 +7,8 @@ from assertpy import assert_that
 from fastapi.testclient import TestClient
 
 from podex.api.v2.errors import (
+    PROBLEM_JSON_MEDIA_TYPE,
+    PROBLEM_TYPE_BASE,
     STATUS_CODE_TO_ERROR_CODE,
     error_code_for_status,
 )
@@ -15,17 +17,21 @@ from podex.main import create_app
 from podex.middleware import REQUEST_ID_HEADER
 
 
-def test_not_found_returns_error_envelope(client: TestClient) -> None:
-    """404 responses use the standard envelope with ``not_found`` code."""
+def test_not_found_returns_problem_details(client: TestClient) -> None:
+    """404 responses use the RFC 9457 body with the ``not_found`` code."""
     response = client.get("/api/v2/podcasts/9999")
 
     assert_that(response.status_code).is_equal_to(404)
+    assert_that(response.headers["content-type"]).is_equal_to(
+        PROBLEM_JSON_MEDIA_TYPE,
+    )
     body = response.json()
-    assert_that(body).contains_key("error")
-    error = body["error"]
-    assert_that(error["code"]).is_equal_to("not_found")
-    assert_that(error["message"]).is_equal_to("Podcast not found")
-    assert_that(error["request_id"]).is_equal_to(response.headers[REQUEST_ID_HEADER])
+    assert_that(body["type"]).is_equal_to(f"{PROBLEM_TYPE_BASE}not_found")
+    assert_that(body["title"]).is_equal_to("Not Found")
+    assert_that(body["status"]).is_equal_to(404)
+    assert_that(body["code"]).is_equal_to("not_found")
+    assert_that(body["detail"]).is_equal_to("Podcast not found")
+    assert_that(body["request_id"]).is_equal_to(response.headers[REQUEST_ID_HEADER])
 
 
 def test_validation_error_returns_details(client: TestClient) -> None:
@@ -33,10 +39,14 @@ def test_validation_error_returns_details(client: TestClient) -> None:
     response = client.get("/api/v2/podcasts", params={"limit": 0})
 
     assert_that(response.status_code).is_equal_to(422)
+    assert_that(response.headers["content-type"]).is_equal_to(
+        PROBLEM_JSON_MEDIA_TYPE,
+    )
     body = response.json()
-    assert_that(body["error"]["code"]).is_equal_to("unprocessable_entity")
-    assert_that(body["error"]["details"]).is_not_empty()
-    loc_paths = [tuple(item["loc"]) for item in body["error"]["details"]]
+    assert_that(body["status"]).is_equal_to(422)
+    assert_that(body["code"]).is_equal_to("unprocessable_entity")
+    assert_that(body["errors"]).is_not_empty()
+    loc_paths = [tuple(item["loc"]) for item in body["errors"]]
     assert_that(loc_paths).contains(("query", "limit"))
 
 
@@ -58,9 +68,9 @@ def test_unhandled_exception_returns_500_envelope(
 
     assert_that(response.status_code).is_equal_to(500)
     body = response.json()
-    assert_that(body["error"]["code"]).is_equal_to("internal_server_error")
-    assert_that(body["error"]["message"]).is_equal_to("Internal server error.")
-    assert_that(body["error"]["request_id"]).is_equal_to("err-1")
+    assert_that(body["code"]).is_equal_to("internal_server_error")
+    assert_that(body["detail"]).is_equal_to("Internal server error.")
+    assert_that(body["request_id"]).is_equal_to("err-1")
 
 
 def test_error_code_for_status_uses_registered_map() -> None:
@@ -104,7 +114,7 @@ def test_http_exception_with_structured_detail_preserves_code(
         response = test_client.get("/custom-conflict")
 
     assert_that(response.status_code).is_equal_to(409)
-    error = response.json()["error"]
+    error = response.json()
     assert_that(error["code"]).is_equal_to("custom_conflict")
-    assert_that(error["message"]).is_equal_to("already exists")
-    assert_that(error["details"][0]["loc"]).is_equal_to(["body", "slug"])
+    assert_that(error["detail"]).is_equal_to("already exists")
+    assert_that(error["errors"][0]["loc"]).is_equal_to(["body", "slug"])

--- a/backend/tests/test_media.py
+++ b/backend/tests/test_media.py
@@ -57,5 +57,5 @@ def test_get_media_not_found(client: TestClient) -> None:
 
     assert_that(response.status_code).is_equal_to(404)
     body = response.json()
-    assert_that(body["error"]["code"]).is_equal_to("not_found")
-    assert_that(body["error"]["message"]).is_equal_to("Media not found")
+    assert_that(body["code"]).is_equal_to("not_found")
+    assert_that(body["detail"]).is_equal_to("Media not found")

--- a/backend/tests/test_mentions.py
+++ b/backend/tests/test_mentions.py
@@ -89,7 +89,7 @@ def test_episode_mentions_not_found(client: TestClient) -> None:
     response = client.get("/api/v2/episodes/999/mentions")
 
     assert_that(response.status_code).is_equal_to(404)
-    assert_that(response.json()["error"]["code"]).is_equal_to("not_found")
+    assert_that(response.json()["code"]).is_equal_to("not_found")
 
 
 def test_media_mentions_not_found(client: TestClient) -> None:
@@ -97,4 +97,4 @@ def test_media_mentions_not_found(client: TestClient) -> None:
     response = client.get("/api/v2/media/999/mentions")
 
     assert_that(response.status_code).is_equal_to(404)
-    assert_that(response.json()["error"]["code"]).is_equal_to("not_found")
+    assert_that(response.json()["code"]).is_equal_to("not_found")

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -84,9 +84,14 @@ def test_blocks_requests_over_limit_with_429(tight_client: TestClient) -> None:
     assert_that(blocked.headers).contains_key("Retry-After")
     assert_that(blocked.headers["X-RateLimit-Remaining"]).is_equal_to("0")
     body = blocked.json()
-    assert_that(body["error"]["code"]).is_equal_to("rate_limited")
-    assert_that(body["error"]["message"]).contains("Rate limit")
-    assert_that(body["error"]["request_id"]).is_equal_to(
+    assert_that(blocked.headers["content-type"]).is_equal_to(
+        "application/problem+json",
+    )
+    assert_that(body["status"]).is_equal_to(429)
+    assert_that(body["title"]).is_equal_to("Too Many Requests")
+    assert_that(body["code"]).is_equal_to("rate_limited")
+    assert_that(body["detail"]).contains("Rate limit")
+    assert_that(body["request_id"]).is_equal_to(
         blocked.headers[REQUEST_ID_HEADER],
     )
     assert_that(blocked.headers).contains_key(REQUEST_ID_HEADER)
@@ -199,7 +204,7 @@ def test_middleware_works_with_redis_backed_limiter(
     assert_that(second.status_code).is_equal_to(200)
     assert_that(third.status_code).is_equal_to(429)
     assert_that(third.headers).contains_key("Retry-After")
-    assert_that(third.json()["error"]["code"]).is_equal_to("rate_limited")
+    assert_that(third.json()["code"]).is_equal_to("rate_limited")
 
 
 def test_access_log_records_request_details(

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -63,8 +63,8 @@ def test_pagination_rejects_out_of_range_limit(client: TestClient) -> None:
 
     assert_that(response.status_code).is_equal_to(422)
     body = response.json()
-    assert_that(body["error"]["code"]).is_equal_to("unprocessable_entity")
-    loc_paths = [tuple(item["loc"]) for item in body["error"]["details"]]
+    assert_that(body["code"]).is_equal_to("unprocessable_entity")
+    loc_paths = [tuple(item["loc"]) for item in body["errors"]]
     assert_that(loc_paths).contains(("query", "limit"))
 
 
@@ -74,7 +74,7 @@ def test_pagination_rejects_negative_offset(client: TestClient) -> None:
 
     assert_that(response.status_code).is_equal_to(422)
     body = response.json()
-    assert_that(body["error"]["code"]).is_equal_to("unprocessable_entity")
+    assert_that(body["code"]).is_equal_to("unprocessable_entity")
 
 
 def test_pagination_applies_to_episode_and_media_lists(

--- a/backend/tests/test_podcasts.py
+++ b/backend/tests/test_podcasts.py
@@ -49,6 +49,6 @@ def test_get_podcast_not_found(client: TestClient) -> None:
 
     assert_that(response.status_code).is_equal_to(404)
     body = response.json()
-    assert_that(body["error"]["code"]).is_equal_to("not_found")
-    assert_that(body["error"]["message"]).is_equal_to("Podcast not found")
-    assert_that(body["error"]["request_id"]).is_not_empty()
+    assert_that(body["code"]).is_equal_to("not_found")
+    assert_that(body["detail"]).is_equal_to("Podcast not found")
+    assert_that(body["request_id"]).is_not_empty()

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,17 +6,21 @@ export type Podcast = components["schemas"]["PodcastRead"];
 /** A single page of podcasts returned by the v2 list endpoint. */
 export type PodcastPage = components["schemas"]["Page_PodcastRead_"];
 
-/** The uniform error envelope returned by ``/api/v2`` failures. */
-export type ApiError = {
+/**
+ * The RFC 9457 problem-details body returned by `/api/v2` failures, served
+ * as `application/problem+json`. `type`, `title`, `status`, and `detail` are
+ * standard members; `code`, `request_id`, and `errors` are podex extensions.
+ */
+export type ApiProblem = {
+  type: string;
+  title: string;
+  status: number;
+  detail?: string | null;
   code: string;
-  message: string;
   request_id?: string | null;
-  details?: {
+  errors?: {
     loc: (string | number)[];
     msg: string;
     type: string;
   }[];
 };
-
-/** The wrapper carrying an :class:`ApiError` body from ``/api/v2``. */
-export type ApiErrorResponse = { error: ApiError };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `refactor(api): adopt RFC 9457 Problem Details for the v2 error envelope`

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Replaces the bespoke `{"error": {code, message, request_id, details}}` envelope with a flat [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) problem-details body served as `application/problem+json`, implemented in-house (no new dependency):

```json
{
  "type": "https://podex.example/problems/rate_limited",
  "title": "Too Many Requests",
  "status": 429,
  "detail": "Rate limit exceeded. Try again later.",
  "code": "rate_limited",
  "request_id": "req_abc123",
  "errors": [{"loc": ["query", "limit"], "msg": "...", "type": "..."}]
}
```

- `schemas.py`: `ErrorBody`/`ErrorResponse` → `ProblemDetails` (standard members + `code`/`request_id`/`errors` extensions).
- `errors.py`: new shared `build_problem` constructor; handlers emit the flat body with the problem media type; `title` is the HTTP reason phrase, `type` is `https://podex.example/problems/<code>` (RFC 2606 placeholder domain per the repo boundary rules).
- `middleware.py`: the rate-limit 429 path now uses the same `build_problem` instead of hand-rolling the envelope.
- Frontend `types.ts`: `ApiError`/`ApiErrorResponse` collapse into one `ApiProblem` type. `types.gen.ts` unchanged (error models are not referenced by the OpenAPI snapshot).
- Tests across the suite updated to the flat shape; error tests now also pin the media type and the standard `type`/`title`/`status` members.

Deliberately **not** marked as a semver-major: the API is pre-alpha and the in-repo frontend is the only consumer — doing this now is exactly why #235 exists ("cheap reshape now, breaking change later").

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #235

## Details

Verified: `uv run lintro tst` (145 passed), ruff/mypy/pydoclint clean; frontend `astro check` 0 errors, `vitest run` 34 passed, `check:api` type regeneration produces no diff.