### PR TITLE
feat(models): add IngestionRun audit model and migration

### DIFF
--- a/backend/alembic/versions/0003_add_ingestion_runs.py
+++ b/backend/alembic/versions/0003_add_ingestion_runs.py
@@ -1,0 +1,54 @@
+"""Add the ingestion_runs table.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-07-18 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_STATUSES = ("running", "completed", "failed")
+
+
+def upgrade() -> None:
+    """Create the ingestion_runs audit table."""
+    op.create_table(
+        "ingestion_runs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(*_STATUSES, native_enum=False, length=32),
+            nullable=False,
+        ),
+        sa.Column("error_summary", sa.Text(), nullable=True),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_ingestion_runs_status", "ingestion_runs", ["status"])
+
+
+def downgrade() -> None:
+    """Drop the ingestion_runs table."""
+    op.drop_index("ix_ingestion_runs_status", table_name="ingestion_runs")
+    op.drop_table("ingestion_runs")

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -6,8 +6,18 @@ metadata-based table creation and Alembic autogenerate see every table.
 
 from podex.models.base import Base
 from podex.models.episode import Episode
+from podex.models.ingestion_run import IngestionRun, IngestionRunStatus
 from podex.models.media import Media, MediaType
 from podex.models.mention import Mention
 from podex.models.podcast import Podcast
 
-__all__ = ["Base", "Episode", "Media", "MediaType", "Mention", "Podcast"]
+__all__ = [
+    "Base",
+    "Episode",
+    "IngestionRun",
+    "IngestionRunStatus",
+    "Media",
+    "MediaType",
+    "Mention",
+    "Podcast",
+]

--- a/backend/src/podex/models/ingestion_run.py
+++ b/backend/src/podex/models/ingestion_run.py
@@ -1,0 +1,48 @@
+"""Ingestion run ORM model."""
+
+from datetime import datetime
+from enum import StrEnum, auto
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class IngestionRunStatus(StrEnum):
+    """Lifecycle state of an ingestion pipeline run."""
+
+    RUNNING = auto()
+    COMPLETED = auto()
+    FAILED = auto()
+
+
+class IngestionRun(Base):
+    """A single execution of the discovery/ingestion pipeline.
+
+    Rows give ingest jobs an auditable history: when each run started, how
+    it ended, and a short error summary when it failed. Discovery and
+    recurring-ingest services record one row per run.
+    """
+
+    __tablename__ = "ingestion_runs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    status: Mapped[IngestionRunStatus] = mapped_column(
+        SAEnum(IngestionRunStatus, native_enum=False, length=32),
+        index=True,
+    )
+    error_summary: Mapped[str | None] = mapped_column(Text, default=None)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        default=None,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )

--- a/backend/tests/test_ingestion_runs.py
+++ b/backend/tests/test_ingestion_runs.py
@@ -1,0 +1,46 @@
+"""Tests for the ingestion run model."""
+
+from datetime import datetime
+
+from assertpy import assert_that
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.models import IngestionRun, IngestionRunStatus
+
+
+def test_create_ingestion_run(db_session: Session) -> None:
+    """A completed run round-trips its status, timestamps, and summary."""
+    started_at = datetime(2026, 2, 3)
+    completed_at = datetime(2026, 2, 3, 1)
+
+    run = IngestionRun(
+        status=IngestionRunStatus.COMPLETED,
+        error_summary=None,
+        started_at=started_at,
+        completed_at=completed_at,
+    )
+    db_session.add(run)
+    db_session.commit()
+
+    stored = db_session.execute(select(IngestionRun)).scalar_one()
+    assert_that(stored.status).is_equal_to(IngestionRunStatus.COMPLETED)
+    assert_that(stored.error_summary).is_none()
+    assert_that(stored.started_at).is_equal_to(started_at)
+    assert_that(stored.completed_at).is_equal_to(completed_at)
+    assert_that(stored.created_at).is_not_none()
+
+
+def test_failed_run_records_error_summary(db_session: Session) -> None:
+    """A failed run keeps its error summary and stays open-ended."""
+    run = IngestionRun(
+        status=IngestionRunStatus.FAILED,
+        error_summary="feed fetch timed out",
+    )
+    db_session.add(run)
+    db_session.commit()
+
+    stored = db_session.execute(select(IngestionRun)).scalar_one()
+    assert_that(stored.status).is_equal_to(IngestionRunStatus.FAILED)
+    assert_that(stored.error_summary).is_equal_to("feed fetch timed out")
+    assert_that(stored.completed_at).is_none()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(models): add IngestionRun audit model and migration`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

First slice of the discovery/ingest theme from the #108 split (source: the #103 branch, re-authored to main's conventions):

- `models/ingestion_run.py`: `IngestionRun` ORM model — one row per pipeline run with a `running/completed/failed` `IngestionRunStatus` StrEnum (stored `native_enum=False`, matching `MediaType`), tz-aware timestamps with `server_default=func.now()`, and a nullable `error_summary`.
- `alembic/versions/0003_add_ingestion_runs.py`: matching migration with clean up/down, renumbered into main's sequence (branch original was `003_add_ingestion_runs` against a divergent chain).
- `tests/test_ingestion_runs.py`: round-trip and failure-path coverage; the existing migration replay + schema-drift guard validates model↔migration parity.

Discovery providers, the dedup orchestrator (#65), and recurring ingest (#11) build on this in the next slices.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #65
- Relates to #108

## Details

Verified: `uv run lintro tst` (147 passed, including the Alembic replay/drift guard) and ruff/mypy/pydoclint clean.