### PR TITLE
feat(models): add discovery-tracking columns for cross-provider dedup

### DIFF
--- a/backend/alembic/versions/0004_add_discovery_tracking.py
+++ b/backend/alembic/versions/0004_add_discovery_tracking.py
@@ -1,0 +1,94 @@
+"""Add discovery-tracking columns to podcasts and episodes.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-07-18 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0004"
+down_revision: str | None = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SOURCES = ("podscripts", "rss", "youtube", "spotify", "apple", "manual")
+
+
+def _source_enum() -> sa.Enum:
+    """Return the non-native enum type shared by both discovery columns."""
+    return sa.Enum(*_SOURCES, native_enum=False, length=50)
+
+
+def upgrade() -> None:
+    """Add provider handles, source ids, and dedup indexes."""
+    op.add_column("podcasts", sa.Column("rss_url", sa.String(500), nullable=True))
+    op.add_column("podcasts", sa.Column("spotify_id", sa.String(50), nullable=True))
+    op.add_column("podcasts", sa.Column("apple_id", sa.String(50), nullable=True))
+    op.add_column(
+        "podcasts",
+        sa.Column("youtube_channel_id", sa.String(30), nullable=True),
+    )
+    op.add_column(
+        "podcasts",
+        sa.Column("podscripts_slug", sa.String(100), nullable=True),
+    )
+    op.add_column(
+        "podcasts",
+        sa.Column("discovery_source", _source_enum(), nullable=True),
+    )
+
+    op.add_column(
+        "episodes",
+        sa.Column("duration_seconds", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "episodes",
+        sa.Column("thumbnail_url", sa.String(1000), nullable=True),
+    )
+    op.add_column("episodes", sa.Column("youtube_id", sa.String(20), nullable=True))
+    op.add_column("episodes", sa.Column("spotify_uri", sa.String(50), nullable=True))
+    op.add_column("episodes", sa.Column("apple_id", sa.String(50), nullable=True))
+    op.add_column("episodes", sa.Column("rss_guid", sa.String(500), nullable=True))
+    op.add_column("episodes", sa.Column("episode_url", sa.String(500), nullable=True))
+    op.add_column(
+        "episodes",
+        sa.Column("discovery_source", _source_enum(), nullable=True),
+    )
+
+    op.create_index("ix_podcasts_rss_url", "podcasts", ["rss_url"])
+    op.create_index("ix_podcasts_spotify_id", "podcasts", ["spotify_id"])
+    op.create_index("ix_podcasts_podscripts_slug", "podcasts", ["podscripts_slug"])
+    op.create_index("ix_episodes_youtube_id", "episodes", ["youtube_id"])
+    op.create_index("ix_episodes_spotify_uri", "episodes", ["spotify_uri"])
+    op.create_index("ix_episodes_rss_guid", "episodes", ["rss_guid"])
+
+
+def downgrade() -> None:
+    """Remove discovery-tracking columns and their indexes."""
+    op.drop_index("ix_episodes_rss_guid", table_name="episodes")
+    op.drop_index("ix_episodes_spotify_uri", table_name="episodes")
+    op.drop_index("ix_episodes_youtube_id", table_name="episodes")
+    op.drop_index("ix_podcasts_podscripts_slug", table_name="podcasts")
+    op.drop_index("ix_podcasts_spotify_id", table_name="podcasts")
+    op.drop_index("ix_podcasts_rss_url", table_name="podcasts")
+
+    op.drop_column("episodes", "discovery_source")
+    op.drop_column("episodes", "episode_url")
+    op.drop_column("episodes", "rss_guid")
+    op.drop_column("episodes", "apple_id")
+    op.drop_column("episodes", "spotify_uri")
+    op.drop_column("episodes", "youtube_id")
+    op.drop_column("episodes", "thumbnail_url")
+    op.drop_column("episodes", "duration_seconds")
+
+    op.drop_column("podcasts", "discovery_source")
+    op.drop_column("podcasts", "podscripts_slug")
+    op.drop_column("podcasts", "youtube_channel_id")
+    op.drop_column("podcasts", "apple_id")
+    op.drop_column("podcasts", "spotify_id")
+    op.drop_column("podcasts", "rss_url")

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -5,7 +5,7 @@ metadata-based table creation and Alembic autogenerate see every table.
 """
 
 from podex.models.base import Base
-from podex.models.episode import Episode
+from podex.models.episode import DiscoverySource, Episode
 from podex.models.ingestion_run import IngestionRun, IngestionRunStatus
 from podex.models.media import Media, MediaType
 from podex.models.mention import Mention
@@ -13,6 +13,7 @@ from podex.models.podcast import Podcast
 
 __all__ = [
     "Base",
+    "DiscoverySource",
     "Episode",
     "IngestionRun",
     "IngestionRunStatus",

--- a/backend/src/podex/models/episode.py
+++ b/backend/src/podex/models/episode.py
@@ -1,11 +1,24 @@
 """Episode ORM model."""
 
 from datetime import datetime
+from enum import StrEnum, auto
 
 from sqlalchemy import DateTime, ForeignKey, Index, String, func
+from sqlalchemy import Enum as SAEnum
 from sqlalchemy.orm import Mapped, mapped_column
 
 from podex.models.base import Base
+
+
+class DiscoverySource(StrEnum):
+    """Where an episode or podcast was first discovered."""
+
+    PODSCRIPTS = auto()
+    RSS = auto()
+    YOUTUBE = auto()
+    SPOTIFY = auto()
+    APPLE = auto()
+    MANUAL = auto()
 
 
 class Episode(Base):
@@ -27,6 +40,30 @@ class Episode(Base):
     episode_number: Mapped[int | None] = mapped_column(default=None)
     published_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
+        default=None,
+    )
+    duration_seconds: Mapped[int | None] = mapped_column(default=None)
+    thumbnail_url: Mapped[str | None] = mapped_column(String(1000), default=None)
+    # Source-specific identifiers used for cross-provider deduplication.
+    youtube_id: Mapped[str | None] = mapped_column(
+        String(20),
+        index=True,
+        default=None,
+    )
+    spotify_uri: Mapped[str | None] = mapped_column(
+        String(50),
+        index=True,
+        default=None,
+    )
+    apple_id: Mapped[str | None] = mapped_column(String(50), default=None)
+    rss_guid: Mapped[str | None] = mapped_column(
+        String(500),
+        index=True,
+        default=None,
+    )
+    episode_url: Mapped[str | None] = mapped_column(String(500), default=None)
+    discovery_source: Mapped[DiscoverySource | None] = mapped_column(
+        SAEnum(DiscoverySource, native_enum=False, length=50),
         default=None,
     )
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/podex/models/podcast.py
+++ b/backend/src/podex/models/podcast.py
@@ -3,9 +3,11 @@
 from datetime import datetime
 
 from sqlalchemy import DateTime, String, func
+from sqlalchemy import Enum as SAEnum
 from sqlalchemy.orm import Mapped, mapped_column
 
 from podex.models.base import Base
+from podex.models.episode import DiscoverySource
 
 
 class Podcast(Base):
@@ -17,6 +19,28 @@ class Podcast(Base):
     name: Mapped[str] = mapped_column(String(255), index=True)
     slug: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     description: Mapped[str | None] = mapped_column(String(2000), default=None)
+    # Provider handles used by discovery to locate this podcast's feeds.
+    rss_url: Mapped[str | None] = mapped_column(
+        String(500),
+        index=True,
+        default=None,
+    )
+    spotify_id: Mapped[str | None] = mapped_column(
+        String(50),
+        index=True,
+        default=None,
+    )
+    apple_id: Mapped[str | None] = mapped_column(String(50), default=None)
+    youtube_channel_id: Mapped[str | None] = mapped_column(String(30), default=None)
+    podscripts_slug: Mapped[str | None] = mapped_column(
+        String(100),
+        index=True,
+        default=None,
+    )
+    discovery_source: Mapped[DiscoverySource | None] = mapped_column(
+        SAEnum(DiscoverySource, native_enum=False, length=50),
+        default=None,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/backend/tests/test_discovery_tracking.py
+++ b/backend/tests/test_discovery_tracking.py
@@ -1,0 +1,60 @@
+"""Tests for the discovery-tracking columns on podcasts and episodes."""
+
+from assertpy import assert_that
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.models import DiscoverySource, Episode, Podcast
+
+
+def test_podcast_stores_provider_handles(db_session: Session) -> None:
+    """Provider handles and the discovery source round-trip on podcasts."""
+    podcast = Podcast(
+        name="Example Show",
+        slug="example-show-discovery",
+        rss_url="https://feeds.example.com/example-show.xml",
+        spotify_id="0abc123",
+        podscripts_slug="example-show",
+        discovery_source=DiscoverySource.RSS,
+    )
+    db_session.add(podcast)
+    db_session.commit()
+
+    stored = db_session.execute(
+        select(Podcast).where(Podcast.slug == "example-show-discovery"),
+    ).scalar_one()
+    assert_that(stored.rss_url).is_equal_to(
+        "https://feeds.example.com/example-show.xml"
+    )
+    assert_that(stored.spotify_id).is_equal_to("0abc123")
+    assert_that(stored.podscripts_slug).is_equal_to("example-show")
+    assert_that(stored.discovery_source).is_equal_to(DiscoverySource.RSS)
+    assert_that(stored.apple_id).is_none()
+    assert_that(stored.youtube_channel_id).is_none()
+
+
+def test_episode_stores_source_identifiers(db_session: Session) -> None:
+    """Source-specific ids used for dedup round-trip on episodes."""
+    podcast = Podcast(name="Example Show", slug="example-show-episode-ids")
+    db_session.add(podcast)
+    db_session.commit()
+
+    episode = Episode(
+        podcast_id=podcast.id,
+        title="Pilot",
+        duration_seconds=3600,
+        youtube_id="dQw4w9WgXcQ",
+        spotify_uri="spotify:episode:0abc123",
+        rss_guid="urn:example:episode:1",
+        episode_url="https://podcasts.example.com/example-show/1",
+        discovery_source=DiscoverySource.PODSCRIPTS,
+    )
+    db_session.add(episode)
+    db_session.commit()
+
+    stored = db_session.execute(select(Episode)).scalar_one()
+    assert_that(stored.duration_seconds).is_equal_to(3600)
+    assert_that(stored.youtube_id).is_equal_to("dQw4w9WgXcQ")
+    assert_that(stored.spotify_uri).is_equal_to("spotify:episode:0abc123")
+    assert_that(stored.rss_guid).is_equal_to("urn:example:episode:1")
+    assert_that(stored.discovery_source).is_equal_to(DiscoverySource.PODSCRIPTS)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(models): add discovery-tracking columns for cross-provider dedup`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Second slice of the discovery/ingest theme from the #108 split (source: the #103 branch's `007_add_discovery_tracking`, re-authored to main's conventions):

- `Podcast` gains provider handles: `rss_url`, `spotify_id`, `apple_id`, `youtube_channel_id`, `podscripts_slug`.
- `Episode` gains source-specific ids for dedup (`youtube_id`, `spotify_uri`, `apple_id`, `rss_guid`, `episode_url`) plus `duration_seconds` and `thumbnail_url`.
- Both get a nullable `discovery_source` — a `DiscoverySource` StrEnum (`podscripts/rss/youtube/spotify/apple/manual`) stored `native_enum=False`, matching `MediaType`/`IngestionRunStatus`.
- Migration `0004` adds the columns and indexes on the dedup-hot lookups (`rss_guid`, `spotify_uri`, `youtube_id`, `rss_url`, `spotify_id`, `podscripts_slug`) with a clean downgrade.
- Deferred: the branch's podcast `status` lifecycle column belongs to the ops-console slice, not discovery.

Next slice ports the provider clients + `DiscoveryOrchestrator` dedup/upsert logic that consumes these columns (closes #65 there).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #65
- Relates to #108

## Details

Verified: `uv run lintro tst` (149 passed, including the migration replay + schema-drift guard, which pins model↔migration parity for the new columns) and ruff/mypy/pydoclint clean.