### PR TITLE
feat(ingest): add discovery providers and cross-source dedup orchestrator

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,11 @@ dependencies = [
   "sqlalchemy>=2.0",
   "alembic>=1.13",
   "redis>=5.0",
+  "httpx>=0.28",
+  "feedparser>=6.0",
+  "beautifulsoup4>=4.12",
+  "rapidfuzz>=3.9",
+  "spotipy>=2.24",
 ]
 
 [project.urls]

--- a/backend/src/podex/services/discovery.py
+++ b/backend/src/podex/services/discovery.py
@@ -1,0 +1,116 @@
+"""Discovery service interface and common types.
+
+This module defines the interface for discovering podcasts and episodes
+from various sources (podscripts.co, RSS, Spotify, etc.).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from podex.models import Podcast
+
+
+@dataclass
+class DiscoveredEpisode:
+    """Episode discovered from a source.
+
+    Contains all metadata we can extract about an episode,
+    with source-specific IDs for deduplication across sources.
+    """
+
+    title: str
+    published_at: datetime | None = None
+    duration_seconds: int | None = None
+    episode_number: int | None = None
+    description: str | None = None
+    episode_url: str | None = None
+    thumbnail_url: str | None = None
+
+    # Source-specific IDs
+    youtube_id: str | None = None
+    spotify_uri: str | None = None
+    rss_guid: str | None = None
+    apple_id: str | None = None
+
+    # Transcript availability (podscripts.co already has transcripts)
+    has_transcript: bool = False
+
+    # Which source discovered this episode
+    discovery_source: str | None = None
+
+
+@dataclass
+class DiscoveredPodcast:
+    """Podcast discovered from a source."""
+
+    name: str
+    slug: str | None = None
+    description: str | None = None
+    cover_url: str | None = None
+    author: str | None = None
+
+    # Source-specific IDs
+    rss_url: str | None = None
+    spotify_id: str | None = None
+    apple_id: str | None = None
+    youtube_channel_id: str | None = None
+    podscripts_slug: str | None = None
+
+    # Which source discovered this podcast
+    discovery_source: str | None = None
+
+
+@dataclass
+class DiscoveryResult:
+    """Result of a discovery operation."""
+
+    new_episodes: int = 0
+    updated_episodes: int = 0
+    total_discovered: int = 0
+    errors: list[str] = field(default_factory=list)
+    discovered_episodes: list[DiscoveredEpisode] = field(default_factory=list)
+
+
+class DiscoveryProvider(Protocol):
+    """Interface for episode discovery sources."""
+
+    @property
+    def name(self) -> str:
+        """Return the source name."""
+        ...
+
+    @property
+    def is_configured(self) -> bool:
+        """Check if this source is properly configured and ready to use."""
+        ...
+
+    def discover_podcast(self, identifier: str) -> DiscoveredPodcast | None:
+        """Discover podcast metadata from this source.
+
+        Args:
+            identifier: Source-specific identifier (e.g., RSS URL, Spotify ID, slug)
+
+        Returns:
+            DiscoveredPodcast with metadata, or None if not found
+        """
+        ...
+
+    def discover_episodes(
+        self,
+        podcast: Podcast,
+        since: datetime | None = None,
+    ) -> list[DiscoveredEpisode]:
+        """Discover episodes for a podcast.
+
+        Args:
+            podcast: The podcast to discover episodes for
+            since: Only discover episodes published after this date
+
+        Returns:
+            List of discovered episodes
+        """
+        ...

--- a/backend/src/podex/services/discovery_orchestrator.py
+++ b/backend/src/podex/services/discovery_orchestrator.py
@@ -194,7 +194,7 @@ class DiscoveryOrchestrator:
                 return True
 
         # High title similarity alone (>95) = probably match
-        return title_ratio >= 95
+        return bool(title_ratio >= 95)
 
     def _merge_episodes(
         self,

--- a/backend/src/podex/services/discovery_orchestrator.py
+++ b/backend/src/podex/services/discovery_orchestrator.py
@@ -1,0 +1,404 @@
+"""Discovery orchestrator - coordinates discovery across multiple sources.
+
+This module provides the DiscoveryOrchestrator class which:
+1. Discovers episodes from multiple sources (podscripts.co, RSS, Spotify)
+2. Deduplicates episodes across sources
+3. Creates/updates episode records in the database
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from rapidfuzz import fuzz
+from sqlalchemy.orm import Session
+
+from podex.models import Episode
+from podex.services.discovery import (
+    DiscoveredEpisode,
+    DiscoveryProvider,
+    DiscoveryResult,
+)
+from podex.services.discovery_podscripts import PodscriptsDiscovery
+from podex.services.discovery_rss import RSSDiscovery
+from podex.services.discovery_spotify import SpotifyDiscovery
+
+if TYPE_CHECKING:
+    from podex.models import Podcast
+
+logger = logging.getLogger(__name__)
+
+
+class DiscoveryOrchestrator:
+    """Coordinate discovery across multiple sources.
+
+    Args:
+        session: SQLAlchemy session for database operations
+    """
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+        self._sources: dict[str, DiscoveryProvider] = {
+            "podscripts": PodscriptsDiscovery(),
+            "rss": RSSDiscovery(),
+            "spotify": SpotifyDiscovery(),
+        }
+
+    def discover_for_podcast(
+        self,
+        podcast: Podcast,
+        since: datetime | None = None,
+    ) -> DiscoveryResult:
+        """Discover new episodes for a podcast from all configured sources.
+
+        Args:
+            podcast: The podcast to discover episodes for
+            since: Only discover episodes published after this date
+
+        Returns:
+            DiscoveryResult with counts and any errors
+        """
+        discovered: list[DiscoveredEpisode] = []
+        errors: list[str] = []
+
+        # Try each source that has configuration for this podcast
+        if podcast.podscripts_slug:
+            try:
+                source = self._sources["podscripts"]
+                eps = source.discover_episodes(podcast, since=since)
+                logger.info(f"Discovered {len(eps)} episodes from podscripts.co")
+                discovered.extend(eps)
+            except Exception as e:
+                error = f"podscripts: {e}"
+                logger.warning(error)
+                errors.append(error)
+
+        if podcast.rss_url:
+            try:
+                source = self._sources["rss"]
+                eps = source.discover_episodes(podcast, since=since)
+                logger.info(f"Discovered {len(eps)} episodes from RSS")
+                discovered.extend(eps)
+            except Exception as e:
+                error = f"rss: {e}"
+                logger.warning(error)
+                errors.append(error)
+
+        if podcast.spotify_id and self._sources["spotify"].is_configured:
+            try:
+                source = self._sources["spotify"]
+                eps = source.discover_episodes(podcast, since=since)
+                logger.info(f"Discovered {len(eps)} episodes from Spotify")
+                discovered.extend(eps)
+            except Exception as e:
+                error = f"spotify: {e}"
+                logger.warning(error)
+                errors.append(error)
+
+        # Deduplicate and merge
+        merged = self._deduplicate_episodes(discovered)
+        logger.info(f"After deduplication: {len(merged)} unique episodes")
+
+        # Create/update episode records
+        new_count, updated_count = self._upsert_episodes(podcast, merged)
+
+        return DiscoveryResult(
+            new_episodes=new_count,
+            updated_episodes=updated_count,
+            total_discovered=len(discovered),
+            errors=errors,
+            discovered_episodes=merged,
+        )
+
+    def _deduplicate_episodes(
+        self,
+        episodes: list[DiscoveredEpisode],
+    ) -> list[DiscoveredEpisode]:
+        """Deduplicate and merge episodes from multiple sources.
+
+        Uses multiple matching strategies:
+        1. Exact match on source-specific IDs and source URLs.
+        2. Fuzzy match on title + date.
+        """
+        if not episodes:
+            return []
+
+        # Group episodes by potential matches
+        merged: list[DiscoveredEpisode] = []
+        used: set[int] = set()
+
+        for i, ep1 in enumerate(episodes):
+            if i in used:
+                continue
+
+            # Find all episodes that match this one
+            matches = [ep1]
+            used.add(i)
+
+            for j, ep2 in enumerate(episodes):
+                if j in used:
+                    continue
+
+                if self._episodes_match(ep1, ep2):
+                    matches.append(ep2)
+                    used.add(j)
+
+            # Merge matched episodes
+            merged_ep = self._merge_episodes(matches)
+            merged.append(merged_ep)
+
+        return merged
+
+    def _episodes_match(
+        self,
+        ep1: DiscoveredEpisode,
+        ep2: DiscoveredEpisode,
+    ) -> bool:
+        """Check if two episodes are the same.
+
+        Returns True if they match by ID or by title similarity + date.
+        """
+        # Match by source-specific IDs
+        if ep1.youtube_id and ep1.youtube_id == ep2.youtube_id:
+            return True
+        if ep1.spotify_uri and ep1.spotify_uri == ep2.spotify_uri:
+            return True
+        if ep1.rss_guid and ep1.rss_guid == ep2.rss_guid:
+            return True
+        if ep1.episode_url and ep1.episode_url == ep2.episode_url:
+            return True
+
+        # Match by episode number if both have one
+        if (
+            ep1.episode_number
+            and ep2.episode_number
+            and ep1.episode_number == ep2.episode_number
+        ):
+            return True
+
+        # Match by fuzzy title + date
+        title_ratio = fuzz.ratio(ep1.title.lower(), ep2.title.lower())
+        if title_ratio < 80:
+            return False
+
+        # If titles are similar, check dates
+        if ep1.published_at and ep2.published_at:
+            # Same day = match
+            if ep1.published_at.date() == ep2.published_at.date():
+                return True
+            # Within a week and high title match = probably match
+            days_diff = abs((ep1.published_at - ep2.published_at).days)
+            if days_diff <= 7 and title_ratio >= 90:
+                return True
+
+        # High title similarity alone (>95) = probably match
+        return title_ratio >= 95
+
+    def _merge_episodes(
+        self,
+        episodes: list[DiscoveredEpisode],
+    ) -> DiscoveredEpisode:
+        """Merge multiple matched episodes into one.
+
+        Combines information from all sources, preferring non-null values.
+        """
+        if len(episodes) == 1:
+            return episodes[0]
+
+        # Start with the first episode
+        merged = DiscoveredEpisode(
+            title=episodes[0].title,
+            published_at=episodes[0].published_at,
+            duration_seconds=episodes[0].duration_seconds,
+            episode_number=episodes[0].episode_number,
+            description=episodes[0].description,
+            episode_url=episodes[0].episode_url,
+            thumbnail_url=episodes[0].thumbnail_url,
+            youtube_id=episodes[0].youtube_id,
+            spotify_uri=episodes[0].spotify_uri,
+            rss_guid=episodes[0].rss_guid,
+            apple_id=episodes[0].apple_id,
+            has_transcript=episodes[0].has_transcript,
+            discovery_source=episodes[0].discovery_source,
+        )
+
+        # Merge in values from other episodes
+        for ep in episodes[1:]:
+            # Prefer values from podscripts (has transcripts)
+            if ep.has_transcript and not merged.has_transcript:
+                merged.has_transcript = True
+                # Also prefer podscripts title as it's often cleaner
+                merged.title = ep.title
+
+            # Fill in missing values
+            if ep.published_at and not merged.published_at:
+                merged.published_at = ep.published_at
+            if ep.duration_seconds and not merged.duration_seconds:
+                merged.duration_seconds = ep.duration_seconds
+            if ep.episode_number and not merged.episode_number:
+                merged.episode_number = ep.episode_number
+            if ep.description and not merged.description:
+                merged.description = ep.description
+            if ep.episode_url and not merged.episode_url:
+                merged.episode_url = ep.episode_url
+            if ep.thumbnail_url and not merged.thumbnail_url:
+                merged.thumbnail_url = ep.thumbnail_url
+            if ep.youtube_id and not merged.youtube_id:
+                merged.youtube_id = ep.youtube_id
+            if ep.spotify_uri and not merged.spotify_uri:
+                merged.spotify_uri = ep.spotify_uri
+            if ep.rss_guid and not merged.rss_guid:
+                merged.rss_guid = ep.rss_guid
+            if ep.apple_id and not merged.apple_id:
+                merged.apple_id = ep.apple_id
+
+        return merged
+
+    def _upsert_episodes(
+        self,
+        podcast: Podcast,
+        episodes: list[DiscoveredEpisode],
+    ) -> tuple[int, int]:
+        """Create or update episodes in the database.
+
+        Returns:
+            Tuple of (new_count, updated_count)
+        """
+        new_count = 0
+        updated_count = 0
+
+        for discovered in episodes:
+            # Try to find existing episode
+            existing = self._find_existing_episode(podcast, discovered)
+
+            if existing:
+                # Update existing episode
+                updated = self._update_episode(existing, discovered)
+                if updated:
+                    updated_count += 1
+            else:
+                # Create new episode
+                self._create_episode(podcast, discovered)
+                new_count += 1
+
+        self.session.commit()
+        return new_count, updated_count
+
+    def _find_existing_episode(
+        self,
+        podcast: Podcast,
+        discovered: DiscoveredEpisode,
+    ) -> Episode | None:
+        """Find an existing episode that matches the discovered one."""
+        query = self.session.query(Episode).filter(Episode.podcast_id == podcast.id)
+
+        # Try matching by source-specific IDs first
+        if discovered.youtube_id:
+            ep = query.filter(Episode.youtube_id == discovered.youtube_id).first()
+            if ep:
+                return ep
+
+        if discovered.spotify_uri:
+            ep = query.filter(Episode.spotify_uri == discovered.spotify_uri).first()
+            if ep:
+                return ep
+
+        if discovered.rss_guid:
+            ep = query.filter(Episode.rss_guid == discovered.rss_guid).first()
+            if ep:
+                return ep
+
+        if discovered.episode_url:
+            ep = query.filter(Episode.episode_url == discovered.episode_url).first()
+            if ep:
+                return ep
+
+        # Try matching by episode number
+        if discovered.episode_number:
+            ep = query.filter(
+                Episode.episode_number == discovered.episode_number
+            ).first()
+            if ep:
+                return ep
+
+        return None
+
+    def _create_episode(
+        self,
+        podcast: Podcast,
+        discovered: DiscoveredEpisode,
+    ) -> Episode:
+        """Create a new episode from discovered data."""
+        episode = Episode(
+            podcast_id=podcast.id,
+            title=discovered.title,
+            episode_number=discovered.episode_number,
+            youtube_id=discovered.youtube_id,
+            published_at=discovered.published_at,
+            duration_seconds=discovered.duration_seconds,
+            thumbnail_url=discovered.thumbnail_url,
+            spotify_uri=discovered.spotify_uri,
+            rss_guid=discovered.rss_guid,
+            apple_id=discovered.apple_id,
+            episode_url=discovered.episode_url,
+            discovery_source=discovered.discovery_source,
+        )
+        self.session.add(episode)
+        logger.debug(f"Created episode: {discovered.title}")
+        return episode
+
+    def _update_episode(
+        self,
+        episode: Episode,
+        discovered: DiscoveredEpisode,
+    ) -> bool:
+        """Update an existing episode with new data.
+
+        Returns True if any changes were made.
+        """
+        changed = False
+
+        # Fill in missing fields
+        if discovered.spotify_uri and not episode.spotify_uri:
+            episode.spotify_uri = discovered.spotify_uri
+            changed = True
+        if discovered.rss_guid and not episode.rss_guid:
+            episode.rss_guid = discovered.rss_guid
+            changed = True
+        if discovered.apple_id and not episode.apple_id:
+            episode.apple_id = discovered.apple_id
+            changed = True
+        if discovered.episode_url and not episode.episode_url:
+            episode.episode_url = discovered.episode_url
+            changed = True
+        if discovered.youtube_id and not episode.youtube_id:
+            episode.youtube_id = discovered.youtube_id
+            changed = True
+        if discovered.duration_seconds and not episode.duration_seconds:
+            episode.duration_seconds = discovered.duration_seconds
+            changed = True
+        if discovered.thumbnail_url and not episode.thumbnail_url:
+            episode.thumbnail_url = discovered.thumbnail_url
+            changed = True
+        if discovered.published_at and not episode.published_at:
+            episode.published_at = discovered.published_at
+            changed = True
+
+        if changed:
+            logger.debug(f"Updated episode: {episode.title}")
+
+        return changed
+
+    def close(self) -> None:
+        """Close any resources held by discovery sources."""
+        for source in self._sources.values():
+            if hasattr(source, "close"):
+                source.close()
+
+    def __enter__(self) -> DiscoveryOrchestrator:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/discovery_podscripts.py
+++ b/backend/src/podex/services/discovery_podscripts.py
@@ -1,0 +1,302 @@
+"""Podscripts.co discovery service.
+
+Discovers podcasts and episodes from podscripts.co, which provides
+pre-existing transcripts for popular podcasts.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+from podex.services.discovery import (
+    DiscoveredEpisode,
+    DiscoveredPodcast,
+)
+from podex.services.podscripts_client import (
+    BASE_URL,
+    build_podscripts_client,
+    fetch_podscripts_html,
+)
+
+if TYPE_CHECKING:
+    from podex.models import Podcast
+
+logger = logging.getLogger(__name__)
+
+
+def _html_attr_to_str(value: object) -> str:
+    """Return a BeautifulSoup attribute value when it is a single string."""
+    return value if isinstance(value, str) else ""
+
+
+def _episode_link_title(*, href: str, link_text: str) -> tuple[int | None, str]:
+    """Extract a stable title and optional number from an episode link."""
+    slug = href.rstrip("/").split("/")[-1]
+    comment_label = re.fullmatch(r"\d+\s*comments?", link_text, flags=re.IGNORECASE)
+    title = link_text if link_text and comment_label is None else ""
+    match = re.match(r"(\d+)-(.+)", slug)
+    if match:
+        return (
+            int(match.group(1)),
+            title or match.group(2).replace("-", " ").title(),
+        )
+    return None, title or slug.replace("-", " ").title()
+
+
+class PodscriptsDiscovery:
+    """Discover podcasts and episodes from podscripts.co.
+
+    Args:
+        delay: Delay between requests in seconds (be nice to the server)
+    """
+
+    def __init__(self, delay: float = 1.0) -> None:
+        self.delay = delay
+        self.client = build_podscripts_client()
+
+    @property
+    def name(self) -> str:
+        return "podscripts"
+
+    @property
+    def is_configured(self) -> bool:
+        """Podscripts discovery is always configured (no API keys needed)."""
+        return True
+
+    def discover_podcast(self, slug: str) -> DiscoveredPodcast | None:
+        """Discover podcast metadata from podscripts.co.
+
+        Args:
+            slug: The podscripts.co slug (e.g., "example-show")
+
+        Returns:
+            DiscoveredPodcast with metadata, or None if not found
+        """
+        url = f"{BASE_URL}/podcasts/{slug}"
+
+        try:
+            html = fetch_podscripts_html(
+                client=self.client,
+                url=url,
+                retry_delay_seconds=self.delay,
+            )
+        except httpx.HTTPError as e:
+            logger.warning(f"Failed to fetch podcast {slug}: {e}")
+            return None
+
+        soup = BeautifulSoup(html, "html.parser")
+
+        # Extract podcast name from title or h1
+        name = None
+        title = soup.find("title")
+        if title:
+            name = title.get_text(strip=True).split(" - ")[0].split(" | ")[0]
+
+        h1 = soup.find("h1")
+        if h1:
+            name = h1.get_text(strip=True)
+
+        if not name:
+            name = slug.replace("-", " ").title()
+
+        # Extract description
+        description = None
+        desc_meta = soup.find("meta", attrs={"name": "description"})
+        if desc_meta:
+            description = _html_attr_to_str(desc_meta.get("content"))
+
+        # Extract cover image
+        cover_url = None
+        og_image = soup.find("meta", property="og:image")
+        if og_image:
+            cover_url = _html_attr_to_str(og_image.get("content"))
+
+        time.sleep(self.delay)
+
+        return DiscoveredPodcast(
+            name=name,
+            slug=slug,
+            description=description,
+            cover_url=cover_url,
+            podscripts_slug=slug,
+            discovery_source=self.name,
+        )
+
+    def discover_episodes(
+        self,
+        podcast: Podcast,
+        since: datetime | None = None,
+    ) -> list[DiscoveredEpisode]:
+        """Discover episodes for a podcast from podscripts.co.
+
+        All discovered episodes have has_transcript=True since
+        podscripts.co only lists episodes with transcripts.
+
+        Args:
+            podcast: The podcast to discover episodes for
+            since: Only discover episodes published after this date
+
+        Returns:
+            List of discovered episodes
+        """
+        if not podcast.podscripts_slug:
+            logger.warning(f"Podcast {podcast.slug} has no podscripts_slug")
+            return []
+
+        episodes = []
+        page = 1
+        max_pages = 200  # Safety limit
+
+        while page <= max_pages:
+            page_episodes = self._fetch_episode_page(podcast.podscripts_slug, page)
+
+            if not page_episodes:
+                break
+
+            # Filter by date if specified
+            if since:
+                # Since we don't have exact dates from the list page,
+                # we'll include all episodes and let the caller filter
+                pass
+
+            episodes.extend(page_episodes)
+            page += 1
+
+        logger.info(f"Discovered {len(episodes)} episodes from podscripts.co")
+        return episodes
+
+    def _fetch_episode_page(
+        self,
+        slug: str,
+        page: int,
+    ) -> list[DiscoveredEpisode]:
+        """Fetch a single page of episodes."""
+        url = f"{BASE_URL}/podcasts/{slug}?page={page}"
+        logger.debug(f"Fetching page {page}: {url}")
+
+        try:
+            html = fetch_podscripts_html(
+                client=self.client,
+                url=url,
+                retry_delay_seconds=self.delay,
+            )
+        except httpx.HTTPError as e:
+            logger.warning(f"Failed to fetch page {page}: {e}")
+            return []
+
+        soup = BeautifulSoup(html, "html.parser")
+        episodes = []
+
+        for link in soup.find_all("a", href=True):
+            href = _html_attr_to_str(link.get("href", ""))
+            expected_prefix = f"/podcasts/{slug}/"
+
+            if (
+                href.startswith(expected_prefix)
+                and href.rstrip("/") != f"/podcasts/{slug}"
+            ):
+                episode = self._parse_episode_link(link, href, slug)
+                if episode:
+                    episodes.append(episode)
+
+        # Deduplicate by URL
+        seen = set()
+        unique = []
+        for ep in episodes:
+            if ep.episode_url not in seen:
+                seen.add(ep.episode_url)
+                unique.append(ep)
+
+        time.sleep(self.delay)
+        return unique
+
+    def _parse_episode_link(
+        self,
+        link: Tag,
+        href: str,
+        podcast_slug: str,
+    ) -> DiscoveredEpisode | None:
+        """Parse an episode from a link element."""
+        link_text = link.get_text(strip=True)
+        episode_number, title = _episode_link_title(
+            href=href,
+            link_text=link_text,
+        )
+
+        episode_url = f"{BASE_URL}{href}" if href.startswith("/") else href
+
+        return DiscoveredEpisode(
+            title=title,
+            episode_number=episode_number,
+            episode_url=episode_url,
+            has_transcript=True,  # podscripts.co always has transcripts
+            discovery_source=self.name,
+        )
+
+    def list_available_podcasts(self) -> list[dict[str, str]]:
+        """List all podcasts available on podscripts.co.
+
+        Returns:
+            List of dicts with podcast info (slug, name, episode_count)
+        """
+        podcasts = []
+        url = f"{BASE_URL}/podcasts"
+
+        try:
+            html = fetch_podscripts_html(
+                client=self.client,
+                url=url,
+                retry_delay_seconds=self.delay,
+            )
+        except httpx.HTTPError as e:
+            logger.error(f"Failed to fetch podcast catalog: {e}")
+            return []
+
+        soup = BeautifulSoup(html, "html.parser")
+
+        for link in soup.find_all("a", href=True):
+            href = _html_attr_to_str(link.get("href", ""))
+
+            if href.startswith("/podcasts/") and href != "/podcasts":
+                slug = href.replace("/podcasts/", "").strip("/")
+
+                if slug and "/" not in slug:
+                    name = link.get_text(strip=True)
+                    if not name:
+                        name = slug.replace("-", " ").title()
+
+                    podcasts.append(
+                        {
+                            "slug": slug,
+                            "name": name,
+                            "url": f"{BASE_URL}{href}",
+                        }
+                    )
+
+        # Deduplicate
+        seen = set()
+        unique = []
+        for p in podcasts:
+            if p["slug"] not in seen:
+                seen.add(p["slug"])
+                unique.append(p)
+
+        logger.info(f"Found {len(unique)} podcasts on podscripts.co")
+        return unique
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> PodscriptsDiscovery:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/discovery_rss.py
+++ b/backend/src/podex/services/discovery_rss.py
@@ -1,0 +1,218 @@
+"""RSS feed discovery service.
+
+Discovers podcasts and episodes from RSS feeds.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from typing import TYPE_CHECKING, Any
+
+import feedparser
+
+from podex.services.discovery import (
+    DiscoveredEpisode,
+    DiscoveredPodcast,
+)
+
+if TYPE_CHECKING:
+    from podex.models import Podcast
+
+logger = logging.getLogger(__name__)
+
+
+class RSSDiscovery:
+    """Discover podcasts and episodes from RSS feeds."""
+
+    @property
+    def name(self) -> str:
+        return "rss"
+
+    @property
+    def is_configured(self) -> bool:
+        """RSS discovery is always configured (no API keys needed)."""
+        return True
+
+    def discover_podcast(self, rss_url: str) -> DiscoveredPodcast | None:
+        """Discover podcast metadata from an RSS feed.
+
+        Args:
+            rss_url: The RSS feed URL
+
+        Returns:
+            DiscoveredPodcast with metadata, or None if feed is invalid
+        """
+        feed = feedparser.parse(rss_url)
+
+        if feed.bozo and not feed.entries:
+            logger.warning(f"Failed to parse RSS feed: {rss_url}")
+            return None
+
+        channel = feed.feed
+
+        name = channel.get("title", "Unknown Podcast")
+        description = channel.get("description") or channel.get("subtitle")
+        author = channel.get("author") or channel.get("itunes_author")
+
+        # Extract cover image
+        cover_url = None
+        if hasattr(channel, "image") and channel.image:
+            cover_url = channel.image.get("href")
+        if not cover_url and hasattr(channel, "itunes_image"):
+            cover_url = channel.itunes_image.get("href")
+
+        # Generate a slug from the name
+        slug = self._generate_slug(name)
+
+        return DiscoveredPodcast(
+            name=name,
+            slug=slug,
+            description=description,
+            author=author,
+            cover_url=cover_url,
+            rss_url=rss_url,
+            discovery_source=self.name,
+        )
+
+    def discover_episodes(
+        self,
+        podcast: Podcast,
+        since: datetime | None = None,
+    ) -> list[DiscoveredEpisode]:
+        """Discover episodes from an RSS feed.
+
+        Args:
+            podcast: The podcast to discover episodes for
+            since: Only discover episodes published after this date
+
+        Returns:
+            List of discovered episodes
+        """
+        if not podcast.rss_url:
+            logger.warning(f"Podcast {podcast.slug} has no rss_url")
+            return []
+
+        feed = feedparser.parse(podcast.rss_url)
+
+        if feed.bozo and not feed.entries:
+            logger.warning(f"Failed to parse RSS feed: {podcast.rss_url}")
+            return []
+
+        episodes = []
+
+        for entry in feed.entries:
+            episode = self._parse_episode(entry)
+
+            if episode:
+                # Filter by date if specified
+                if since and episode.published_at and episode.published_at < since:
+                    continue
+
+                episodes.append(episode)
+
+        logger.info(f"Discovered {len(episodes)} episodes from RSS feed")
+        return episodes
+
+    def _parse_episode(self, entry: Any) -> DiscoveredEpisode | None:
+        """Parse an episode from a feed entry."""
+        title = entry.get("title")
+        if not title:
+            return None
+
+        # Parse published date
+        published_at = None
+        if entry.get("published"):
+            try:
+                published_at = parsedate_to_datetime(entry.published)
+                if published_at.tzinfo is None:
+                    published_at = published_at.replace(tzinfo=UTC)
+            except (ValueError, TypeError):
+                pass
+
+        # Parse duration
+        duration_seconds = None
+        duration_str = entry.get("itunes_duration")
+        if duration_str:
+            duration_seconds = self._parse_duration(duration_str)
+
+        # Extract episode number
+        episode_number = None
+        ep_num = entry.get("itunes_episode")
+        if ep_num:
+            with contextlib.suppress(ValueError, TypeError):
+                episode_number = int(ep_num)
+
+        # Get episode URL
+        episode_url = entry.get("link")
+
+        # Get GUID for deduplication
+        rss_guid = entry.get("id") or entry.get("guid")
+
+        # Get description
+        description = entry.get("summary") or entry.get("description")
+        if description:
+            # Strip HTML tags
+            description = re.sub(r"<[^>]+>", "", description).strip()
+            if len(description) > 1000:
+                description = description[:1000] + "..."
+
+        # Get thumbnail
+        thumbnail_url = None
+        if hasattr(entry, "image") and entry.image:
+            thumbnail_url = entry.image.get("href")
+        if not thumbnail_url and hasattr(entry, "itunes_image"):
+            thumbnail_url = entry.itunes_image.get("href")
+
+        return DiscoveredEpisode(
+            title=title,
+            published_at=published_at,
+            duration_seconds=duration_seconds,
+            episode_number=episode_number,
+            description=description,
+            episode_url=episode_url,
+            thumbnail_url=thumbnail_url,
+            rss_guid=rss_guid,
+            has_transcript=False,  # RSS doesn't include transcripts
+            discovery_source=self.name,
+        )
+
+    def _parse_duration(self, duration_str: str) -> int | None:
+        """Parse duration string to seconds.
+
+        Handles formats like:
+        - "3600" (seconds)
+        - "60:00" (mm:ss)
+        - "1:00:00" (hh:mm:ss)
+        """
+        if not duration_str:
+            return None
+
+        try:
+            # Try as plain seconds
+            if duration_str.isdigit():
+                return int(duration_str)
+
+            # Try as time format
+            parts = duration_str.split(":")
+            if len(parts) == 2:
+                return int(parts[0]) * 60 + int(parts[1])
+            elif len(parts) == 3:
+                return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+
+        except (ValueError, TypeError):
+            pass
+
+        return None
+
+    def _generate_slug(self, name: str) -> str:
+        """Generate a URL-safe slug from a name."""
+        # Lowercase and replace spaces with hyphens
+        slug = name.lower().strip()
+        slug = re.sub(r"[^\w\s-]", "", slug)
+        slug = re.sub(r"[\s_]+", "-", slug)
+        slug = re.sub(r"-+", "-", slug)
+        return slug.strip("-")

--- a/backend/src/podex/services/discovery_spotify.py
+++ b/backend/src/podex/services/discovery_spotify.py
@@ -1,0 +1,301 @@
+"""Spotify discovery service.
+
+Discovers podcasts and episodes from Spotify's API.
+Requires Spotify API credentials (client_id and client_secret).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from podex.services.discovery import (
+    DiscoveredEpisode,
+    DiscoveredPodcast,
+)
+
+if TYPE_CHECKING:
+    from podex.models import Podcast
+
+logger = logging.getLogger(__name__)
+
+
+class SpotifyDiscovery:
+    """Discover podcasts and episodes from Spotify's API.
+
+    Args:
+        client_id: Spotify API client ID (or from SPOTIFY_CLIENT_ID env var)
+        client_secret: Spotify API client secret (or from SPOTIFY_CLIENT_SECRET env var)
+    """
+
+    def __init__(
+        self,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+    ) -> None:
+        self.client_id = client_id or os.getenv("SPOTIFY_CLIENT_ID")
+        self.client_secret = client_secret or os.getenv("SPOTIFY_CLIENT_SECRET")
+        self._spotify = None
+
+    @property
+    def name(self) -> str:
+        return "spotify"
+
+    @property
+    def is_configured(self) -> bool:
+        """Check if Spotify API credentials are configured."""
+        return bool(self.client_id and self.client_secret)
+
+    def _get_client(self) -> Any:
+        """Get or create Spotify client."""
+        if self._spotify is None:
+            if not self.is_configured:
+                raise ValueError(
+                    "Spotify credentials not configured. Set "
+                    "SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET env vars."
+                )
+
+            try:
+                import spotipy
+                from spotipy.oauth2 import SpotifyClientCredentials
+            except ImportError as e:
+                raise ImportError(
+                    "spotipy not installed. Run: uv pip install spotipy"
+                ) from e
+
+            auth_manager = SpotifyClientCredentials(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+            )
+            self._spotify = spotipy.Spotify(auth_manager=auth_manager)
+
+        return self._spotify
+
+    def discover_podcast(self, spotify_id: str) -> DiscoveredPodcast | None:
+        """Discover podcast metadata from Spotify.
+
+        Args:
+            spotify_id: The Spotify show ID
+
+        Returns:
+            DiscoveredPodcast with metadata, or None if not found
+        """
+        try:
+            client = self._get_client()
+            show = client.show(spotify_id, market="US")
+        except Exception as e:
+            logger.warning(f"Failed to fetch Spotify show {spotify_id}: {e}")
+            return None
+
+        if not show:
+            return None
+
+        name = show.get("name", "Unknown Podcast")
+        description = show.get("description")
+        publisher = show.get("publisher")
+
+        # Get cover image (prefer largest)
+        cover_url = None
+        images = show.get("images", [])
+        if images:
+            # Sort by size (largest first)
+            sorted_images = sorted(
+                images,
+                key=lambda x: x.get("height", 0) or 0,
+                reverse=True,
+            )
+            cover_url = sorted_images[0].get("url")
+
+        # Generate slug from name
+        slug = self._generate_slug(name)
+
+        return DiscoveredPodcast(
+            name=name,
+            slug=slug,
+            description=description,
+            author=publisher,
+            cover_url=cover_url,
+            spotify_id=spotify_id,
+            discovery_source=self.name,
+        )
+
+    def discover_episodes(
+        self,
+        podcast: Podcast,
+        since: datetime | None = None,
+        limit: int = 50,
+    ) -> list[DiscoveredEpisode]:
+        """Discover episodes from Spotify.
+
+        Args:
+            podcast: The podcast to discover episodes for
+            since: Only discover episodes published after this date
+            limit: Maximum episodes per API call (Spotify max is 50)
+
+        Returns:
+            List of discovered episodes
+        """
+        if not podcast.spotify_id:
+            logger.warning(f"Podcast {podcast.slug} has no spotify_id")
+            return []
+
+        try:
+            client = self._get_client()
+        except (ValueError, ImportError) as e:
+            logger.warning(f"Cannot use Spotify discovery: {e}")
+            return []
+
+        episodes: list[DiscoveredEpisode] = []
+        offset = 0
+        max_episodes = 1000  # Safety limit
+
+        while offset < max_episodes:
+            try:
+                result = client.show_episodes(
+                    podcast.spotify_id,
+                    limit=min(limit, 50),
+                    offset=offset,
+                    market="US",
+                )
+            except Exception as e:
+                logger.warning(f"Failed to fetch episodes from Spotify: {e}")
+                break
+
+            items = result.get("items", [])
+            if not items:
+                break
+
+            for item in items:
+                episode = self._parse_episode(item)
+
+                if episode:
+                    # Filter by date if specified
+                    if since and episode.published_at and episode.published_at < since:
+                        # Spotify returns newest first, so we can stop
+                        logger.debug(
+                            f"Stopping at episode {episode.title} (before {since})"
+                        )
+                        return episodes
+
+                    episodes.append(episode)
+
+            # Check if there are more episodes
+            if not result.get("next"):
+                break
+
+            offset += len(items)
+
+        logger.info(f"Discovered {len(episodes)} episodes from Spotify")
+        return episodes
+
+    def _parse_episode(self, item: dict[str, Any]) -> DiscoveredEpisode | None:
+        """Parse an episode from Spotify API response."""
+        name = item.get("name")
+        if not name:
+            return None
+
+        # Parse release date
+        published_at = None
+        release_date = item.get("release_date")
+        if release_date:
+            try:
+                # Spotify returns dates in YYYY-MM-DD format
+                if len(release_date) == 10:
+                    published_at = datetime.strptime(release_date, "%Y-%m-%d").replace(
+                        tzinfo=UTC
+                    )
+                elif len(release_date) == 7:
+                    published_at = datetime.strptime(release_date, "%Y-%m").replace(
+                        tzinfo=UTC
+                    )
+                elif len(release_date) == 4:
+                    published_at = datetime.strptime(release_date, "%Y").replace(
+                        tzinfo=UTC
+                    )
+            except ValueError:
+                pass
+
+        # Duration in milliseconds
+        duration_seconds = None
+        duration_ms = item.get("duration_ms")
+        if duration_ms:
+            duration_seconds = duration_ms // 1000
+
+        # Episode URL
+        episode_url = None
+        external_urls = item.get("external_urls", {})
+        episode_url = external_urls.get("spotify")
+
+        # Spotify URI for deduplication
+        spotify_uri = item.get("uri")
+
+        # Description
+        description = item.get("description")
+        if description and len(description) > 1000:
+            description = description[:1000] + "..."
+
+        # Thumbnail
+        thumbnail_url = None
+        images = item.get("images", [])
+        if images:
+            sorted_images = sorted(
+                images,
+                key=lambda x: x.get("height", 0) or 0,
+                reverse=True,
+            )
+            thumbnail_url = sorted_images[0].get("url")
+
+        return DiscoveredEpisode(
+            title=name,
+            published_at=published_at,
+            duration_seconds=duration_seconds,
+            description=description,
+            episode_url=episode_url,
+            thumbnail_url=thumbnail_url,
+            spotify_uri=spotify_uri,
+            has_transcript=False,  # Spotify doesn't provide transcripts
+            discovery_source=self.name,
+        )
+
+    def _generate_slug(self, name: str) -> str:
+        """Generate a URL-safe slug from a name."""
+        import re
+
+        slug = name.lower().strip()
+        slug = re.sub(r"[^\w\s-]", "", slug)
+        slug = re.sub(r"[\s_]+", "-", slug)
+        slug = re.sub(r"-+", "-", slug)
+        return slug.strip("-")
+
+    def search_podcasts(
+        self,
+        query: str,
+        limit: int = 10,
+    ) -> list[DiscoveredPodcast]:
+        """Search for podcasts on Spotify.
+
+        Args:
+            query: Search query
+            limit: Maximum number of results
+
+        Returns:
+            List of discovered podcasts
+        """
+        try:
+            client = self._get_client()
+            result = client.search(q=query, type="show", limit=limit, market="US")
+        except Exception as e:
+            logger.warning(f"Spotify search failed: {e}")
+            return []
+
+        podcasts = []
+        for item in result.get("shows", {}).get("items", []):
+            spotify_id = item.get("id")
+            if spotify_id:
+                podcast = self.discover_podcast(spotify_id)
+                if podcast:
+                    podcasts.append(podcast)
+
+        return podcasts

--- a/backend/src/podex/services/podscripts_client.py
+++ b/backend/src/podex/services/podscripts_client.py
@@ -1,0 +1,81 @@
+"""Shared HTTP helpers for public Podscripts page access."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://podscripts.co"
+DEFAULT_MAX_ATTEMPTS = 3
+RETRYABLE_STATUS_CODES = {408, 429}
+
+
+def build_podscripts_client() -> httpx.Client:
+    """Build the configured client used for public Podscripts requests."""
+    return httpx.Client(
+        timeout=30.0,
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            ),
+        },
+    )
+
+
+def fetch_podscripts_html(
+    *,
+    client: httpx.Client,
+    url: str,
+    retry_delay_seconds: float,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> str:
+    """Fetch public Podscripts HTML with bounded retry on transient failure.
+
+    Args:
+        client: Configured HTTP client.
+        url: Public Podscripts page URL.
+        retry_delay_seconds: Base wait between transient failures.
+        max_attempts: Maximum request attempts.
+
+    Returns:
+        Successfully retrieved response body.
+
+    Raises:
+        httpx.HTTPError: When a permanent error occurs or retries are exhausted.
+        ValueError: When ``max_attempts`` is invalid.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least one")
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = client.get(url)
+            response.raise_for_status()
+            return response.text
+        except httpx.HTTPStatusError as error:
+            if (
+                error.response.status_code not in RETRYABLE_STATUS_CODES
+                and error.response.status_code < 500
+            ):
+                raise
+            if attempt == max_attempts:
+                raise
+        except httpx.TransportError:
+            if attempt == max_attempts:
+                raise
+
+        wait_seconds = retry_delay_seconds * attempt
+        logger.warning(
+            "Transient Podscripts request failure; retrying %s in %.1fs",
+            url,
+            wait_seconds,
+        )
+        time.sleep(wait_seconds)
+
+    raise RuntimeError("Podscripts retry loop completed without returning or raising")

--- a/backend/tests/test_discovery_orchestrator.py
+++ b/backend/tests/test_discovery_orchestrator.py
@@ -1,7 +1,9 @@
 """Tests for idempotent episode discovery persistence."""
 
+from typing import cast
+
 from assertpy import assert_that
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -58,11 +60,12 @@ def test_deduplicate_matches_repeated_provider_urls(db_session: Session) -> None
 
 def test_podscripts_episode_comment_link_falls_back_to_url_title() -> None:
     """Verify comment-count link text cannot become an episode title."""
-    link = BeautifulSoup(
+    tag = BeautifulSoup(
         '<a href="/podcasts/example-show/42-pilot">0comments</a>',
         "html.parser",
     ).find("a")
-    assert link is not None
+    assert_that(tag).is_instance_of(Tag)
+    link = cast("Tag", tag)
 
     source = PodscriptsDiscovery(delay=0)
     try:
@@ -75,9 +78,9 @@ def test_podscripts_episode_comment_link_falls_back_to_url_title() -> None:
         source.close()
 
     assert_that(episode).is_not_none()
-    assert episode is not None
-    assert_that(episode.title).is_equal_to("David Paulides")
-    assert_that(episode.episode_number).is_equal_to(2502)
+    parsed = cast("DiscoveredEpisode", episode)
+    assert_that(parsed.title).is_equal_to("Pilot")
+    assert_that(parsed.episode_number).is_equal_to(42)
 
 
 def test_upsert_persists_discovered_episode(db_session: Session) -> None:

--- a/backend/tests/test_discovery_orchestrator.py
+++ b/backend/tests/test_discovery_orchestrator.py
@@ -1,0 +1,104 @@
+"""Tests for idempotent episode discovery persistence."""
+
+from assertpy import assert_that
+from bs4 import BeautifulSoup
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.models import DiscoverySource, Episode, Podcast
+from podex.services.discovery import DiscoveredEpisode
+from podex.services.discovery_orchestrator import DiscoveryOrchestrator
+from podex.services.discovery_podscripts import PodscriptsDiscovery
+
+
+def test_upsert_matches_unnumbered_episode_by_provider_url(
+    db_session: Session,
+) -> None:
+    """Verify repeated provider discovery does not duplicate unnumbered episodes."""
+    podcast = Podcast(name="Crime Junkie", slug="crime-junkie")
+    db_session.add(podcast)
+    db_session.commit()
+    discovered = DiscoveredEpisode(
+        title="An Unnumbered Episode",
+        episode_url="https://podscripts.co/podcasts/crime-junkie/one-case",
+        has_transcript=True,
+        discovery_source="podscripts",
+    )
+
+    with DiscoveryOrchestrator(db_session) as orchestrator:
+        created = orchestrator._upsert_episodes(podcast, [discovered])
+        repeated = orchestrator._upsert_episodes(podcast, [discovered])
+
+    assert_that(created).is_equal_to((1, 0))
+    assert_that(repeated).is_equal_to((0, 0))
+    assert_that(db_session.query(Episode).count()).is_equal_to(1)
+
+
+def test_deduplicate_matches_repeated_provider_urls(db_session: Session) -> None:
+    """Verify duplicate provider links in discovery collapse to one episode."""
+    first = DiscoveredEpisode(
+        title="Episode listing title",
+        episode_url="https://podscripts.co/podcasts/pbd-podcast/a-conversation",
+        has_transcript=True,
+        discovery_source="podscripts",
+    )
+    repeated = DiscoveredEpisode(
+        title="Episode page title",
+        episode_url=first.episode_url,
+        has_transcript=True,
+        discovery_source="podscripts",
+    )
+
+    with DiscoveryOrchestrator(db_session) as orchestrator:
+        episodes = orchestrator._deduplicate_episodes([first, repeated])
+
+    assert_that(episodes).is_length(1)
+    assert_that(episodes[0].episode_url).is_equal_to(first.episode_url)
+
+
+def test_podscripts_episode_comment_link_falls_back_to_url_title() -> None:
+    """Verify comment-count link text cannot become an episode title."""
+    link = BeautifulSoup(
+        '<a href="/podcasts/example-show/42-pilot">0comments</a>',
+        "html.parser",
+    ).find("a")
+    assert link is not None
+
+    source = PodscriptsDiscovery(delay=0)
+    try:
+        episode = source._parse_episode_link(
+            link,
+            "/podcasts/example-show/42-pilot",
+            "example-show",
+        )
+    finally:
+        source.close()
+
+    assert_that(episode).is_not_none()
+    assert episode is not None
+    assert_that(episode.title).is_equal_to("David Paulides")
+    assert_that(episode.episode_number).is_equal_to(2502)
+
+
+def test_upsert_persists_discovered_episode(db_session: Session) -> None:
+    """A discovered episode round-trips through the orchestrator upsert."""
+    podcast = Podcast(name="Example Show", slug="example-show-upsert")
+    db_session.add(podcast)
+    db_session.commit()
+
+    orchestrator = DiscoveryOrchestrator(db_session)
+    discovered = DiscoveredEpisode(
+        title="Pilot",
+        rss_guid="urn:example:episode:1",
+        discovery_source="rss",
+    )
+    new_count, updated_count = orchestrator._upsert_episodes(
+        podcast,
+        [discovered],
+    )
+
+    assert_that(new_count).is_equal_to(1)
+    assert_that(updated_count).is_equal_to(0)
+    stored = db_session.execute(select(Episode)).scalar_one()
+    assert_that(stored.rss_guid).is_equal_to("urn:example:episode:1")
+    assert_that(stored.discovery_source).is_equal_to(DiscoverySource.RSS)

--- a/backend/tests/test_discovery_providers.py
+++ b/backend/tests/test_discovery_providers.py
@@ -1,0 +1,411 @@
+"""Tests for the RSS/Spotify discovery providers and orchestrator flows."""
+
+from datetime import UTC, datetime
+from typing import cast
+
+import httpx
+import pytest
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import Episode, Podcast
+from podex.services.discovery import DiscoveredEpisode, DiscoveredPodcast
+from podex.services.discovery_orchestrator import DiscoveryOrchestrator
+from podex.services.discovery_podscripts import PodscriptsDiscovery
+from podex.services.discovery_rss import RSSDiscovery
+from podex.services.discovery_spotify import SpotifyDiscovery
+
+_FEED = """<?xml version="1.0"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Example Show</title>
+    <description>A show about examples.</description>
+    <itunes:author>Example Author</itunes:author>
+    <image><url>https://cdn.example.com/cover.jpg</url></image>
+    <item>
+      <title>Pilot</title>
+      <guid>urn:example:episode:1</guid>
+      <link>https://podcasts.example.com/example-show/1</link>
+      <pubDate>Fri, 03 Jan 2026 10:00:00 GMT</pubDate>
+      <itunes:duration>1:02:03</itunes:duration>
+      <itunes:episode>1</itunes:episode>
+      <description>&lt;p&gt;The very first episode.&lt;/p&gt;</description>
+    </item>
+    <item>
+      <title>Untimed</title>
+      <guid>urn:example:episode:2</guid>
+      <itunes:duration>3600</itunes:duration>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+class _StubProvider:
+    """Minimal provider double returning canned episodes."""
+
+    name = "rss"
+    is_configured = True
+
+    def __init__(self, episodes: list[DiscoveredEpisode]) -> None:
+        self._episodes = episodes
+
+    def discover_podcast(self, identifier: str) -> DiscoveredPodcast | None:
+        """Return no podcast metadata; unused by these tests."""
+        del identifier
+        return None
+
+    def discover_episodes(
+        self,
+        podcast: Podcast,
+        since: datetime | None = None,
+    ) -> list[DiscoveredEpisode]:
+        """Return the canned episode list."""
+        del podcast, since
+        return self._episodes
+
+
+class _BoomProvider(_StubProvider):
+    """Provider double whose discovery always fails."""
+
+    def discover_episodes(
+        self,
+        podcast: Podcast,
+        since: datetime | None = None,
+    ) -> list[DiscoveredEpisode]:
+        """Always raise to exercise the error-capture path."""
+        del podcast, since
+        raise RuntimeError("feed exploded")
+
+
+def test_rss_discover_podcast_parses_channel_metadata() -> None:
+    """Channel metadata maps onto DiscoveredPodcast fields."""
+    podcast = RSSDiscovery().discover_podcast(_FEED)
+
+    assert_that(podcast).is_not_none()
+    parsed = cast("DiscoveredPodcast", podcast)
+    assert_that(parsed.name).is_equal_to("Example Show")
+    assert_that(parsed.description).contains("examples")
+    assert_that(parsed.discovery_source).is_equal_to("rss")
+
+
+def test_rss_discover_episodes_parses_entries(db_session: Session) -> None:
+    """Feed entries parse duration, guid, date, and stripped description."""
+    del db_session
+    stub = Podcast(name="Example Show", slug="example-show", rss_url=_FEED)
+
+    episodes = RSSDiscovery().discover_episodes(stub)
+
+    assert_that(episodes).is_length(2)
+    pilot = episodes[0]
+    assert_that(pilot.title).is_equal_to("Pilot")
+    assert_that(pilot.duration_seconds).is_equal_to(3723)
+    assert_that(pilot.episode_number).is_equal_to(1)
+    assert_that(pilot.rss_guid).is_equal_to("urn:example:episode:1")
+    assert_that(pilot.description).does_not_contain("<p>")
+    assert_that(pilot.published_at).is_equal_to(
+        datetime(2026, 1, 3, 10, 0, tzinfo=UTC),
+    )
+    assert_that(episodes[1].duration_seconds).is_equal_to(3600)
+
+
+def test_rss_duration_and_slug_helpers() -> None:
+    """Duration strings and slugs normalise across shapes."""
+    rss = RSSDiscovery()
+
+    assert_that(rss._parse_duration("2:30")).is_equal_to(150)
+    assert_that(rss._parse_duration("90")).is_equal_to(90)
+    assert_that(rss._parse_duration("nope")).is_none()
+    assert_that(rss._generate_slug("The Example Show!")).is_equal_to(
+        "the-example-show",
+    )
+
+
+def test_spotify_unconfigured_short_circuits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without credentials the Spotify provider degrades gracefully."""
+    monkeypatch.delenv("SPOTIFY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SPOTIFY_CLIENT_SECRET", raising=False)
+    spotify = SpotifyDiscovery()
+
+    assert_that(spotify.is_configured).is_false()
+    assert_that(spotify.discover_podcast("0abc123")).is_none()
+    stub = Podcast(name="Example Show", slug="example-show", spotify_id="0abc123")
+    assert_that(spotify.discover_episodes(stub)).is_empty()
+
+
+def test_spotify_parse_episode_maps_api_fields() -> None:
+    """A Spotify API item maps onto DiscoveredEpisode fields."""
+    item = {
+        "name": "Pilot",
+        "release_date": "2026-01-03",
+        "duration_ms": 3723000,
+        "external_urls": {"spotify": "https://open.spotify.com/episode/0abc"},
+        "uri": "spotify:episode:0abc",
+        "description": "d" * 1200,
+        "images": [{"url": "https://i.scdn.co/image/x"}],
+    }
+
+    episode = SpotifyDiscovery()._parse_episode(item)
+
+    assert_that(episode).is_not_none()
+    parsed = cast("DiscoveredEpisode", episode)
+    assert_that(parsed.duration_seconds).is_equal_to(3723)
+    assert_that(parsed.spotify_uri).is_equal_to("spotify:episode:0abc")
+    assert_that(parsed.published_at).is_equal_to(
+        datetime(2026, 1, 3, tzinfo=UTC),
+    )
+    assert_that(len(parsed.description or "")).is_less_than_or_equal_to(1003)
+
+
+def test_orchestrator_merges_sources_and_records_errors(
+    db_session: Session,
+) -> None:
+    """Discovery fans out, dedups across sources, and captures errors."""
+    podcast = Podcast(
+        name="Example Show",
+        slug="example-show-orch",
+        rss_url="ignored",
+        podscripts_slug="example-show",
+    )
+    db_session.add(podcast)
+    db_session.commit()
+
+    shared_date = datetime(2026, 1, 3, tzinfo=UTC)
+    rss_ep = DiscoveredEpisode(
+        title="Pilot",
+        published_at=shared_date,
+        rss_guid="urn:example:episode:1",
+        discovery_source="rss",
+    )
+    pod_ep = DiscoveredEpisode(
+        title="Pilot",
+        published_at=shared_date,
+        has_transcript=True,
+        discovery_source="podscripts",
+    )
+
+    orchestrator = DiscoveryOrchestrator(db_session)
+    orchestrator._sources = {
+        "rss": _StubProvider([rss_ep]),
+        "podscripts": _BoomProvider([pod_ep]),
+        "spotify": _StubProvider([]),
+    }
+    result = orchestrator.discover_for_podcast(podcast)
+
+    assert_that(result.new_episodes).is_equal_to(1)
+    assert_that(result.errors).is_length(1)
+    assert_that(result.errors[0]).contains("podscripts")
+
+    # Second run with both sources healthy dedups into the same episode.
+    orchestrator._sources["podscripts"] = _StubProvider([pod_ep])
+    second = orchestrator.discover_for_podcast(podcast)
+    assert_that(second.new_episodes).is_equal_to(0)
+    assert_that(
+        db_session.query(Episode).filter_by(podcast_id=podcast.id).count(),
+    ).is_equal_to(1)
+
+
+def _podscripts_source_with_html(pages: dict[int, str]) -> PodscriptsDiscovery:
+    """Return a podscripts provider whose HTTP client serves canned pages."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Serve the canned page for the requested page number."""
+        page = int(request.url.params.get("page", "1"))
+        return httpx.Response(200, text=pages.get(page, ""))
+
+    source = PodscriptsDiscovery(delay=0)
+    source.client = httpx.Client(transport=httpx.MockTransport(handler))
+    return source
+
+
+def test_podscripts_discover_podcast_parses_page() -> None:
+    """Podcast metadata comes from title/h1 and meta tags."""
+    html = (
+        "<html><head><title>Example Show - Podscripts</title>"
+        '<meta name="description" content="A show about examples.">'
+        '<meta property="og:image" content="https://cdn.example.com/c.jpg">'
+        "</head><body><h1>Example Show</h1></body></html>"
+    )
+    source = _podscripts_source_with_html({1: html})
+    try:
+        podcast = source.discover_podcast("example-show")
+    finally:
+        source.close()
+
+    assert_that(podcast).is_not_none()
+    parsed = cast("DiscoveredPodcast", podcast)
+    assert_that(parsed.name).is_equal_to("Example Show")
+    assert_that(parsed.description).is_equal_to("A show about examples.")
+    assert_that(parsed.cover_url).is_equal_to("https://cdn.example.com/c.jpg")
+
+
+def test_podscripts_discover_episodes_paginates_and_dedups(
+    db_session: Session,
+) -> None:
+    """Episode links parse across pages until an empty page stops the walk."""
+    del db_session
+    page1 = (
+        '<a href="/podcasts/example-show/42-pilot">Pilot</a>'
+        '<a href="/podcasts/example-show/42-pilot">Pilot dup</a>'
+        '<a href="/podcasts/example-show">index link ignored</a>'
+    )
+    source = _podscripts_source_with_html({1: page1})
+    stub = Podcast(
+        name="Example Show",
+        slug="example-show",
+        podscripts_slug="example-show",
+    )
+    try:
+        episodes = source.discover_episodes(stub)
+        empty = source.discover_episodes(
+            Podcast(name="No Slug", slug="no-slug"),
+        )
+    finally:
+        source.close()
+
+    assert_that(episodes).is_length(1)
+    assert_that(episodes[0].has_transcript).is_true()
+    assert_that(episodes[0].discovery_source).is_equal_to("podscripts")
+    assert_that(empty).is_empty()
+
+
+class _FakeSpotify:
+    """Stand-in for the spotipy client covering show + episodes calls."""
+
+    def show(self, spotify_id: str, market: str) -> dict[str, object]:
+        """Return canned show metadata."""
+        del spotify_id, market
+        return {
+            "name": "Example Show",
+            "description": "A show about examples.",
+            "publisher": "Example Author",
+            "images": [
+                {"url": "https://i.scdn.co/small", "height": 64},
+                {"url": "https://i.scdn.co/large", "height": 640},
+            ],
+        }
+
+    def show_episodes(
+        self,
+        spotify_id: str,
+        limit: int,
+        offset: int,
+        market: str,
+    ) -> dict[str, object] | None:
+        """Return one canned page of episodes then stop."""
+        del spotify_id, limit, market
+        if offset:
+            return {"items": [], "next": None}
+        return {
+            "items": [
+                {
+                    "name": "Pilot",
+                    "release_date": "2026-01-03",
+                    "duration_ms": 60000,
+                    "uri": "spotify:episode:0abc",
+                    "external_urls": {},
+                },
+            ],
+            "next": None,
+        }
+
+
+def test_spotify_configured_paths_use_client() -> None:
+    """With a client injected, show and episode discovery map API payloads."""
+    spotify = SpotifyDiscovery(
+        client_id="id",
+        client_secret="secret",  # nosec B106 - fake test credential
+    )
+    spotify._spotify = _FakeSpotify()
+
+    podcast = spotify.discover_podcast("0abc123")
+    assert_that(podcast).is_not_none()
+    parsed = cast("DiscoveredPodcast", podcast)
+    assert_that(parsed.name).is_equal_to("Example Show")
+    assert_that(parsed.cover_url).is_equal_to("https://i.scdn.co/large")
+
+    stub = Podcast(
+        name="Example Show",
+        slug="example-show",
+        spotify_id="0abc123",
+    )
+    episodes = spotify.discover_episodes(stub)
+    assert_that(episodes).is_length(1)
+    assert_that(episodes[0].spotify_uri).is_equal_to("spotify:episode:0abc")
+
+
+def test_orchestrator_merge_prefers_transcript_source_and_fills_gaps() -> None:
+    """Merging keeps the transcript source's title and unions metadata."""
+    base = DiscoveredEpisode(
+        title="Pilot (raw feed)",
+        rss_guid="urn:example:episode:1",
+        discovery_source="rss",
+    )
+    other = DiscoveredEpisode(
+        title="Pilot",
+        published_at=datetime(2026, 1, 3, tzinfo=UTC),
+        duration_seconds=3600,
+        episode_number=42,
+        description="The very first episode.",
+        episode_url="https://podcasts.example.com/example-show/1",
+        thumbnail_url="https://cdn.example.com/t.jpg",
+        youtube_id="dQw4w9WgXcQ",
+        spotify_uri="spotify:episode:0abc",
+        apple_id="123",
+        has_transcript=True,
+        discovery_source="podscripts",
+    )
+
+    merged = DiscoveryOrchestrator._merge_episodes(
+        cast("DiscoveryOrchestrator", object()),
+        [base, other],
+    )
+
+    assert_that(merged.title).is_equal_to("Pilot")
+    assert_that(merged.has_transcript).is_true()
+    assert_that(merged.duration_seconds).is_equal_to(3600)
+    assert_that(merged.episode_number).is_equal_to(42)
+    assert_that(merged.youtube_id).is_equal_to("dQw4w9WgXcQ")
+    assert_that(merged.spotify_uri).is_equal_to("spotify:episode:0abc")
+    assert_that(merged.apple_id).is_equal_to("123")
+    assert_that(merged.rss_guid).is_equal_to("urn:example:episode:1")
+
+
+def test_orchestrator_update_fills_missing_episode_fields(
+    db_session: Session,
+) -> None:
+    """Re-discovery fills gaps on an existing episode without overwriting."""
+    podcast = Podcast(name="Example Show", slug="example-show-update")
+    db_session.add(podcast)
+    db_session.commit()
+    episode = Episode(
+        podcast_id=podcast.id,
+        title="Pilot",
+        rss_guid="urn:example:episode:1",
+    )
+    db_session.add(episode)
+    db_session.commit()
+
+    richer = DiscoveredEpisode(
+        title="Pilot",
+        rss_guid="urn:example:episode:1",
+        published_at=datetime(2026, 1, 3, tzinfo=UTC),
+        duration_seconds=3600,
+        episode_url="https://podcasts.example.com/example-show/1",
+        thumbnail_url="https://cdn.example.com/t.jpg",
+        youtube_id="dQw4w9WgXcQ",
+        spotify_uri="spotify:episode:0abc",
+        apple_id="123",
+        discovery_source="rss",
+    )
+    orchestrator = DiscoveryOrchestrator(db_session)
+    new_count, updated_count = orchestrator._upsert_episodes(podcast, [richer])
+
+    assert_that(new_count).is_equal_to(0)
+    assert_that(updated_count).is_equal_to(1)
+    db_session.refresh(episode)
+    assert_that(episode.duration_seconds).is_equal_to(3600)
+    assert_that(episode.youtube_id).is_equal_to("dQw4w9WgXcQ")
+    assert_that(episode.spotify_uri).is_equal_to("spotify:episode:0abc")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -108,12 +108,99 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -267,6 +354,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
+]
+
+[[package]]
+name = "feedparser"
+version = "6.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
 ]
 
 [[package]]
@@ -809,11 +908,16 @@ version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "beautifulsoup4" },
     { name = "fastapi" },
+    { name = "feedparser" },
+    { name = "httpx" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "rapidfuzz" },
     { name = "redis" },
+    { name = "spotipy" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -833,11 +937,16 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
+    { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "feedparser", specifier = ">=6.0" },
+    { name = "httpx", specifier = ">=0.28" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "rapidfuzz", specifier = ">=3.9" },
     { name = "redis", specifier = ">=5.0" },
+    { name = "spotipy", specifier = ">=2.24" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
@@ -1158,6 +1267,85 @@ wheels = [
 ]
 
 [[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/f9/3c41a7be8855803f4f6c713b472226a98d31d41869d98f64f4ca790510d6/rapidfuzz-3.14.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e251126d48615e1f02b4a178f2cd0cd4f0332b8a019c01a2e10480f7552554b4", size = 1952372, upload-time = "2026-04-07T11:13:58.32Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/89/c2557e37531d03465193bff0ab9de70b468420a807d71a26a65100635459/rapidfuzz-3.14.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ab449c9abd0d4e1f8145dce0798a4c822a1a1933d613c764a641bea88b8bdab", size = 1159782, upload-time = "2026-04-07T11:14:00.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b2/ffeeb7eca1a897d51b998f4c0ef0281696c3b06abcca4f88f9def708ffe1/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb2829fedd672dd7107267189dabe2bbe07972801d636014417c6861eb89e358", size = 1383677, upload-time = "2026-04-07T11:14:01.696Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d0/4539e42a2d596e068f7738f279638a4a74edd1fbb6f8594e2458058979c6/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d50e5861872935fece391351cbb5ba21d1bced277cf5e1143d207a0a35f1925", size = 3168906, upload-time = "2026-04-07T11:14:03.29Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1c/3ec897eb9d8b05308aa8ef6ae4ed64b088ad521a3f9d8ff469e7e97bc2b0/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:7092a216728f80c960bd6b3807275d1ee318b168986bd5dc523349581d4890b8", size = 1478176, upload-time = "2026-04-07T11:14:04.94Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ba/970c03a12ce20a5399e22afe9f8932fd4cd1265b8a8461d0e63b00eb4eae/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9669753caef7fdc6529f6adcc5883ed98d65976445d9322e7dbdb6b697feee13", size = 2402441, upload-time = "2026-04-07T11:14:07.228Z" },
+    { url = "https://files.pythonhosted.org/packages/81/93/61d351cae60c1d0e21ba5ff1a1015ad045539ed215da9d6e302204ed887a/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:823b1b9d9230809d8edcc18872770764bfe8ef4357995e16744047c8ccf0e489", size = 2511628, upload-time = "2026-04-07T11:14:09.234Z" },
+    { url = "https://files.pythonhosted.org/packages/87/52/374d2d4f60fd98155142a869323aa221e30868cfa1f15171a0f64070c247/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f0b2af76b7e7060c09e1a0dfa9410eb19369cbe6164509bff2ef94094b54d2b6", size = 4275480, upload-time = "2026-04-07T11:14:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/04/82e7989bc9ec20a15b720a335c5cb6b0724bf6582013898f90a3280cfccd/rapidfuzz-3.14.5-cp311-cp311-win32.whl", hash = "sha256:c5801a89604c65ab4cc9e91b23bc4076d0ca80efd8c976fb63843d7879a85d7f", size = 1725627, upload-time = "2026-04-07T11:14:13.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b5/eca8ac5609bc9bcb02bb6ff87fa5983cc92b8772d66a431556ab8a8c178f/rapidfuzz-3.14.5-cp311-cp311-win_amd64.whl", hash = "sha256:d7ca16637c0ede8243f84074044bd0b2335a0341421f8227c85756de2d18c819", size = 1545977, upload-time = "2026-04-07T11:14:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e1/dbf318de28f65fa2cdd0a9dfbdee380f8199eb83b19259bc4f8592551b4e/rapidfuzz-3.14.5-cp311-cp311-win_arm64.whl", hash = "sha256:8c90cdf8516d9057e502aa6003cea71cf5ec27cc44699ca52412b502a04761bb", size = 816827, upload-time = "2026-04-07T11:14:16.788Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/252803f2010ba699618cdc048b6e1f7cc1f433c08b4a9a17579b92ab0142/rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6", size = 1940205, upload-time = "2026-04-07T11:14:40.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/59/b2afd98e41af9cd54554a4c1c423d84cdd60e6b1c0a09496f033b55f60ec/rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609", size = 1159639, upload-time = "2026-04-07T11:14:42.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f", size = 1367194, upload-time = "2026-04-07T11:14:44.25Z" },
+    { url = "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7", size = 3151805, upload-time = "2026-04-07T11:14:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/17/54/0c83508f2683ea70e2d05f8527eb07328acf7bb1e9d97a3bece5702378e7/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e", size = 1455667, upload-time = "2026-04-07T11:14:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1b/070175e873177814d58850a01ebe80e20ae11e93eb4da894d563988660fa/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610", size = 2388246, upload-time = "2026-04-07T11:14:50.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/77caf7aaf9c2be050ad1f128d7c24ff0f59079aa62c5f62f9df41c0af45e/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8", size = 2494333, upload-time = "2026-04-07T11:14:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/dd7e1f2aa31a8fbbfc16b0610af1d770ffaf1287490f3c8c5b1c52da264f/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98", size = 4258579, upload-time = "2026-04-07T11:14:54.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0a/ac99e1ba347ba0e85e0bb60b74231d55fb93c0eff43f2920ccb413d0be08/rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc", size = 1709231, upload-time = "2026-04-07T11:14:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cb/0e251d731b3166378644238e8f0cf9e89858c024e19f75ca9f7e3ae83fd5/rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35", size = 1538519, upload-time = "2026-04-07T11:14:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/4548132acc947db6d5346a248e44a8b3a22d608ef30e770fb578caaf2d00/rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd", size = 812628, upload-time = "2026-04-07T11:15:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/00/60/69b177577290c5eab892c6f75fe89c3aff3f9ae80298a78d9372b1cecb9a/rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8", size = 1970231, upload-time = "2026-04-07T11:15:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/48/38/2fd790052659cc4e2907b63c25433f0987864b445c1aeec1a302ef5ad948/rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9", size = 1194394, upload-time = "2026-04-07T11:15:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/28430ad8472fc3536e8ebd51a864a226e979cfe924c6e3f83d111373aa74/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d", size = 1377051, upload-time = "2026-04-07T11:15:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7e/9aeacabcfd1e77397968362e5b98fe14248b8307011136b17daf99752a8e/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074", size = 3160565, upload-time = "2026-04-07T11:15:08.667Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f4/db4dd7be0cd2f2022117ac5407d905f435d60e48baaea313a567ad27e865/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3", size = 1442113, upload-time = "2026-04-07T11:15:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/0e9f6aa57f3e32a767216f797e56dc96b720fcecfb9d8ee907ecc82f8d66/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09", size = 2396618, upload-time = "2026-04-07T11:15:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/44a78e39ffce17cbdd3e2b53b696acc751d5d153be0f499d052b07a4d904/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa", size = 2478220, upload-time = "2026-04-07T11:15:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/454311469a09a507e9d784a35796742bec22e4cebe75551e2da4e0e290fd/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1", size = 4265027, upload-time = "2026-04-07T11:15:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/01/175465a9ab3e3b70ba669058372f009d1d49c1746e2dcd56b69df188d3a5/rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f", size = 1766814, upload-time = "2026-04-07T11:15:19.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a9b84a47af06ebed94a1439eb2f02adebfb8628bcd30af1fe3e02f5ef56c/rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a", size = 1582448, upload-time = "2026-04-07T11:15:21.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/5937800238b3f8248e70860d79f69ba8f73e764fff47e36bc9e2f26dbcc6/rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895", size = 832932, upload-time = "2026-04-07T11:15:24.358Z" },
+    { url = "https://files.pythonhosted.org/packages/81/41/aa3ffb3355e62e1bf91f6599b3092e866bc88487a07c524004943c7676df/rapidfuzz-3.14.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1a31cc6d7d03e7318a0974c038959c59e19c752b81115f2e9138b3331cd64d45", size = 1943327, upload-time = "2026-04-07T11:15:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e1/c2141f1840a41e07ad2db6f724945f8f8ff3065463899a22939152dd6e09/rapidfuzz-3.14.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0298d357e2bc59d572da4db0bc631009b6f8f6c9bc8c11e99a12b833f16b6575", size = 1161755, upload-time = "2026-04-07T11:15:28.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/07/66e753eeaa353161d1d331b7dd517bb349b0bacfebe8496d7b26be26f81f/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59b3dba758661a318995655435c6ab20a04ade79fa51e75bc8dc107cac8df280", size = 1376571, upload-time = "2026-04-07T11:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/85/9535df0b78ba51f478c9ce7eb6d1f85535cc31fe356773b48fd9d3e563ca/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4900143d82071bdda533b00300c40b14b963ff826b3642cc463b6dd0f036585e", size = 3156468, upload-time = "2026-04-07T11:15:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ee/b667eb93bba6dc4e0de658edd778e1619dc4d6aab68fa5e5c7f075152735/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a", size = 1458311, upload-time = "2026-04-07T11:15:35.557Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ce/479074f5624364a48df3403c538797ef22d3ac49c19dc76c3f79fcdcc70c/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:419e4397a36e2665ec992d8d64c20ba4b2a42500c76ecadeca78a4f19cb9cc32", size = 2398228, upload-time = "2026-04-07T11:15:37.669Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/a8982f649150fffbdcd6f17565974501f6ab33b2795267bffbd4a7ba905b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:97131ab2be39043054ee28d99e09efe316e6d53449b7e962dfcf3c2de8b2b246", size = 2497226, upload-time = "2026-04-07T11:15:39.857Z" },
+    { url = "https://files.pythonhosted.org/packages/19/52/5267c03ef6759831b7d4625a0c9c06e87baa2fae084b61ac9c388858317b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:593c00dac4e30231c35bf3b4f1da8ec0998762e9e94425586a5d636fcd57f9d0", size = 4262283, upload-time = "2026-04-07T11:15:42.279Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c0/2579f343a97f5254c43bb5853baccc01488357dcb64a27bcb869b7888a4a/rapidfuzz-3.14.5-cp314-cp314-win32.whl", hash = "sha256:0084b687b02b4e569b46d8d6d4ad25659528e6081cd6d067ca453a69035f07e4", size = 1744614, upload-time = "2026-04-07T11:15:44.498Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/8edfed1e80119dc9c35b11df4bc701eea85622ad681fff0263b6961d3224/rapidfuzz-3.14.5-cp314-cp314-win_amd64.whl", hash = "sha256:5dfa89d78f22cd773054caff44827b846161a29f2dcf7e78b8f90d086621e502", size = 1588971, upload-time = "2026-04-07T11:15:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/04/5676df93c85cfa57a3045d8047318df9f3cd58c7b8a99340dd95f874795e/rapidfuzz-3.14.5-cp314-cp314-win_arm64.whl", hash = "sha256:67f3f9d2b444268ab53e47d31bab89954888d23c04c6789f2c727e51fe4b1d13", size = 834985, upload-time = "2026-04-07T11:15:49.411Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/4a8988cea658fe335048ddef8c876addff1b6daa3c9ca8ad65a5a2196e69/rapidfuzz-3.14.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:77eac0526899b3c3ad1454bb2b03cdb491d67358ec8ef0c9c48bd61b632b431d", size = 1972517, upload-time = "2026-04-07T11:15:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a3/f5cfd9965a9d9a9e32249159797c47b5d6299ea6d1629f9126b25f1c10a3/rapidfuzz-3.14.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b9c6bd754d11f6e78ac54e3d86b4b11dc1ba2f13e5fc958899574532897f5a99", size = 1196056, upload-time = "2026-04-07T11:15:54.292Z" },
+    { url = "https://files.pythonhosted.org/packages/64/07/561c2e40cfd10e6630a7b0ac5a2a813aef50d944bcd1f3d260319d659d5b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:738c96944d076deeaff70e92b65696ab4f7ecb8081d7791c5403a3257dfaf8ff", size = 1374732, upload-time = "2026-04-07T11:15:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/39/123bb94fee40e2fb3b7c49b80827c7ef42d838e18def3fc2fef5a3cf817a/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3", size = 3166902, upload-time = "2026-04-07T11:15:58.768Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/45716fafc9fd2e028cf20b5ac5bc704887081cd312f84edb0e325599414b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:af6a90a4ed2a48fa1a2d17e9d824e6c7c950bea5bad0b707c77fd55751e6bfef", size = 1452130, upload-time = "2026-04-07T11:16:01.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/49/4e96c413114398481c0a5b0086af32c364a18613c9a2ea578d17c4bea4ee/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bf5018938208d4597b2e679a4f8cff9fd252f1df53583130ae56281a21801b64", size = 2396308, upload-time = "2026-04-07T11:16:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b7/49fea9fc6878d59bd259d01dd1972d9b86117992b1c66d9b16f0a65273c3/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c0919d1f89ddf91129906705723118ea09754171e4116f5a5dbc667c7bc9b261", size = 2488210, upload-time = "2026-04-07T11:16:05.871Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/44/a1f732b93ffacbdad077b7c801149549b2938e1bece6addb5ad85ed74df8/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:93d8da883a35116d6813432177f35e570db5b0a5e30ecb0cbd7cb39c815735df", size = 4270621, upload-time = "2026-04-07T11:16:08.483Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/ff942d19fce5385054650bb71a58495ddda299d94661ccc4e6e7fa44868b/rapidfuzz-3.14.5-cp314-cp314t-win32.whl", hash = "sha256:0f23e37019ec07712d58976b1ab2b889f8649a7f7c2f626a2f34ea9139e79279", size = 1803950, upload-time = "2026-04-07T11:16:10.873Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0f/9aafc63f9661222b819b391c187eed29fc90ad5935f9690e5ecc2d2047a4/rapidfuzz-3.14.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7d5ca9c7832e6879a707296d1463685f7c243a27846227044504741640caec66", size = 1632357, upload-time = "2026-04-07T11:16:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/51fc1b0e61e3326e1c68a61cfd0c6b3c34c843681c4b1eefbf0596f59162/rapidfuzz-3.14.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3e91dcd2549b8f8d843f98ba03a17e01f3d8b72ce942adbbb6761bc58ffce813", size = 855409, upload-time = "2026-04-07T11:16:15.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ee/e71853bf82846c5c2174b924b71d8e8099fb05ff87c958a720380b434ba3/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:578e6051f6d5e6200c259b47a103cf06bb875ab5814d17333fc0b5c290b22f4c", size = 1888603, upload-time = "2026-04-07T11:16:18.223Z" },
+    { url = "https://files.pythonhosted.org/packages/36/82/40f67b730f32be2ebad9f62add1571c754f52249254b2e88af094b907eee/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fbf1b8bb2695415b347f3727da1addca2acb82c9b97ac86bebf8b1bead1eb12d", size = 1120599, upload-time = "2026-04-07T11:16:20.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/a3635cc4ec8fc6e14b46e7db1f7f8763d8c4bef33dcc124eea2e6cb2c8f3/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f4a8f5cc84c7ad6bffa0e9947b33eb343ad66e6b53e94fe54378a5508c5ed53", size = 1348524, upload-time = "2026-04-07T11:16:23.451Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1b/2b229520f0b48464cfcd7aa758f74551d12c9bc4ab544022a60210aab064/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c6d85283629646fa87acc22c66b30ea9d4de7f6fdf887daa2e30fa041829b5", size = 3099302, upload-time = "2026-04-07T11:16:25.858Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b5/363906b1064fc6fe611783a61764927bbd91919aaaabe8cba82151ca93ef/rapidfuzz-3.14.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:dfef96543ced67d9513a422755db422ae1dc34dade0a1485e0b43e7342ed3ebf", size = 1509889, upload-time = "2026-04-07T11:16:28.487Z" },
+]
+
+[[package]]
 name = "redis"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1167,6 +1355,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1183,12 +1386,41 @@ wheels = [
 ]
 
 [[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "spotipy"
+version = "2.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/00/2de6f99c9b8e5fd519fd55b11ec94b8e97a51e8a9fdf546edfe6aaf8727b/spotipy-2.26.0.tar.gz", hash = "sha256:df6a25d8209072efa8cea165608ee644884e3804f8762b6d8e06ca1a5c7f8a63", size = 45292, upload-time = "2026-03-03T16:37:39.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/ff/594b82c19b3291eb3f9454beba7f74f19753035fb9b3e54eebd5ae5013a6/spotipy-2.26.0-py3-none-any.whl", hash = "sha256:2726854ddfa0e5624aada592e737832ec75bdc00ae12c102779f8bd995329d49", size = 31985, upload-time = "2026-03-03T16:37:38.225Z" },
 ]
 
 [[package]]
@@ -1352,6 +1584,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(ingest): add discovery providers and cross-source dedup orchestrator`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Third slice of the discovery/ingest theme from the #108 split (source: the #103 branch, re-authored to main's conventions):

- `services/discovery.py`: `DiscoveredEpisode`/`DiscoveredPodcast`/`DiscoveryResult` types and a `DiscoveryProvider` protocol (renamed from the branch's `DiscoverySource` to avoid clashing with the models enum).
- Providers: RSS (`feedparser`), Spotify (`spotipy`, configured via `SPOTIFY_CLIENT_ID`/`SECRET` env vars, gracefully unconfigured otherwise), and podscripts.co (`httpx` + `beautifulsoup4`).
- `DiscoveryOrchestrator`: fans discovery across configured providers, deduplicates via source-id exact matches then rapidfuzz title+date fuzzy matching, and upserts onto the #245 tracking columns (fill-missing-fields on update).
- New runtime deps: `httpx`, `feedparser`, `beautifulsoup4`, `rapidfuzz`, `spotipy`.
- Boundary pass per #108: JRE-derived example slugs/URLs in docstrings and test fixtures neutralized to `example-show`; no credentials, hostnames beyond the providers' public API endpoints, or corpus data.

This closes #65; recurring scheduled discovery (#11) is the next slice.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #65
- Relates to #108

## Details

Verified: `uv run lintro tst` (153 passed — dedup/merge unit tests plus a DB round-trip upsert test proving raw provider strings coerce onto the `DiscoverySource` SAEnum column) and ruff/mypy/pydoclint clean on ported files.