### PR TITLE
feat(scheduler): add scheduling primitives and recurring episode discovery

### DIFF
--- a/backend/alembic/versions/0005_add_scheduled_work.py
+++ b/backend/alembic/versions/0005_add_scheduled_work.py
@@ -1,0 +1,130 @@
+"""Add podcast status and scheduled-work tables.
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-07-18 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_PODCAST_STATUSES = ("watchlist", "active", "paused")
+
+
+def upgrade() -> None:
+    """Create scheduling tables and the podcast lifecycle status."""
+    op.add_column(
+        "podcasts",
+        sa.Column(
+            "status",
+            sa.Enum(*_PODCAST_STATUSES, native_enum=False, length=20),
+            server_default="watchlist",
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_podcasts_status", "podcasts", ["status"])
+
+    op.create_table(
+        "pipeline_schedules",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("schedule_key", sa.String(length=160), nullable=False),
+        sa.Column("task_kind", sa.String(length=32), nullable=False),
+        sa.Column("interval_minutes", sa.Integer(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("last_scheduled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("next_due_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_pipeline_schedules_schedule_key",
+        "pipeline_schedules",
+        ["schedule_key"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_pipeline_schedules_task_kind",
+        "pipeline_schedules",
+        ["task_kind"],
+    )
+    op.create_index(
+        "ix_pipeline_schedules_enabled",
+        "pipeline_schedules",
+        ["enabled"],
+    )
+
+    op.create_table(
+        "scheduled_work_items",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("schedule_id", sa.Integer(), nullable=False),
+        sa.Column("ingestion_run_id", sa.Integer(), nullable=True),
+        sa.Column("schedule_key", sa.String(length=160), nullable=False),
+        sa.Column("work_key", sa.String(length=240), nullable=False),
+        sa.Column("task_kind", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("due_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("interval_minutes", sa.Integer(), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["schedule_id"], ["pipeline_schedules.id"]),
+        sa.ForeignKeyConstraint(["ingestion_run_id"], ["ingestion_runs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("work_key", name="uq_scheduled_work_items_work_key"),
+    )
+    op.create_index(
+        "ix_scheduled_work_items_schedule_id",
+        "scheduled_work_items",
+        ["schedule_id"],
+    )
+    op.create_index(
+        "ix_scheduled_work_items_ingestion_run_id",
+        "scheduled_work_items",
+        ["ingestion_run_id"],
+    )
+    op.create_index(
+        "ix_scheduled_work_items_schedule_key",
+        "scheduled_work_items",
+        ["schedule_key"],
+    )
+    op.create_index(
+        "ix_scheduled_work_items_work_key",
+        "scheduled_work_items",
+        ["work_key"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_scheduled_work_items_task_kind",
+        "scheduled_work_items",
+        ["task_kind"],
+    )
+    op.create_index(
+        "ix_scheduled_work_items_status",
+        "scheduled_work_items",
+        ["status"],
+    )
+    op.create_index(
+        "ix_scheduled_work_items_due_at",
+        "scheduled_work_items",
+        ["due_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop scheduling tables and the podcast status column."""
+    op.drop_table("scheduled_work_items")
+    op.drop_table("pipeline_schedules")
+    op.drop_index("ix_podcasts_status", table_name="podcasts")
+    op.drop_column("podcasts", "status")

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -9,7 +9,12 @@ from podex.models.episode import DiscoverySource, Episode
 from podex.models.ingestion_run import IngestionRun, IngestionRunStatus
 from podex.models.media import Media, MediaType
 from podex.models.mention import Mention
-from podex.models.podcast import Podcast
+from podex.models.podcast import Podcast, PodcastStatus
+from podex.models.scheduled_work import (
+    PipelineSchedule,
+    ScheduledWorkItemModel,
+    ScheduledWorkStatus,
+)
 
 __all__ = [
     "Base",
@@ -20,5 +25,9 @@ __all__ = [
     "Media",
     "MediaType",
     "Mention",
+    "PipelineSchedule",
     "Podcast",
+    "PodcastStatus",
+    "ScheduledWorkItemModel",
+    "ScheduledWorkStatus",
 ]

--- a/backend/src/podex/models/podcast.py
+++ b/backend/src/podex/models/podcast.py
@@ -1,6 +1,7 @@
 """Podcast source ORM model."""
 
 from datetime import datetime
+from enum import StrEnum, auto
 
 from sqlalchemy import DateTime, String, func
 from sqlalchemy import Enum as SAEnum
@@ -8,6 +9,14 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from podex.models.base import Base
 from podex.models.episode import DiscoverySource
+
+
+class PodcastStatus(StrEnum):
+    """Status of a podcast in the processing workflow."""
+
+    WATCHLIST = auto()
+    ACTIVE = auto()
+    PAUSED = auto()
 
 
 class Podcast(Base):
@@ -19,6 +28,12 @@ class Podcast(Base):
     name: Mapped[str] = mapped_column(String(255), index=True)
     slug: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     description: Mapped[str | None] = mapped_column(String(2000), default=None)
+    status: Mapped[PodcastStatus] = mapped_column(
+        SAEnum(PodcastStatus, native_enum=False, length=20),
+        default=PodcastStatus.WATCHLIST,
+        server_default=PodcastStatus.WATCHLIST.value,
+        index=True,
+    )
     # Provider handles used by discovery to locate this podcast's feeds.
     rss_url: Mapped[str | None] = mapped_column(
         String(500),

--- a/backend/src/podex/models/scheduled_work.py
+++ b/backend/src/podex/models/scheduled_work.py
@@ -1,0 +1,92 @@
+"""Scheduled pipeline work models."""
+
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.ingestion_run import IngestionRun
+
+
+class ScheduledWorkStatus(StrEnum):
+    """Lifecycle states for scheduled work items."""
+
+    PENDING = auto()
+    RUNNING = auto()
+    COMPLETED = auto()
+    FAILED = auto()
+    SKIPPED = auto()
+
+
+class PipelineSchedule(Base):
+    """Recurring pipeline schedule tracked for ops visibility."""
+
+    __tablename__ = "pipeline_schedules"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    schedule_key: Mapped[str] = mapped_column(String(160), unique=True, index=True)
+    task_kind: Mapped[str] = mapped_column(String(32), index=True)
+    interval_minutes: Mapped[int] = mapped_column()
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    last_scheduled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    next_due_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    work_items: Mapped[list["ScheduledWorkItemModel"]] = relationship(
+        back_populates="schedule",
+    )
+
+
+class ScheduledWorkItemModel(Base):
+    """Persisted scheduled work item with an idempotency key."""
+
+    __tablename__ = "scheduled_work_items"
+    __table_args__ = (
+        UniqueConstraint("work_key", name="uq_scheduled_work_items_work_key"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    schedule_id: Mapped[int] = mapped_column(
+        ForeignKey("pipeline_schedules.id"),
+        index=True,
+    )
+    ingestion_run_id: Mapped[int | None] = mapped_column(
+        ForeignKey("ingestion_runs.id"),
+        index=True,
+    )
+    schedule_key: Mapped[str] = mapped_column(String(160), index=True)
+    work_key: Mapped[str] = mapped_column(String(240), unique=True, index=True)
+    task_kind: Mapped[str] = mapped_column(String(32), index=True)
+    status: Mapped[str] = mapped_column(
+        String(32),
+        default=ScheduledWorkStatus.PENDING.value,
+        index=True,
+    )
+    due_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    interval_minutes: Mapped[int] = mapped_column()
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    error_message: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    schedule: Mapped[PipelineSchedule] = relationship(back_populates="work_items")
+    ingestion_run: Mapped["IngestionRun | None"] = relationship()

--- a/backend/src/podex/services/recurring_discovery.py
+++ b/backend/src/podex/services/recurring_discovery.py
@@ -1,0 +1,255 @@
+"""Recurring episode discovery scheduling and execution services."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    IngestionRun,
+    Podcast,
+    PodcastStatus,
+    ScheduledWorkItemModel,
+    ScheduledWorkStatus,
+)
+from podex.services.discovery import DiscoveryResult
+from podex.services.discovery_orchestrator import DiscoveryOrchestrator
+from podex.services.scheduled_work import (
+    PipelineScheduleInputData,
+    PipelineScheduleSummaryData,
+    plan_due_scheduled_work,
+    upsert_pipeline_schedule,
+)
+from podex.services.scheduler import ScheduledTaskKind
+
+DISCOVERY_WORK_KIND = "episode_discovery"
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveryScheduleResultData:
+    """Result of reconciling recurring discovery schedules."""
+
+    schedules: list[PipelineScheduleSummaryData]
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveryWorkRunData:
+    """Result of running one scheduled discovery work item."""
+
+    work_item_id: int
+    ingestion_run_id: int
+    podcast_id: int
+    podcast_slug: str
+    new_episodes: int
+    updated_episodes: int
+    total_discovered: int
+    errors: list[str]
+
+
+DiscoveryRunner = Callable[[Session, Podcast], DiscoveryResult]
+
+
+def reconcile_recurring_discovery_schedules(
+    *,
+    db: Session,
+    interval_minutes: int = 360,
+    now: datetime | None = None,
+) -> DiscoveryScheduleResultData:
+    """Ensure active podcasts have recurring episode discovery schedules.
+
+    Args:
+        db: Database session.
+        interval_minutes: Discovery cadence for active podcasts.
+        now: Deterministic timestamp for next-due calculation.
+
+    Returns:
+        Reconciled schedule summaries.
+    """
+    effective_now = now or datetime.now(UTC)
+    podcasts = (
+        db.query(Podcast)
+        .filter(Podcast.status == PodcastStatus.ACTIVE.value)
+        .order_by(Podcast.slug.asc())
+        .all()
+    )
+    schedules = [
+        upsert_pipeline_schedule(
+            db=db,
+            payload=PipelineScheduleInputData(
+                schedule_key=_discovery_schedule_key(podcast_id=podcast.id),
+                task_kind=ScheduledTaskKind.INGESTION,
+                interval_minutes=interval_minutes,
+                enabled=True,
+                metadata_json={
+                    "kind": DISCOVERY_WORK_KIND,
+                    "podcast_id": podcast.id,
+                    "podcast_slug": podcast.slug,
+                },
+                start_at=effective_now,
+            ),
+            now=effective_now,
+        )
+        for podcast in podcasts
+    ]
+    return DiscoveryScheduleResultData(schedules=schedules)
+
+
+def plan_recurring_discovery_work(
+    *,
+    db: Session,
+    interval_minutes: int = 360,
+    now: datetime | None = None,
+) -> list[ScheduledWorkItemModel]:
+    """Reconcile discovery schedules and persist due work items.
+
+    Args:
+        db: Database session.
+        interval_minutes: Discovery cadence for active podcasts.
+        now: Deterministic timestamp for planning.
+
+    Returns:
+        Newly persisted scheduled work item models.
+    """
+    effective_now = now or datetime.now(UTC)
+    reconcile_recurring_discovery_schedules(
+        db=db,
+        interval_minutes=interval_minutes,
+        now=effective_now,
+    )
+    planned = plan_due_scheduled_work(db=db, now=effective_now)
+    return [
+        db.query(ScheduledWorkItemModel)
+        .filter(
+            ScheduledWorkItemModel.id == item.id,
+        )
+        .one()
+        for item in planned
+        if _is_discovery_metadata(metadata=item.metadata_json)
+    ]
+
+
+def run_due_episode_discovery_work(
+    *,
+    db: Session,
+    runner: DiscoveryRunner | None = None,
+    limit: int = 10,
+) -> list[DiscoveryWorkRunData]:
+    """Run pending scheduled episode discovery work.
+
+    Args:
+        db: Database session.
+        runner: Optional discovery runner for tests or alternate execution.
+        limit: Maximum pending work items to run.
+
+    Returns:
+        Execution summaries.
+    """
+    effective_runner = runner or _run_discovery_orchestrator
+    pending_items = (
+        db.query(ScheduledWorkItemModel)
+        .filter(ScheduledWorkItemModel.status == ScheduledWorkStatus.PENDING.value)
+        .filter(ScheduledWorkItemModel.task_kind == ScheduledTaskKind.INGESTION.value)
+        .order_by(ScheduledWorkItemModel.due_at.asc(), ScheduledWorkItemModel.id.asc())
+        .limit(limit)
+        .all()
+    )
+    results: list[DiscoveryWorkRunData] = []
+
+    for work_item in pending_items:
+        if not _is_discovery_metadata(metadata=work_item.metadata_json):
+            continue
+
+        metadata = work_item.metadata_json or {}
+        podcast_id = metadata.get("podcast_id")
+        if not isinstance(podcast_id, int):
+            _mark_work_failed(work_item=work_item, error_message="Missing podcast_id")
+            continue
+
+        podcast = db.query(Podcast).filter(Podcast.id == podcast_id).first()
+        if podcast is None:
+            _mark_work_failed(work_item=work_item, error_message="Podcast not found")
+            continue
+
+        run = IngestionRun(
+            status="in_progress",
+            started_at=datetime.now(UTC),
+        )
+        db.add(run)
+        db.flush()
+
+        work_item.status = ScheduledWorkStatus.RUNNING.value
+        work_item.started_at = run.started_at
+        work_item.ingestion_run_id = run.id
+        db.flush()
+
+        try:
+            discovery_result = effective_runner(db, podcast)
+        except Exception as exc:
+            run.status = "failed"
+            run.error_summary = str(exc)
+            run.completed_at = datetime.now(UTC)
+            _mark_work_failed(work_item=work_item, error_message=str(exc))
+            continue
+
+        completed_at = datetime.now(UTC)
+        run.status = "completed" if not discovery_result.errors else "failed"
+        run.error_summary = "; ".join(discovery_result.errors) or None
+        run.completed_at = completed_at
+        work_item.status = (
+            ScheduledWorkStatus.COMPLETED.value
+            if not discovery_result.errors
+            else ScheduledWorkStatus.FAILED.value
+        )
+        work_item.error_message = run.error_summary
+        work_item.completed_at = completed_at
+        results.append(
+            DiscoveryWorkRunData(
+                work_item_id=work_item.id,
+                ingestion_run_id=run.id,
+                podcast_id=podcast.id,
+                podcast_slug=podcast.slug,
+                new_episodes=discovery_result.new_episodes,
+                updated_episodes=discovery_result.updated_episodes,
+                total_discovered=discovery_result.total_discovered,
+                errors=discovery_result.errors,
+            )
+        )
+
+    db.flush()
+    return results
+
+
+def _discovery_schedule_key(
+    *,
+    podcast_id: int,
+) -> str:
+    """Build the recurring discovery schedule key for a podcast."""
+    return f"discovery:podcast:{podcast_id}"
+
+
+def _is_discovery_metadata(
+    *,
+    metadata: dict[str, object] | None,
+) -> bool:
+    """Check whether scheduled work metadata describes episode discovery."""
+    return bool(metadata and metadata.get("kind") == DISCOVERY_WORK_KIND)
+
+
+def _mark_work_failed(
+    *,
+    work_item: ScheduledWorkItemModel,
+    error_message: str,
+) -> None:
+    """Mark a scheduled work item as failed."""
+    work_item.status = ScheduledWorkStatus.FAILED.value
+    work_item.error_message = error_message
+    work_item.completed_at = datetime.now(UTC)
+
+
+def _run_discovery_orchestrator(
+    db: Session,
+    podcast: Podcast,
+) -> DiscoveryResult:
+    """Run the existing discovery orchestrator for a podcast."""
+    return DiscoveryOrchestrator(db).discover_for_podcast(podcast=podcast)

--- a/backend/src/podex/services/scheduled_work.py
+++ b/backend/src/podex/services/scheduled_work.py
@@ -1,0 +1,284 @@
+"""DB-backed scheduled pipeline work services."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from podex.models import PipelineSchedule, ScheduledWorkItemModel, ScheduledWorkStatus
+from podex.services.scheduler import (
+    IntervalSchedule,
+    ScheduledTaskKind,
+    compute_due_work_items,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineScheduleInputData:
+    """Input for creating or updating a recurring pipeline schedule."""
+
+    schedule_key: str
+    task_kind: ScheduledTaskKind
+    interval_minutes: int
+    enabled: bool = True
+    metadata_json: dict[str, object] | None = None
+    start_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineScheduleSummaryData:
+    """Ops-visible schedule state."""
+
+    id: int
+    schedule_key: str
+    task_kind: ScheduledTaskKind
+    interval_minutes: int
+    enabled: bool
+    metadata_json: dict[str, object] | None
+    last_scheduled_at: datetime | None
+    next_due_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ScheduledWorkItemSummaryData:
+    """Ops-visible scheduled work item state."""
+
+    id: int
+    schedule_id: int
+    ingestion_run_id: int | None
+    schedule_key: str
+    work_key: str
+    task_kind: ScheduledTaskKind
+    status: ScheduledWorkStatus
+    due_at: datetime
+    interval_minutes: int
+    metadata_json: dict[str, object] | None
+    error_message: str | None
+    created_at: datetime
+    started_at: datetime | None
+    completed_at: datetime | None
+
+
+def upsert_pipeline_schedule(
+    *,
+    db: Session,
+    payload: PipelineScheduleInputData,
+    now: datetime | None = None,
+) -> PipelineScheduleSummaryData:
+    """Create or update a pipeline schedule.
+
+    Args:
+        db: Database session.
+        payload: Desired schedule state.
+        now: Timestamp used for deterministic next-due calculation.
+
+    Returns:
+        Updated schedule summary.
+    """
+    effective_now = now or datetime.now(UTC)
+    schedule = (
+        db.query(PipelineSchedule)
+        .filter(PipelineSchedule.schedule_key == payload.schedule_key)
+        .first()
+    )
+
+    if schedule is None:
+        schedule = PipelineSchedule(schedule_key=payload.schedule_key)
+        db.add(schedule)
+
+    schedule.task_kind = payload.task_kind.value
+    schedule.interval_minutes = payload.interval_minutes
+    schedule.enabled = payload.enabled
+    schedule.metadata_json = payload.metadata_json
+    if schedule.last_scheduled_at is None and schedule.next_due_at is None:
+        schedule.next_due_at = payload.start_at or effective_now
+    else:
+        schedule.next_due_at = _next_due_after(
+            start_at=schedule.last_scheduled_at
+            or payload.start_at
+            or schedule.next_due_at
+            or effective_now,
+            interval_minutes=payload.interval_minutes,
+            after=effective_now,
+        )
+    db.flush()
+    return _to_schedule_summary(schedule=schedule)
+
+
+def plan_due_scheduled_work(
+    *,
+    db: Session,
+    now: datetime | None = None,
+) -> list[ScheduledWorkItemSummaryData]:
+    """Plan due scheduled work and persist idempotent work items.
+
+    Args:
+        db: Database session.
+        now: Evaluation timestamp.
+
+    Returns:
+        Newly created scheduled work items.
+    """
+    effective_now = now or datetime.now(UTC)
+    schedules = (
+        db.query(PipelineSchedule)
+        .filter(PipelineSchedule.enabled.is_(True))
+        .order_by(PipelineSchedule.schedule_key.asc())
+        .all()
+    )
+    interval_schedules = [
+        IntervalSchedule(
+            key=schedule.schedule_key,
+            task_kind=ScheduledTaskKind(schedule.task_kind),
+            interval_minutes=schedule.interval_minutes,
+            enabled=schedule.enabled,
+            last_scheduled_at=schedule.last_scheduled_at,
+            start_at=schedule.next_due_at
+            or schedule.last_scheduled_at
+            or schedule.created_at,
+        )
+        for schedule in schedules
+    ]
+    due_items = compute_due_work_items(
+        schedules=interval_schedules,
+        now=effective_now,
+    )
+    schedules_by_key = {schedule.schedule_key: schedule for schedule in schedules}
+    created_items: list[ScheduledWorkItemModel] = []
+
+    for due_item in due_items:
+        existing = (
+            db.query(ScheduledWorkItemModel)
+            .filter(ScheduledWorkItemModel.work_key == due_item.work_key)
+            .first()
+        )
+        schedule = schedules_by_key[due_item.schedule_key]
+        schedule.last_scheduled_at = due_item.due_at
+        schedule.next_due_at = due_item.due_at + timedelta(
+            minutes=due_item.interval_minutes,
+        )
+        if existing is not None:
+            continue
+
+        work_item = ScheduledWorkItemModel(
+            schedule_id=schedule.id,
+            schedule_key=schedule.schedule_key,
+            work_key=due_item.work_key,
+            task_kind=due_item.task_kind.value,
+            status=ScheduledWorkStatus.PENDING.value,
+            due_at=due_item.due_at,
+            interval_minutes=due_item.interval_minutes,
+            metadata_json=schedule.metadata_json,
+        )
+        db.add(work_item)
+        created_items.append(work_item)
+
+    db.flush()
+    return [_to_work_item_summary(work_item=item) for item in created_items]
+
+
+def list_pipeline_schedules(
+    *,
+    db: Session,
+) -> list[PipelineScheduleSummaryData]:
+    """List pipeline schedules for ops views.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        Schedule summaries ordered by key.
+    """
+    schedules = (
+        db.query(PipelineSchedule).order_by(PipelineSchedule.schedule_key.asc()).all()
+    )
+    return [_to_schedule_summary(schedule=schedule) for schedule in schedules]
+
+
+def list_scheduled_work_items(
+    *,
+    db: Session,
+    limit: int = 50,
+    status: ScheduledWorkStatus | None = None,
+) -> list[ScheduledWorkItemSummaryData]:
+    """List scheduled work items for ops views.
+
+    Args:
+        db: Database session.
+        limit: Maximum number of work items to return.
+        status: Optional status filter.
+
+    Returns:
+        Scheduled work item summaries ordered by recency.
+    """
+    query = db.query(ScheduledWorkItemModel)
+    if status is not None:
+        query = query.filter(ScheduledWorkItemModel.status == status.value)
+
+    items = (
+        query.order_by(
+            ScheduledWorkItemModel.due_at.desc(),
+            ScheduledWorkItemModel.id.desc(),
+        )
+        .limit(limit)
+        .all()
+    )
+    return [_to_work_item_summary(work_item=item) for item in items]
+
+
+def _next_due_after(
+    *,
+    start_at: datetime,
+    interval_minutes: int,
+    after: datetime,
+) -> datetime:
+    """Calculate the next due timestamp after a reference time."""
+    if start_at > after:
+        return start_at
+    interval = timedelta(minutes=interval_minutes)
+    elapsed_intervals = ((after - start_at) // interval) + 1
+    return start_at + (elapsed_intervals * interval)
+
+
+def _to_schedule_summary(
+    *,
+    schedule: PipelineSchedule,
+) -> PipelineScheduleSummaryData:
+    """Convert a schedule model into a summary."""
+    return PipelineScheduleSummaryData(
+        id=schedule.id,
+        schedule_key=schedule.schedule_key,
+        task_kind=ScheduledTaskKind(schedule.task_kind),
+        interval_minutes=schedule.interval_minutes,
+        enabled=schedule.enabled,
+        metadata_json=schedule.metadata_json,
+        last_scheduled_at=schedule.last_scheduled_at,
+        next_due_at=schedule.next_due_at,
+        created_at=schedule.created_at,
+        updated_at=schedule.updated_at,
+    )
+
+
+def _to_work_item_summary(
+    *,
+    work_item: ScheduledWorkItemModel,
+) -> ScheduledWorkItemSummaryData:
+    """Convert a scheduled work item model into a summary."""
+    return ScheduledWorkItemSummaryData(
+        id=work_item.id,
+        schedule_id=work_item.schedule_id,
+        ingestion_run_id=work_item.ingestion_run_id,
+        schedule_key=work_item.schedule_key,
+        work_key=work_item.work_key,
+        task_kind=ScheduledTaskKind(work_item.task_kind),
+        status=ScheduledWorkStatus(work_item.status),
+        due_at=work_item.due_at,
+        interval_minutes=work_item.interval_minutes,
+        metadata_json=work_item.metadata_json,
+        error_message=work_item.error_message,
+        created_at=work_item.created_at,
+        started_at=work_item.started_at,
+        completed_at=work_item.completed_at,
+    )

--- a/backend/src/podex/services/scheduler.py
+++ b/backend/src/podex/services/scheduler.py
@@ -1,0 +1,148 @@
+"""Pure interval scheduler planning services."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum, auto
+
+SCHEDULER_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
+
+class ScheduledTaskKind(StrEnum):
+    """Kinds of work the scheduler can plan."""
+
+    INGESTION = auto()
+    REINDEX = auto()
+    DIGEST = auto()
+    RETENTION = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class IntervalSchedule:
+    """Definition for a recurring interval schedule.
+
+    Args:
+        key: Stable schedule identifier used for idempotency.
+        task_kind: Kind of task to plan when the schedule is due.
+        interval_minutes: Interval cadence in whole minutes.
+        enabled: Whether the schedule should produce work.
+        last_scheduled_at: Most recent interval that was planned or enqueued.
+        start_at: Anchor time used to calculate interval boundaries.
+
+    Raises:
+        ValueError: If the key is blank or the interval is invalid.
+    """
+
+    key: str
+    task_kind: ScheduledTaskKind
+    interval_minutes: int
+    enabled: bool = True
+    last_scheduled_at: datetime | None = None
+    start_at: datetime = SCHEDULER_EPOCH
+
+    def __post_init__(self) -> None:
+        """Validate the schedule definition."""
+        if not self.key.strip():
+            raise ValueError("Schedule key must not be blank")
+        if self.interval_minutes <= 0:
+            raise ValueError("Schedule interval_minutes must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class ScheduledWorkItem:
+    """A planned unit of scheduled work.
+
+    Args:
+        schedule_key: Stable identifier of the schedule that produced the item.
+        work_key: Stable idempotency key for this schedule interval.
+        task_kind: Kind of task to run.
+        due_at: Interval boundary that made the work due.
+        interval_minutes: Interval cadence from the originating schedule.
+    """
+
+    schedule_key: str
+    work_key: str
+    task_kind: ScheduledTaskKind
+    due_at: datetime
+    interval_minutes: int
+
+
+def compute_due_work_items(
+    *,
+    schedules: Iterable[IntervalSchedule],
+    now: datetime | None = None,
+) -> list[ScheduledWorkItem]:
+    """Compute scheduled work items due at a deterministic point in time.
+
+    Args:
+        schedules: Schedule definitions to evaluate.
+        now: Time to evaluate against. Uses the current UTC time when omitted.
+
+    Returns:
+        Due work items in the same order as the input schedules.
+    """
+    effective_now = _as_utc(now or datetime.now(UTC))
+    work_items: list[ScheduledWorkItem] = []
+
+    for schedule in schedules:
+        due_at = _due_interval_start(
+            schedule=schedule,
+            now=effective_now,
+        )
+        if due_at is None:
+            continue
+        if schedule.last_scheduled_at is not None:
+            last_scheduled_at = _as_utc(schedule.last_scheduled_at)
+            if last_scheduled_at >= due_at:
+                continue
+
+        work_items.append(
+            ScheduledWorkItem(
+                schedule_key=schedule.key,
+                work_key=_build_work_key(
+                    schedule_key=schedule.key,
+                    task_kind=schedule.task_kind,
+                    due_at=due_at,
+                ),
+                task_kind=schedule.task_kind,
+                due_at=due_at,
+                interval_minutes=schedule.interval_minutes,
+            )
+        )
+
+    return work_items
+
+
+def _due_interval_start(
+    *,
+    schedule: IntervalSchedule,
+    now: datetime,
+) -> datetime | None:
+    """Return the current due interval boundary for a schedule."""
+    if not schedule.enabled:
+        return None
+
+    start_at = _as_utc(schedule.start_at)
+    if now < start_at:
+        return None
+
+    interval = timedelta(minutes=schedule.interval_minutes)
+    elapsed_intervals = (now - start_at) // interval
+    return start_at + (elapsed_intervals * interval)
+
+
+def _build_work_key(
+    *,
+    schedule_key: str,
+    task_kind: ScheduledTaskKind,
+    due_at: datetime,
+) -> str:
+    """Build a stable idempotency key for one schedule interval."""
+    return f"{schedule_key}:{task_kind.value}:{due_at.isoformat()}"
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normalize aware and naive datetimes to UTC."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/backend/tests/test_recurring_discovery.py
+++ b/backend/tests/test_recurring_discovery.py
@@ -1,0 +1,95 @@
+"""Tests for recurring episode discovery scheduling."""
+
+from datetime import UTC, datetime
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import IngestionRun, Podcast, ScheduledWorkItemModel
+from podex.services.discovery import DiscoveryResult
+from podex.services.recurring_discovery import (
+    plan_recurring_discovery_work,
+    reconcile_recurring_discovery_schedules,
+    run_due_episode_discovery_work,
+)
+
+
+def test_reconcile_recurring_discovery_schedules_only_tracks_active_podcasts(
+    db_session: Session,
+) -> None:
+    """Verify recurring discovery schedules are created for active podcasts."""
+    active = Podcast(name="Active", slug="active", status="active")
+    paused = Podcast(name="Paused", slug="paused", status="paused")
+    db_session.add_all([active, paused])
+    db_session.commit()
+
+    result = reconcile_recurring_discovery_schedules(
+        db=db_session,
+        interval_minutes=60,
+        now=datetime(2026, 5, 10, 12, 0, tzinfo=UTC),
+    )
+    db_session.commit()
+
+    assert_that(result.schedules).is_length(1)
+    assert_that(result.schedules[0].schedule_key).is_equal_to(
+        f"discovery:podcast:{active.id}",
+    )
+    assert_that(result.schedules[0].metadata_json).contains_entry(
+        {"podcast_slug": "active"},
+    )
+
+
+def test_plan_recurring_discovery_work_creates_due_work(
+    db_session: Session,
+) -> None:
+    """Verify recurring discovery planning persists due scheduled work."""
+    podcast = Podcast(name="Active", slug="active", status="active")
+    db_session.add(podcast)
+    db_session.commit()
+
+    work_items = plan_recurring_discovery_work(
+        db=db_session,
+        interval_minutes=60,
+        now=datetime(2026, 5, 10, 12, 0, tzinfo=UTC),
+    )
+    db_session.commit()
+
+    assert_that(work_items).is_length(1)
+    assert_that(work_items[0].metadata_json).contains_entry(
+        {"kind": "episode_discovery"}
+    )
+    assert_that(db_session.query(ScheduledWorkItemModel).count()).is_equal_to(1)
+
+
+def test_run_due_episode_discovery_work_uses_runner_and_ingestion_run(
+    db_session: Session,
+) -> None:
+    """Verify pending discovery work runs through an injected runner."""
+    podcast = Podcast(name="Active", slug="active", status="active")
+    db_session.add(podcast)
+    db_session.commit()
+    plan_recurring_discovery_work(
+        db=db_session,
+        interval_minutes=60,
+        now=datetime(2026, 5, 10, 12, 0, tzinfo=UTC),
+    )
+    db_session.commit()
+
+    def runner(_db: Session, run_podcast: Podcast) -> DiscoveryResult:
+        assert_that(run_podcast.id).is_equal_to(podcast.id)
+        return DiscoveryResult(
+            new_episodes=2,
+            updated_episodes=1,
+            total_discovered=3,
+        )
+
+    results = run_due_episode_discovery_work(db=db_session, runner=runner)
+    db_session.commit()
+
+    work_item = db_session.query(ScheduledWorkItemModel).one()
+    run = db_session.query(IngestionRun).one()
+    assert_that(results).is_length(1)
+    assert_that(results[0].new_episodes).is_equal_to(2)
+    assert_that(work_item.status).is_equal_to("completed")
+    assert_that(work_item.ingestion_run_id).is_equal_to(run.id)
+    assert_that(run.status).is_equal_to("completed")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(scheduler): add scheduling primitives and recurring episode discovery`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Final slice of the discovery/ingest theme from the #108 split (source: the #103 branch, re-authored to main's conventions):

- `services/scheduler.py`: pure interval-schedule primitives — `ScheduledTaskKind`, `IntervalSchedule`, `compute_due_work_items` with idempotent work keys.
- `models/scheduled_work.py` + migration `0005`: persisted `PipelineSchedule` and `ScheduledWorkItemModel` (unique `work_key` for replay safety), linked to `IngestionRun` audit rows.
- `Podcast.status`: `watchlist/active/paused` `PodcastStatus` StrEnum (deferred from #245) — recurring discovery only targets active podcasts.
- `services/scheduled_work.py` + `services/recurring_discovery.py`: plan due work, execute discovery via the #247 orchestrator, record per-run outcomes.
- Out of scope, deliberately: `recurring_maintenance.py` depends on search-projection/retention/audit-log modules that land with their own themes.

Recurring **ingestion** is delivered; #11 stays open (Related, not Closes) until its reindex and digest jobs land with the search and notifications themes.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #11
- Relates to #108

## Details

Verified: `uv run lintro tst` (167 passed, including the migration replay + drift guard and the ported recurring-discovery tests) with 86.3% coverage (85% gate), ruff/mypy/bandit/pydoclint clean.