### PR TITLE
feat(models): add transcript, mention-candidate, and review-queue models

### DIFF
--- a/backend/alembic/versions/0006_add_extraction_models.py
+++ b/backend/alembic/versions/0006_add_extraction_models.py
@@ -1,0 +1,163 @@
+"""Add transcripts, mention candidates, provenance, and review items.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-07-18 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the extraction-workflow tables."""
+    op.create_table(
+        "transcripts",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("episode_id", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.String(length=50), nullable=False),
+        sa.Column("raw_text", sa.Text(), nullable=True),
+        sa.Column("segments_json", sa.JSON(), nullable=True),
+        sa.Column("fetched_at", sa.DateTime(), nullable=True),
+        sa.Column("cleaned_text", sa.Text(), nullable=True),
+        sa.Column("cleaned_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["episode_id"], ["episodes.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_transcripts_episode_id", "transcripts", ["episode_id"])
+
+    op.create_table(
+        "mention_candidates",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("episode_id", sa.Integer(), nullable=False),
+        sa.Column("media_id", sa.Integer(), nullable=True),
+        sa.Column("mention_id", sa.Integer(), nullable=True),
+        sa.Column("media_type", sa.String(length=20), nullable=False),
+        sa.Column("raw_title", sa.String(length=500), nullable=False),
+        sa.Column("normalized_title", sa.String(length=500), nullable=True),
+        sa.Column("suggested_author", sa.String(length=255), nullable=True),
+        sa.Column("timestamp_seconds", sa.Integer(), nullable=True),
+        sa.Column("context", sa.Text(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("extraction_source", sa.String(length=50), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("state", sa.String(length=32), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["episode_id"], ["episodes.id"]),
+        sa.ForeignKeyConstraint(["media_id"], ["media.id"]),
+        sa.ForeignKeyConstraint(["mention_id"], ["mentions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_mention_candidates_episode_id",
+        "mention_candidates",
+        ["episode_id"],
+    )
+    op.create_index(
+        "ix_mention_candidates_media_id",
+        "mention_candidates",
+        ["media_id"],
+    )
+    op.create_index(
+        "ix_mention_candidates_mention_id",
+        "mention_candidates",
+        ["mention_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_mention_candidates_media_type",
+        "mention_candidates",
+        ["media_type"],
+    )
+    op.create_index("ix_mention_candidates_state", "mention_candidates", ["state"])
+
+    op.create_table(
+        "mention_candidate_provenance",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("mention_candidate_id", sa.Integer(), nullable=False),
+        sa.Column("media_id", sa.Integer(), nullable=True),
+        sa.Column("event_type", sa.String(length=32), nullable=False),
+        sa.Column("change_summary", sa.Text(), nullable=True),
+        sa.Column("raw_title", sa.String(length=500), nullable=False),
+        sa.Column("normalized_title", sa.String(length=500), nullable=True),
+        sa.Column("suggested_author", sa.String(length=255), nullable=True),
+        sa.Column("timestamp_seconds", sa.Integer(), nullable=True),
+        sa.Column("context", sa.Text(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("extraction_source", sa.String(length=50), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["mention_candidate_id"],
+            ["mention_candidates.id"],
+        ),
+        sa.ForeignKeyConstraint(["media_id"], ["media.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_mention_candidate_provenance_mention_candidate_id",
+        "mention_candidate_provenance",
+        ["mention_candidate_id"],
+    )
+    op.create_index(
+        "ix_mention_candidate_provenance_media_id",
+        "mention_candidate_provenance",
+        ["media_id"],
+    )
+    op.create_index(
+        "ix_mention_candidate_provenance_event_type",
+        "mention_candidate_provenance",
+        ["event_type"],
+    )
+
+    op.create_table(
+        "review_items",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("mention_candidate_id", sa.Integer(), nullable=False),
+        sa.Column("target_media_id", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("priority", sa.String(length=16), nullable=False),
+        sa.Column("assigned_to", sa.String(length=100), nullable=True),
+        sa.Column("decision_note", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("decided_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["mention_candidate_id"],
+            ["mention_candidates.id"],
+        ),
+        sa.ForeignKeyConstraint(["target_media_id"], ["media.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_review_items_mention_candidate_id",
+        "review_items",
+        ["mention_candidate_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_review_items_target_media_id",
+        "review_items",
+        ["target_media_id"],
+    )
+    op.create_index("ix_review_items_status", "review_items", ["status"])
+    op.create_index("ix_review_items_priority", "review_items", ["priority"])
+
+
+def downgrade() -> None:
+    """Drop the extraction-workflow tables."""
+    op.drop_table("review_items")
+    op.drop_table("mention_candidate_provenance")
+    op.drop_table("mention_candidates")
+    op.drop_table("transcripts")

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -9,12 +9,19 @@ from podex.models.episode import DiscoverySource, Episode
 from podex.models.ingestion_run import IngestionRun, IngestionRunStatus
 from podex.models.media import Media, MediaType
 from podex.models.mention import Mention
+from podex.models.mention_candidate import MentionCandidate, MentionCandidateState
+from podex.models.mention_candidate_provenance import (
+    MentionCandidateProvenance,
+    MentionCandidateProvenanceEventType,
+)
 from podex.models.podcast import Podcast, PodcastStatus
+from podex.models.review_item import ReviewItem, ReviewItemStatus, ReviewPriority
 from podex.models.scheduled_work import (
     PipelineSchedule,
     ScheduledWorkItemModel,
     ScheduledWorkStatus,
 )
+from podex.models.transcript import Transcript
 
 __all__ = [
     "Base",
@@ -25,9 +32,17 @@ __all__ = [
     "Media",
     "MediaType",
     "Mention",
+    "MentionCandidate",
+    "MentionCandidateProvenance",
+    "MentionCandidateProvenanceEventType",
+    "MentionCandidateState",
     "PipelineSchedule",
     "Podcast",
     "PodcastStatus",
+    "ReviewItem",
+    "ReviewItemStatus",
+    "ReviewPriority",
     "ScheduledWorkItemModel",
+    "Transcript",
     "ScheduledWorkStatus",
 ]

--- a/backend/src/podex/models/episode.py
+++ b/backend/src/podex/models/episode.py
@@ -2,12 +2,16 @@
 
 from datetime import datetime
 from enum import StrEnum, auto
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, ForeignKey, Index, String, func
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.transcript import Transcript
 
 
 class DiscoverySource(StrEnum):
@@ -69,4 +73,8 @@ class Episode(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
+    )
+
+    transcripts: Mapped[list["Transcript"]] = relationship(
+        back_populates="episode",
     )

--- a/backend/src/podex/models/mention_candidate.py
+++ b/backend/src/podex/models/mention_candidate.py
@@ -1,0 +1,74 @@
+"""Mention candidate model."""
+
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import JSON, Float, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.episode import Episode
+    from podex.models.media import Media
+    from podex.models.mention import Mention
+    from podex.models.mention_candidate_provenance import MentionCandidateProvenance
+    from podex.models.review_item import ReviewItem
+
+
+class MentionCandidateState(StrEnum):
+    """Lifecycle states for extracted mention candidates."""
+
+    PENDING_REVIEW = auto()
+    PUBLISHED = auto()
+    REJECTED = auto()
+    MERGED = auto()
+    SPLIT = auto()
+
+
+class MentionCandidate(Base):
+    """Candidate mention extracted from an episode before publication."""
+
+    __tablename__ = "mention_candidates"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    episode_id: Mapped[int] = mapped_column(ForeignKey("episodes.id"), index=True)
+    media_id: Mapped[int | None] = mapped_column(ForeignKey("media.id"), index=True)
+    mention_id: Mapped[int | None] = mapped_column(
+        ForeignKey("mentions.id"),
+        unique=True,
+        index=True,
+    )
+    media_type: Mapped[str] = mapped_column(String(20), index=True)
+    raw_title: Mapped[str] = mapped_column(String(500))
+    normalized_title: Mapped[str | None] = mapped_column(String(500))
+    suggested_author: Mapped[str | None] = mapped_column(String(255))
+    timestamp_seconds: Mapped[int | None] = mapped_column()
+    context: Mapped[str | None] = mapped_column(Text)
+    confidence: Mapped[float] = mapped_column(Float, default=0.0)
+    extraction_source: Mapped[str | None] = mapped_column(String(50))
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    state: Mapped[str] = mapped_column(
+        String(32),
+        index=True,
+        default=MentionCandidateState.PENDING_REVIEW.value,
+    )
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+    reviewed_at: Mapped[datetime | None] = mapped_column()
+
+    episode: Mapped["Episode"] = relationship()
+    media: Mapped["Media | None"] = relationship()
+    mention: Mapped["Mention | None"] = relationship()
+    review_item: Mapped["ReviewItem | None"] = relationship(
+        back_populates="mention_candidate",
+        uselist=False,
+    )
+    provenance_events: Mapped[list["MentionCandidateProvenance"]] = relationship(
+        back_populates="mention_candidate",
+        order_by="desc(MentionCandidateProvenance.created_at)",
+    )

--- a/backend/src/podex/models/mention_candidate_provenance.py
+++ b/backend/src/podex/models/mention_candidate_provenance.py
@@ -1,0 +1,50 @@
+"""Mention candidate provenance model."""
+
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import JSON, Float, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+    from podex.models.mention_candidate import MentionCandidate
+
+
+class MentionCandidateProvenanceEventType(StrEnum):
+    """Event types recorded for candidate extraction provenance."""
+
+    CREATED = auto()
+    UPDATED = auto()
+
+
+class MentionCandidateProvenance(Base):
+    """Immutable provenance snapshot for a mention candidate extraction event."""
+
+    __tablename__ = "mention_candidate_provenance"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    mention_candidate_id: Mapped[int] = mapped_column(
+        ForeignKey("mention_candidates.id"),
+        index=True,
+    )
+    media_id: Mapped[int | None] = mapped_column(ForeignKey("media.id"), index=True)
+    event_type: Mapped[str] = mapped_column(String(32), index=True)
+    change_summary: Mapped[str | None] = mapped_column(Text)
+    raw_title: Mapped[str] = mapped_column(String(500))
+    normalized_title: Mapped[str | None] = mapped_column(String(500))
+    suggested_author: Mapped[str | None] = mapped_column(String(255))
+    timestamp_seconds: Mapped[int | None] = mapped_column()
+    context: Mapped[str | None] = mapped_column(Text)
+    confidence: Mapped[float] = mapped_column(Float, default=0.0)
+    extraction_source: Mapped[str | None] = mapped_column(String(50))
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+
+    mention_candidate: Mapped["MentionCandidate"] = relationship(
+        back_populates="provenance_events",
+    )
+    media: Mapped["Media | None"] = relationship()

--- a/backend/src/podex/models/review_item.py
+++ b/backend/src/podex/models/review_item.py
@@ -1,0 +1,157 @@
+"""Review item model."""
+
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+    from podex.models.mention_candidate import MentionCandidate
+
+
+class ReviewItemStatus(StrEnum):
+    """Review queue statuses for operator decisions."""
+
+    PENDING = auto()
+    IN_REVIEW = auto()
+    APPROVED = auto()
+    REJECTED = auto()
+    MERGED = auto()
+    SPLIT = auto()
+
+
+class ReviewPriority(StrEnum):
+    """Priority assigned to a review queue item."""
+
+    LOW = auto()
+    MEDIUM = auto()
+    HIGH = auto()
+
+
+class ReviewItem(Base):
+    """Operator-facing review item for a single mention candidate."""
+
+    __tablename__ = "review_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    mention_candidate_id: Mapped[int] = mapped_column(
+        ForeignKey("mention_candidates.id"),
+        unique=True,
+        index=True,
+    )
+    target_media_id: Mapped[int | None] = mapped_column(
+        ForeignKey("media.id"),
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(
+        String(32),
+        index=True,
+        default=ReviewItemStatus.PENDING.value,
+    )
+    priority: Mapped[str] = mapped_column(
+        String(16),
+        index=True,
+        default=ReviewPriority.MEDIUM.value,
+    )
+    assigned_to: Mapped[str | None] = mapped_column(String(100))
+    decision_note: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+    decided_at: Mapped[datetime | None] = mapped_column()
+
+    mention_candidate: Mapped["MentionCandidate"] = relationship(
+        back_populates="review_item",
+    )
+    target_media: Mapped["Media | None"] = relationship()
+
+    def assign(self, *, actor_name: str | None = None) -> None:
+        """Move the item into active review.
+
+        Args:
+            actor_name: Optional operator name to attach to the item.
+        """
+        self.status = ReviewItemStatus.IN_REVIEW.value
+        self.assigned_to = actor_name or self.assigned_to
+        self.updated_at = datetime.now(UTC)
+
+    def approve(
+        self,
+        *,
+        actor_name: str | None = None,
+        note: str | None = None,
+    ) -> None:
+        """Mark the item as approved.
+
+        Args:
+            actor_name: Optional operator name to attach to the item.
+            note: Optional decision note.
+        """
+        now = datetime.now(UTC)
+        self.status = ReviewItemStatus.APPROVED.value
+        self.assigned_to = actor_name or self.assigned_to
+        self.decision_note = note
+        self.updated_at = now
+        self.decided_at = now
+
+    def reject(
+        self,
+        *,
+        actor_name: str | None = None,
+        note: str | None = None,
+    ) -> None:
+        """Mark the item as rejected.
+
+        Args:
+            actor_name: Optional operator name to attach to the item.
+            note: Optional decision note.
+        """
+        now = datetime.now(UTC)
+        self.status = ReviewItemStatus.REJECTED.value
+        self.assigned_to = actor_name or self.assigned_to
+        self.decision_note = note
+        self.updated_at = now
+        self.decided_at = now
+
+    def mark_merged(
+        self,
+        *,
+        actor_name: str | None = None,
+        note: str | None = None,
+        target_media_id: int,
+    ) -> None:
+        """Mark the item as merged into an existing canonical media record.
+
+        Args:
+            actor_name: Optional operator name to attach to the item.
+            note: Optional decision note.
+            target_media_id: Internal media identifier merged into.
+        """
+        now = datetime.now(UTC)
+        self.status = ReviewItemStatus.MERGED.value
+        self.assigned_to = actor_name or self.assigned_to
+        self.decision_note = note
+        self.target_media_id = target_media_id
+        self.updated_at = now
+        self.decided_at = now
+
+    def mark_split(
+        self,
+        *,
+        actor_name: str | None = None,
+        note: str | None = None,
+    ) -> None:
+        """Mark the item as split into replacement review candidates."""
+        now = datetime.now(UTC)
+        self.status = ReviewItemStatus.SPLIT.value
+        self.assigned_to = actor_name or self.assigned_to
+        self.decision_note = note
+        self.updated_at = now
+        self.decided_at = now

--- a/backend/src/podex/models/transcript.py
+++ b/backend/src/podex/models/transcript.py
@@ -1,0 +1,34 @@
+"""Transcript ORM model."""
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import JSON, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.episode import Episode
+
+
+class Transcript(Base):
+    """A stored transcript for an episode.
+
+    Retention/digest metadata is added by the retention theme; this slice
+    carries only the core acquisition and cleanup fields extraction needs.
+    """
+
+    __tablename__ = "transcripts"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    episode_id: Mapped[int] = mapped_column(ForeignKey("episodes.id"), index=True)
+    provider: Mapped[str] = mapped_column(String(50))
+    raw_text: Mapped[str | None] = mapped_column(Text)
+    segments_json: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON)
+    fetched_at: Mapped[datetime | None] = mapped_column()
+    cleaned_text: Mapped[str | None] = mapped_column(Text)
+    cleaned_at: Mapped[datetime | None] = mapped_column()
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+
+    episode: Mapped["Episode"] = relationship(back_populates="transcripts")

--- a/backend/tests/test_extraction_models.py
+++ b/backend/tests/test_extraction_models.py
@@ -1,0 +1,111 @@
+"""Tests for the extraction-workflow models."""
+
+from assertpy import assert_that
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    MentionCandidate,
+    MentionCandidateProvenance,
+    MentionCandidateProvenanceEventType,
+    MentionCandidateState,
+    ReviewItem,
+    ReviewItemStatus,
+    ReviewPriority,
+    Transcript,
+)
+from tests.conftest import seed_catalog_graph
+
+
+def test_transcript_round_trips_and_links_to_episode(
+    db_session: Session,
+) -> None:
+    """A transcript persists its text payloads and reaches its episode."""
+    graph = seed_catalog_graph(db_session)
+    transcript = Transcript(
+        episode_id=graph.episode_id,
+        provider="podscripts",
+        raw_text="raw words",
+        segments_json=[{"start": 0, "end": 5, "text": "raw words"}],
+        cleaned_text="clean words",
+    )
+    db_session.add(transcript)
+    db_session.commit()
+
+    stored = db_session.execute(select(Transcript)).scalar_one()
+    assert_that(stored.provider).is_equal_to("podscripts")
+    assert_that(stored.cleaned_text).is_equal_to("clean words")
+    assert_that(stored.episode.id).is_equal_to(graph.episode_id)
+    assert_that(stored.episode.transcripts).contains(stored)
+
+
+def test_mention_candidate_defaults_to_pending_review(
+    db_session: Session,
+) -> None:
+    """New candidates start pending review with zero confidence recorded."""
+    graph = seed_catalog_graph(db_session)
+    candidate = MentionCandidate(
+        episode_id=graph.episode_id,
+        media_type="book",
+        raw_title="Dune",
+        confidence=0.87,
+        extraction_source="llm",
+    )
+    db_session.add(candidate)
+    db_session.commit()
+
+    stored = db_session.execute(select(MentionCandidate)).scalar_one()
+    assert_that(stored.state).is_equal_to(
+        MentionCandidateState.PENDING_REVIEW.value,
+    )
+    assert_that(stored.confidence).is_equal_to(0.87)
+    assert_that(stored.mention_id).is_none()
+
+
+def test_provenance_event_links_to_candidate(db_session: Session) -> None:
+    """Provenance events attach to their candidate with a typed event."""
+    graph = seed_catalog_graph(db_session)
+    candidate = MentionCandidate(
+        episode_id=graph.episode_id,
+        media_type="book",
+        raw_title="Dune",
+    )
+    db_session.add(candidate)
+    db_session.commit()
+
+    event = MentionCandidateProvenance(
+        mention_candidate_id=candidate.id,
+        event_type=MentionCandidateProvenanceEventType.CREATED.value,
+        raw_title="Dune",
+        confidence=0.5,
+    )
+    db_session.add(event)
+    db_session.commit()
+
+    stored = db_session.execute(
+        select(MentionCandidateProvenance),
+    ).scalar_one()
+    assert_that(stored.mention_candidate.id).is_equal_to(candidate.id)
+    assert_that(candidate.provenance_events).contains(stored)
+
+
+def test_review_item_defaults_and_candidate_link(db_session: Session) -> None:
+    """Review items default to pending/medium and back-reference candidates."""
+    graph = seed_catalog_graph(db_session)
+    candidate = MentionCandidate(
+        episode_id=graph.episode_id,
+        media_type="book",
+        raw_title="Dune",
+    )
+    db_session.add(candidate)
+    db_session.commit()
+
+    item = ReviewItem(mention_candidate_id=candidate.id)
+    db_session.add(item)
+    db_session.commit()
+
+    stored = db_session.execute(select(ReviewItem)).scalar_one()
+    assert_that(stored.status).is_equal_to(ReviewItemStatus.PENDING.value)
+    assert_that(stored.priority).is_equal_to(ReviewPriority.MEDIUM.value)
+    assert_that(stored.mention_candidate.id).is_equal_to(candidate.id)
+    assert_that(candidate.review_item).is_equal_to(stored)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(models): add transcript, mention-candidate, and review-queue models`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

First slice of the extraction theme (old PR3 in the #108 split; source: the #103 branch, trimmed to this theme's scope):

- `Transcript`: core acquisition/cleanup fields (`provider`, `raw_text`, `segments_json`, `cleaned_text`, timestamps) with an `Episode.transcripts` relationship. The branch's retention/digest/purge columns are **deferred to the retention theme** — they'll arrive in that theme's own migration.
- `MentionCandidate` + `MentionCandidateState`: extracted candidates with confidence, normalized titles, a unique promotion link to `mentions`, and typed `MentionCandidateProvenance` events (#55's audit trail).
- `ReviewItem` + `ReviewItemStatus`/`ReviewPriority`: one-per-candidate review-queue entries.
- Deferred: `transcription_jobs` FKs on candidates/provenance (that model belongs to the transcription theme).
- Migration `0006` creates all four tables with clean up/down; the replay + schema-drift guard pins parity.

Next slices: extraction service + spans (#55), then the LLM workflow re-authored onto the `prompt_config` injection seam (#35, closing #236).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #54
- Relates to #55
- Relates to #108

## Details

Verified: `uv run lintro tst` (171 passed, drift guard included) at 86% coverage; ruff/mypy/bandit/pydoclint clean. No prompt text anywhere — the #237 semgrep gate stays green.