### PR TITLE
feat(extraction): add LLM extraction workflow behind the prompt injection seam

### DIFF
--- a/backend/.semgrep/prompt-boundary.yaml
+++ b/backend/.semgrep/prompt-boundary.yaml
@@ -21,7 +21,9 @@ rules:
           regex: '.*_PROMPT$'
     paths:
       exclude:
-        - '**/services/prompts_default.py'
+        - 'prompts_default.py'
+        - '**/prompts_default.py'
+        - 'src/podex/services/prompts_default.py'
 
   - id: podex-prompt-marker-text-outside-designated-module
     languages: [generic]
@@ -39,4 +41,6 @@ rules:
       include:
         - '*.py'
       exclude:
-        - '**/services/prompts_default.py'
+        - 'prompts_default.py'
+        - '**/prompts_default.py'
+        - 'src/podex/services/prompts_default.py'

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "beautifulsoup4>=4.12",
   "rapidfuzz>=3.9",
   "spotipy>=2.24",
+  "anthropic>=0.40",
 ]
 
 [project.urls]

--- a/backend/src/podex/services/extraction.py
+++ b/backend/src/podex/services/extraction.py
@@ -1,0 +1,170 @@
+"""Mention extraction service."""
+
+from __future__ import annotations
+
+import re
+import string
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from podex.models import Media, Mention
+
+TITLE_PATTERN = re.compile(r"\b([A-Z][A-Za-z0-9]+(?:\s+[A-Z][A-Za-z0-9]+){1,5})\b")
+STOPWORDS = {
+    "The",
+    "A",
+    "An",
+    "And",
+    "Or",
+    "But",
+    "If",
+    "Then",
+    "This",
+    "That",
+    "These",
+    "Those",
+    "You",
+    "Your",
+    "We",
+    "Our",
+    "I",
+    "He",
+    "She",
+    "They",
+    "It",
+    "His",
+    "Her",
+    "Their",
+    "My",
+    "Mine",
+    "On",
+    "In",
+    "At",
+    "Of",
+    "To",
+    "For",
+}
+
+
+@dataclass
+class ExtractedMention:
+    """Mention extracted from transcript."""
+
+    media_id: int
+    timestamp_seconds: int | None
+    context: str
+    confidence: float
+
+
+def normalize_text(value: str) -> str:
+    table = str.maketrans("", "", string.punctuation)
+    return value.translate(table).lower().strip()
+
+
+def extract_mentions_from_segments(
+    segments: list[dict[str, Any]],
+    media_items: list[Media],
+    enable_heuristic: bool = False,
+) -> list[ExtractedMention]:
+    """Extract mentions using known media items.
+
+    Args:
+        segments: Transcript segments with text and timestamps
+        media_items: Known media items to match against
+        enable_heuristic: If True, also extract title-cased sequences as potential
+            media references. Disabled by default as it creates many false positives
+            (place names, person names, etc.). For production use, consider using
+            an LLM to identify actual media references.
+    """
+    normalized_media = {
+        normalize_text(media.title): media.id for media in media_items if media.title
+    }
+
+    results: list[ExtractedMention] = []
+    seen: set[tuple[int, int | None]] = set()
+
+    for segment in segments:
+        text = segment.get("text", "") or ""
+        if not text:
+            continue
+        segment_lower = text.lower()
+        timestamp = (
+            int(segment.get("start", 0)) if segment.get("start") is not None else None
+        )
+
+        for title_norm, media_id in normalized_media.items():
+            if title_norm and title_norm in normalize_text(segment_lower):
+                key = (media_id, timestamp)
+                if key in seen:
+                    continue
+                seen.add(key)
+                results.append(
+                    ExtractedMention(
+                        media_id=media_id,
+                        timestamp_seconds=timestamp,
+                        context=text.strip(),
+                        confidence=0.9,
+                    )
+                )
+
+        # Heuristic extraction: title-cased sequences
+        # Disabled by default - creates too many false positives (places, names, etc.)
+        if enable_heuristic:
+            matches = TITLE_PATTERN.findall(text)
+            for match in matches[:5]:
+                words = match.split()
+                if all(word in STOPWORDS for word in words):
+                    continue
+                title_norm = normalize_text(match)
+                if title_norm in normalized_media:
+                    continue
+                # Create placeholder media later; mark with id -1 for now
+                results.append(
+                    ExtractedMention(
+                        media_id=-1,
+                        timestamp_seconds=timestamp,
+                        context=text.strip(),
+                        confidence=0.4,
+                    )
+                )
+
+    return results
+
+
+def materialize_mentions(
+    episode_id: int,
+    segments: list[dict[str, Any]],
+    media_items: list[Media],
+    create_media_fn: Callable[[str], Media],
+) -> list[Mention]:
+    """Convert extracted mentions into Mention models, creating media when needed."""
+    extracted = extract_mentions_from_segments(segments, media_items)
+    mentions: list[Mention] = []
+
+    for item in extracted:
+        media_id = item.media_id
+        if media_id == -1:
+            # Create a placeholder media item from context substring
+            title = _best_guess_title(item.context)
+            media = create_media_fn(title)
+            media_id = media.id
+
+        mentions.append(
+            Mention(
+                episode_id=episode_id,
+                media_id=media_id,
+                timestamp_seconds=item.timestamp_seconds,
+                context=item.context,
+                confidence=item.confidence,
+            )
+        )
+
+    return mentions
+
+
+def _best_guess_title(context: str) -> str:
+    matches: list[str] = TITLE_PATTERN.findall(context)
+    if matches:
+        return matches[0]
+    return context[:80].strip() or "Unknown Title"

--- a/backend/src/podex/services/llm_extraction.py
+++ b/backend/src/podex/services/llm_extraction.py
@@ -1,0 +1,217 @@
+"""LLM media-mention extraction over cleaned transcripts.
+
+Prompts follow the #29 load-don't-embed boundary: the system prompt is
+injected by the caller (tuned prompts are podex-ops data, resolved through
+:mod:`podex.services.prompt_config`) and falls back to the generic prompt in
+:mod:`podex.services.prompts_default`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import anthropic
+
+from podex.models.media import MediaType
+from podex.services.prompts_default import DEFAULT_EXTRACTION_SYSTEM_PROMPT
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_EXTRACTION_MODEL = "claude-opus-4-8"
+_MAX_OUTPUT_TOKENS = 4000
+_MIN_TRANSCRIPT_CHARS = 100
+
+
+class ExtractionError(Exception):
+    """Base error for LLM extraction failures."""
+
+
+@dataclass
+class ExtractedMedia:
+    """A single media/person/place item extracted from a transcript."""
+
+    title: str
+    media_type: MediaType
+    creator: str | None = None
+    year: int | None = None
+    confidence: float = 0.8
+
+
+@dataclass
+class ExtractionResult:
+    """Outcome of one extraction run: items plus any non-fatal errors."""
+
+    items: list[ExtractedMedia] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        """Return True if extraction completed without errors."""
+        return len(self.errors) == 0
+
+
+class LLMExtractor:
+    """Extract media mentions from transcripts via the Anthropic API.
+
+    Args:
+        client: Anthropic SDK client; constructed from environment
+            credentials when omitted. Inject a stub in tests.
+        model: Model id used for extraction requests.
+        system_prompt: Injected (podex-ops) system prompt; falls back to the
+            generic prompt in :mod:`podex.services.prompts_default`.
+    """
+
+    def __init__(
+        self,
+        client: anthropic.Anthropic | None = None,
+        model: str = DEFAULT_EXTRACTION_MODEL,
+        system_prompt: str | None = None,
+    ) -> None:
+        self.client = client or anthropic.Anthropic()
+        self.model = model
+        self.system_prompt = system_prompt or DEFAULT_EXTRACTION_SYSTEM_PROMPT
+
+    def extract_from_transcript(
+        self,
+        segments: list[dict[str, str]],
+        max_chars: int = 150000,
+    ) -> ExtractionResult:
+        """Extract media mentions from a full transcript.
+
+        Args:
+            segments: Transcript segments with ``text`` keys.
+            max_chars: Maximum characters sent to the model.
+
+        Returns:
+            ExtractionResult with items and any errors encountered.
+        """
+        result = ExtractionResult()
+
+        full_text = " ".join(
+            seg.get("text", "").strip() for seg in segments if seg.get("text")
+        )
+        if not full_text or len(full_text) < _MIN_TRANSCRIPT_CHARS:
+            return result
+
+        if len(full_text) > max_chars:
+            logger.warning(
+                "Transcript truncated from %d to %d chars", len(full_text), max_chars
+            )
+            full_text = full_text[:max_chars]
+
+        try:
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=_MAX_OUTPUT_TOKENS,
+                system=self.system_prompt,
+                messages=[{"role": "user", "content": f"TRANSCRIPT:\n\n{full_text}"}],
+            )
+        except anthropic.APIStatusError as exc:
+            error_msg = f"API request failed: {exc.status_code}"
+            logger.error(error_msg)
+            result.errors.append(error_msg)
+            return result
+        except anthropic.APIConnectionError as exc:
+            error_msg = f"Network error: {exc}"
+            logger.error(error_msg)
+            result.errors.append(error_msg)
+            return result
+
+        response_text = next(
+            (block.text for block in response.content if block.type == "text"),
+            "",
+        ).strip()
+        if not response_text:
+            return result
+
+        items, parse_errors = self._parse_json_response(response_text)
+        result.errors.extend(parse_errors)
+
+        seen_titles: set[str] = set()
+        for item in items:
+            if not isinstance(item, dict) or "title" not in item:
+                continue
+
+            title = str(item["title"]).strip()
+            title_lower = title.lower()
+            if title_lower in seen_titles:
+                continue
+            seen_titles.add(title_lower)
+
+            media_type_str = item.get("type", "article")
+            try:
+                media_type = MediaType(media_type_str)
+            except ValueError:
+                media_type = MediaType.ARTICLE
+
+            result.items.append(
+                ExtractedMedia(
+                    title=title,
+                    media_type=media_type,
+                    creator=item.get("creator"),
+                    year=item.get("year"),
+                    confidence=float(item.get("confidence", 0.8)),
+                ),
+            )
+
+        logger.info("Extracted %d media items", len(result.items))
+        return result
+
+    def _parse_json_response(
+        self,
+        response_text: str,
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        """Parse a JSON array from model output, tolerating surrounding prose.
+
+        Args:
+            response_text: Raw text returned by the model.
+
+        Returns:
+            Tuple of (parsed items, list of error messages).
+        """
+        errors: list[str] = []
+
+        try:
+            parsed = json.loads(response_text)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list):
+            return parsed, errors
+        if parsed is not None:
+            errors.append(f"Expected JSON array, got {type(parsed).__name__}")
+            return [], errors
+
+        start = response_text.find("[")
+        if start < 0:
+            error_msg = f"No JSON array in response: {response_text[:200]}"
+            logger.warning(error_msg)
+            errors.append(error_msg)
+            return [], errors
+
+        depth = 0
+        end = start
+        for i, char in enumerate(response_text[start:], start):
+            if char == "[":
+                depth += 1
+            elif char == "]":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+
+        if end <= start:
+            error_msg = f"No complete JSON array found: {response_text[:200]}"
+            logger.warning(error_msg)
+            errors.append(error_msg)
+            return [], errors
+
+        try:
+            return json.loads(response_text[start:end]), errors
+        except json.JSONDecodeError as exc:
+            error_msg = f"Failed to parse JSON: {exc}"
+            logger.warning(error_msg)
+            errors.append(error_msg)
+            return [], errors

--- a/backend/src/podex/services/llm_transcript_cleanup.py
+++ b/backend/src/podex/services/llm_transcript_cleanup.py
@@ -1,0 +1,211 @@
+"""LLM transcript cleanup for speech-to-text errors.
+
+Prompts follow the #29 load-don't-embed boundary: the system prompt is
+injected by the caller (tuned prompts are podex-ops data, resolved through
+:mod:`podex.services.prompt_config`) and falls back to the generic prompt in
+:mod:`podex.services.prompts_default`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import anthropic
+
+from podex.services.prompts_default import DEFAULT_CLEANUP_SYSTEM_PROMPT
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CLEANUP_MODEL = "claude-opus-4-8"
+_MAX_OUTPUT_TOKENS = 8000
+_MIN_TRANSCRIPT_CHARS = 100
+_MAX_TERMINOLOGY_TERMS = 50
+
+
+@dataclass
+class CleanupCorrection:
+    """A single correction the model applied to the transcript."""
+
+    original: str
+    corrected: str
+    reason: str
+
+
+@dataclass
+class CleanupResult:
+    """Outcome of one cleanup run: cleaned text plus corrections made."""
+
+    cleaned_text: str
+    corrections_made: list[CleanupCorrection] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        """Return True if cleanup completed without errors."""
+        return len(self.errors) == 0
+
+    @property
+    def correction_count(self) -> int:
+        """Return the number of corrections applied."""
+        return len(self.corrections_made)
+
+
+class TranscriptCleaner:
+    """Fix speech-to-text errors in transcripts via the Anthropic API.
+
+    Args:
+        client: Anthropic SDK client; constructed from environment
+            credentials when omitted. Inject a stub in tests.
+        model: Model id used for cleanup requests.
+        system_prompt: Injected (podex-ops) system prompt; falls back to the
+            generic prompt in :mod:`podex.services.prompts_default`.
+    """
+
+    def __init__(
+        self,
+        client: anthropic.Anthropic | None = None,
+        model: str = DEFAULT_CLEANUP_MODEL,
+        system_prompt: str | None = None,
+    ) -> None:
+        self.client = client or anthropic.Anthropic()
+        self.model = model
+        self.system_prompt = system_prompt or DEFAULT_CLEANUP_SYSTEM_PROMPT
+
+    def cleanup_transcript(
+        self,
+        transcript_text: str,
+        podcast_name: str | None = None,
+        host_name: str | None = None,
+        guest_name: str | None = None,
+        terminology: list[str] | None = None,
+        max_chars: int = 100000,
+    ) -> CleanupResult:
+        """Clean up a transcript using the configured model.
+
+        Args:
+            transcript_text: The raw transcript text to clean.
+            podcast_name: Name of the podcast for context.
+            host_name: Name of the host.
+            guest_name: Name of the guest (if any).
+            terminology: Known terms that may be misspelled.
+            max_chars: Maximum characters sent to the model.
+
+        Returns:
+            CleanupResult with cleaned text and corrections made.
+        """
+        result = CleanupResult(cleaned_text=transcript_text)
+
+        if len(transcript_text) < _MIN_TRANSCRIPT_CHARS:
+            return result
+
+        if len(transcript_text) > max_chars:
+            logger.warning(
+                "Transcript truncated from %d to %d chars",
+                len(transcript_text),
+                max_chars,
+            )
+            transcript_text = transcript_text[:max_chars]
+
+        context_parts = []
+        if podcast_name:
+            context_parts.append(f"Podcast: {podcast_name}")
+        if host_name:
+            context_parts.append(f"Host: {host_name}")
+        if guest_name:
+            context_parts.append(f"Guest: {guest_name}")
+        if terminology:
+            terms = terminology[:_MAX_TERMINOLOGY_TERMS]
+            context_parts.append(f"Known terms and names: {', '.join(terms)}")
+        context = (
+            "\n".join(context_parts) if context_parts else "No additional context."
+        )
+
+        user_message = (
+            f"CONTEXT:\n{context}\n\n"
+            f"TRANSCRIPT TO CLEAN:\n{transcript_text}\n\n"
+            "Please analyze the transcript and fix any transcription errors. "
+            "Return as JSON."
+        )
+
+        try:
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=_MAX_OUTPUT_TOKENS,
+                system=self.system_prompt,
+                messages=[{"role": "user", "content": user_message}],
+            )
+        except anthropic.APIStatusError as exc:
+            result.errors.append(f"API error: {exc.status_code}")
+            return result
+        except anthropic.APIConnectionError as exc:
+            result.errors.append(f"Network error: {exc}")
+            return result
+
+        response_text = next(
+            (block.text for block in response.content if block.type == "text"),
+            "",
+        ).strip()
+        if not response_text:
+            return result
+
+        parsed = self._parse_json_response(response_text)
+        if parsed is None:
+            result.errors.append("Failed to parse JSON from response")
+            return result
+
+        result.cleaned_text = str(parsed.get("cleaned_text", transcript_text))
+        for corr in parsed.get("corrections", []):
+            if isinstance(corr, dict):
+                result.corrections_made.append(
+                    CleanupCorrection(
+                        original=corr.get("original", ""),
+                        corrected=corr.get("corrected", ""),
+                        reason=corr.get("reason", ""),
+                    ),
+                )
+
+        logger.info("Made %d corrections", len(result.corrections_made))
+        return result
+
+    def _parse_json_response(self, response_text: str) -> dict[str, Any] | None:
+        """Parse a JSON object from model output, tolerating surrounding prose.
+
+        Args:
+            response_text: Raw text returned by the model.
+
+        Returns:
+            The parsed object, or None when no valid JSON object is found.
+        """
+        try:
+            parsed = json.loads(response_text)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            return parsed
+
+        start = response_text.find("{")
+        if start < 0:
+            return None
+
+        brace_count = 0
+        end = start
+        for i, char in enumerate(response_text[start:], start):
+            if char == "{":
+                brace_count += 1
+            elif char == "}":
+                brace_count -= 1
+                if brace_count == 0:
+                    end = i + 1
+                    break
+
+        if end <= start:
+            return None
+
+        try:
+            fallback = json.loads(response_text[start:end])
+        except json.JSONDecodeError:
+            return None
+        return fallback if isinstance(fallback, dict) else None

--- a/backend/src/podex/services/prompt_config.py
+++ b/backend/src/podex/services/prompt_config.py
@@ -1,0 +1,184 @@
+"""JSON-backed prompt configuration for transcription accuracy."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class GuestContext(BaseModel):
+    """Context about a guest for improved transcription."""
+
+    name: str
+    background: str | None = None
+    profession: str | None = None
+    terminology: list[str] = Field(default_factory=list)
+    topics: list[str] = Field(default_factory=list)
+
+
+class EpisodeConfig(BaseModel):
+    """Episode-specific configuration."""
+
+    guest: str | None = None
+    guests: list[str] | None = None
+    guest_context: GuestContext | None = None
+    custom_prompt: str | None = None
+    terminology: list[str] = Field(default_factory=list)
+    topics: list[str] = Field(default_factory=list)
+    notes: str | None = None
+
+
+class PodcastConfig(BaseModel):
+    """Podcast-level configuration."""
+
+    name: str
+    slug: str
+    host: str
+    co_hosts: list[str] = Field(default_factory=list)
+    common_terminology: list[str] = Field(default_factory=list)
+    common_topics: list[str] = Field(default_factory=list)
+    default_prompt: str | None = None
+
+
+class PromptConfig(BaseModel):
+    """Full prompt configuration for a podcast."""
+
+    podcast: PodcastConfig
+    episodes: dict[str, EpisodeConfig] = Field(default_factory=dict)
+    initial_prompts: dict[str, str] = Field(default_factory=dict)
+
+    def get_episode_config(self, episode_number: int | None) -> EpisodeConfig | None:
+        """Get configuration for a specific episode number."""
+        if episode_number is None:
+            return None
+        return self.episodes.get(str(episode_number))
+
+    def get_prompt_for_episode(self, episode_number: int | None) -> str:
+        """Build the initial prompt for a specific episode."""
+        parts = []
+
+        # Base podcast info
+        parts.append(f"Podcast: {self.podcast.name}")
+        parts.append(f"Host: {self.podcast.host}")
+        if self.podcast.co_hosts:
+            parts.append(f"Co-hosts: {', '.join(self.podcast.co_hosts)}")
+
+        # Episode-specific info
+        ep_config = self.get_episode_config(episode_number)
+        if ep_config:
+            # Custom prompt overrides everything
+            if ep_config.custom_prompt:
+                return ep_config.custom_prompt
+
+            # Add guest info
+            if ep_config.guest:
+                parts.append(f"Guest: {ep_config.guest}")
+            elif ep_config.guests:
+                parts.append(f"Guests: {', '.join(ep_config.guests)}")
+
+            # Add guest context
+            if ep_config.guest_context:
+                gc = ep_config.guest_context
+                if gc.profession:
+                    parts.append(f"Guest profession: {gc.profession}")
+                if gc.background:
+                    parts.append(f"Guest background: {gc.background}")
+                if gc.terminology:
+                    parts.append(f"Key terms: {', '.join(gc.terminology[:15])}")
+                if gc.topics:
+                    parts.append(f"Topics: {', '.join(gc.topics[:10])}")
+
+            # Add episode-specific terminology
+            if ep_config.terminology:
+                parts.append(f"Episode terms: {', '.join(ep_config.terminology[:10])}")
+
+        # Common terminology (always include some)
+        if self.podcast.common_terminology:
+            terms = self.podcast.common_terminology[:20]
+            parts.append(f"Common terms: {', '.join(terms)}")
+
+        return ". ".join(parts) + "."
+
+    @classmethod
+    def load_from_file(cls, path: Path) -> PromptConfig:
+        """Load configuration from a JSON file."""
+        with open(path) as f:
+            data = json.load(f)
+        return cls.model_validate(data)
+
+    @classmethod
+    def load_for_podcast(
+        cls,
+        slug: str,
+        config_dir: Path | None = None,
+    ) -> PromptConfig | None:
+        """Load configuration for a podcast by slug."""
+        if config_dir is None:
+            config_dir = Path(__file__).parent.parent.parent.parent / "data" / "prompts"
+
+        config_path = config_dir / f"{slug}.json"
+        if not config_path.exists():
+            logger.debug(f"No prompt config found for {slug} at {config_path}")
+            return None
+
+        try:
+            return cls.load_from_file(config_path)
+        except Exception as e:
+            logger.warning(f"Failed to load prompt config for {slug}: {e}")
+            return None
+
+
+class PromptConfigManager:
+    """Manages prompt configurations for multiple podcasts."""
+
+    def __init__(self, config_dir: Path | None = None):
+        if config_dir is None:
+            config_dir = Path(__file__).parent.parent.parent.parent / "data" / "prompts"
+        self.config_dir = config_dir
+        self._cache: dict[str, PromptConfig | None] = {}
+
+    def get_config(self, podcast_slug: str) -> PromptConfig | None:
+        """Get configuration for a podcast (cached)."""
+        if podcast_slug not in self._cache:
+            self._cache[podcast_slug] = PromptConfig.load_for_podcast(
+                podcast_slug,
+                self.config_dir,
+            )
+        return self._cache[podcast_slug]
+
+    def get_prompt(
+        self,
+        podcast_slug: str,
+        episode_number: int | None = None,
+    ) -> str | None:
+        """Get the initial prompt for a specific episode."""
+        config = self.get_config(podcast_slug)
+        if config is None:
+            return None
+        return config.get_prompt_for_episode(episode_number)
+
+    def get_episode_config(
+        self,
+        podcast_slug: str,
+        episode_number: int,
+    ) -> EpisodeConfig | None:
+        """Get episode configuration for context."""
+        config = self.get_config(podcast_slug)
+        if config is None:
+            return None
+        return config.get_episode_config(episode_number)
+
+    def clear_cache(self) -> None:
+        """Clear the configuration cache."""
+        self._cache.clear()
+
+    def list_configured_podcasts(self) -> list[str]:
+        """List all podcasts that have configuration files."""
+        if not self.config_dir.exists():
+            return []
+        return [p.stem for p in self.config_dir.glob("*.json") if p.is_file()]

--- a/backend/src/podex/services/prompts_default.py
+++ b/backend/src/podex/services/prompts_default.py
@@ -1,0 +1,113 @@
+"""Designated generic fallback prompts — the ONLY module allowed to hold prompt text.
+
+Boundary rule (issues #29 / #236, enforced by ``backend/.semgrep/
+prompt-boundary.yaml``): prompt text may exist in exactly this file, and only
+as *generic* fallbacks. Tuned, host-specific, or corpus-derived prompts are
+podex-ops data and must arrive at runtime through the
+:mod:`podex.services.prompt_config` injection seam — never committed here or
+anywhere else in the public tree.
+"""
+
+from typing import Final
+
+DEFAULT_EXTRACTION_SYSTEM_PROMPT: Final = """<role>
+You are a media and entity extraction system for podcast transcripts.
+Your job is to identify all mentions of media, people, and places.
+</role>
+
+<task>
+Extract ALL references to media, people, and places from the transcript.
+Return a JSON array of items. Include both in-depth discussions AND casual
+mentions. We track mention frequency for statistics, so completeness matters.
+</task>
+
+<media_types>
+- book: Books, audiobooks, written works
+- movie: Films, feature movies
+- tv_show: TV series, streaming shows
+- documentary: Documentary films or series
+- podcast: Other podcasts mentioned
+- study: Scientific studies, research papers, academic works
+- article: Named articles (newspapers, magazines, online)
+- person: Notable people (guests, celebrities, historical figures, experts)
+- place: Specific locations discussed (cities, countries, venues, landmarks)
+</media_types>
+
+<output_schema>
+For each item, provide:
+- title: The name (for people, use their full name if known)
+- type: One of the media_types above
+- creator: Author/director/creator if applicable (null for person/place)
+- year: Year if known (null otherwise)
+- confidence: 0.0-1.0 score based on the rubric below
+</output_schema>
+
+<confidence_rubric>
+- 0.9-1.0: Explicitly named with full title/name, clearly identified
+- 0.7-0.8: Clearly referenced but title may be paraphrased or incomplete
+- 0.5-0.6: Brief mention or casual name-drop, but identifiable
+- Below 0.5: Too ambiguous - do not include
+</confidence_rubric>
+
+<rules>
+1. Extract ALL named references, including brief mentions (we track frequency)
+2. For unnamed references ("that book about X"), skip them
+3. Deduplicate - include each unique item only once per transcript
+4. For people: include anyone named, from casual mentions to main subjects
+5. For places: include specific named locations, not generic references
+6. When uncertain about type, use your best judgment based on context
+</rules>
+
+<examples>
+Input: "Have you read 1984? George Orwell predicted the surveillance state."
+Output: [
+  {"title": "1984", "type": "book", "creator": "George Orwell",
+   "year": 1949, "confidence": 0.95}
+]
+
+Input: "When I was in Austin, Texas last month..."
+Output: [
+  {"title": "Austin, Texas", "type": "place", "creator": null,
+   "year": null, "confidence": 0.85}
+]
+
+Input: "I read some book about habits, can't remember the name"
+Output: []
+</examples>
+
+<response_format>
+Return ONLY a valid JSON array. No explanation or other text.
+If no items found, return: []
+</response_format>"""
+
+DEFAULT_CLEANUP_SYSTEM_PROMPT: Final = """You are a transcript editor. \
+Your task is to fix errors in AI-generated speech-to-text transcripts.
+
+Fix the following types of errors:
+1. Proper nouns (names of people, places, products, companies)
+2. Technical terminology specific to the topic being discussed
+3. Obvious homophones (e.g., "their/there/they're" based on context)
+4. Clear word boundary errors (e.g., "a lot" vs "alot", compound words)
+
+DO NOT:
+- Add or remove content beyond fixing transcription errors
+- Change the speaker's meaning or intent
+- "Improve" grammar beyond obvious transcription errors
+- Change colloquial speech patterns or informal language
+- Add punctuation beyond what's needed for clarity
+
+Context will be provided about:
+- Podcast name and host(s)
+- Guest information (if available)
+- Known terminology that may appear
+
+Return a JSON object with:
+{
+  "cleaned_text": "The corrected transcript text",
+  "corrections": [
+    {"original": "original text", "corrected": "fixed text", "reason": "brief reason"}
+  ]
+}
+
+Only include corrections that were actually made. If no corrections are needed, \
+return the original text with an empty corrections array."""

--- a/backend/tests/test_extraction_service.py
+++ b/backend/tests/test_extraction_service.py
@@ -1,0 +1,74 @@
+"""Tests for the heuristic mention-extraction service."""
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import Media, MediaType
+from podex.services.extraction import (
+    extract_mentions_from_segments,
+    materialize_mentions,
+    normalize_text,
+)
+from tests.conftest import seed_catalog_graph
+
+
+def _media(media_id: int, title: str) -> Media:
+    media = Media(type=MediaType.BOOK, title=title)
+    media.id = media_id
+    return media
+
+
+def test_normalize_text_strips_punctuation_and_case() -> None:
+    """Normalization lowercases and removes punctuation."""
+    assert_that(normalize_text("Dune: Part Two!")).is_equal_to("dune part two")
+
+
+def test_extract_matches_known_media_and_dedups() -> None:
+    """Known titles match per segment with timestamps, deduplicated."""
+    segments = [
+        {"text": "We discussed Dune at length.", "start": 12.5},
+        {"text": "Dune again, same segment topic.", "start": 12.5},
+        {"text": "Dune reprise later on.", "start": 40},
+        {"text": "Nothing relevant here.", "start": 55},
+    ]
+
+    mentions = extract_mentions_from_segments(segments, [_media(7, "Dune")])
+
+    assert_that(mentions).is_length(2)
+    assert_that(mentions[0].media_id).is_equal_to(7)
+    assert_that(mentions[0].timestamp_seconds).is_equal_to(12)
+    assert_that(mentions[0].confidence).is_equal_to(0.9)
+
+
+def test_extract_heuristic_flags_title_cased_sequences() -> None:
+    """With the heuristic enabled, unknown title-cased runs are flagged."""
+    segments = [{"text": "Have you seen Blade Runner recently?", "start": 3}]
+
+    mentions = extract_mentions_from_segments(
+        segments,
+        [],
+        enable_heuristic=True,
+    )
+
+    assert_that(mentions).is_length(1)
+    assert_that(mentions[0].media_id).is_equal_to(-1)
+    assert_that(mentions[0].confidence).is_equal_to(0.4)
+
+
+def test_materialize_mentions_builds_mention_models(db_session: Session) -> None:
+    """Extracted matches materialize as Mention rows for the episode."""
+    graph = seed_catalog_graph(db_session)
+    media = db_session.get(Media, graph.media_id)
+    assert_that(media).is_not_none()
+
+    mentions = materialize_mentions(
+        episode_id=graph.episode_id,
+        segments=[{"text": "Talking about Dune today.", "start": 5}],
+        media_items=[media] if media else [],
+        create_media_fn=lambda title: _media(999, title),
+    )
+
+    assert_that(mentions).is_length(1)
+    assert_that(mentions[0].episode_id).is_equal_to(graph.episode_id)
+    assert_that(mentions[0].media_id).is_equal_to(graph.media_id)
+    assert_that(mentions[0].context).contains("Dune")

--- a/backend/tests/test_llm_extraction.py
+++ b/backend/tests/test_llm_extraction.py
@@ -1,0 +1,275 @@
+"""Tests for the LLM extraction/cleanup services and the prompt seam."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import anthropic
+import httpx
+from assertpy import assert_that
+
+from podex.models.media import MediaType
+from podex.services.llm_extraction import LLMExtractor
+from podex.services.llm_transcript_cleanup import TranscriptCleaner
+from podex.services.prompt_config import PromptConfig, PromptConfigManager
+from podex.services.prompts_default import (
+    DEFAULT_CLEANUP_SYSTEM_PROMPT,
+    DEFAULT_EXTRACTION_SYSTEM_PROMPT,
+)
+
+_LONG_TEXT = "word " * 60
+
+
+class _FakeMessages:
+    """Messages endpoint double returning canned text or raising."""
+
+    def __init__(self, text: str | None = None, error: Exception | None = None):
+        self.text = text
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> SimpleNamespace:
+        """Record the request and return a single-text-block response."""
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text=self.text or "")],
+        )
+
+
+def _fake_client(
+    text: str | None = None,
+    error: Exception | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(messages=_FakeMessages(text=text, error=error))
+
+
+def _status_error(code: int) -> anthropic.APIStatusError:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    return anthropic.APIStatusError(
+        "boom",
+        response=httpx.Response(code, request=request),
+        body=None,
+    )
+
+
+def test_extractor_uses_default_prompt_and_parses_items() -> None:
+    """The generic fallback prompt is sent and items are deduplicated."""
+    payload = json.dumps(
+        [
+            {"title": "Dune", "type": "book", "creator": "Herbert", "year": 1965},
+            {"title": "dune", "type": "book"},
+            {"title": "Somewhere", "type": "mystery_type", "confidence": 0.6},
+        ],
+    )
+    client = _fake_client(text=f"Here you go:\n{payload}")
+
+    result = LLMExtractor(client=client).extract_from_transcript(
+        [{"text": _LONG_TEXT}],
+    )
+
+    assert_that(result.success).is_true()
+    assert_that(result.items).is_length(2)
+    assert_that(result.items[0].media_type).is_equal_to(MediaType.BOOK)
+    assert_that(result.items[1].media_type).is_equal_to(MediaType.ARTICLE)
+    sent = client.messages.calls[0]
+    assert_that(sent["system"]).is_equal_to(DEFAULT_EXTRACTION_SYSTEM_PROMPT)
+    assert_that(sent["model"]).is_equal_to("claude-opus-4-8")
+
+
+def test_extractor_prefers_injected_prompt() -> None:
+    """An injected (podex-ops) prompt overrides the generic fallback."""
+    client = _fake_client(text="[]")
+    extractor = LLMExtractor(client=client, system_prompt="injected ops prompt")
+
+    extractor.extract_from_transcript([{"text": _LONG_TEXT}])
+
+    assert_that(client.messages.calls[0]["system"]).is_equal_to(
+        "injected ops prompt",
+    )
+
+
+def test_extractor_skips_short_transcripts() -> None:
+    """Transcripts under the minimum length never reach the API."""
+    client = _fake_client(text="[]")
+
+    result = LLMExtractor(client=client).extract_from_transcript(
+        [{"text": "too short"}],
+    )
+
+    assert_that(result.items).is_empty()
+    assert_that(client.messages.calls).is_empty()
+
+
+def test_extractor_records_api_errors() -> None:
+    """API and network failures surface as result errors, not exceptions."""
+    api_err = LLMExtractor(client=_fake_client(error=_status_error(500)))
+    net_err = LLMExtractor(
+        client=_fake_client(
+            error=anthropic.APIConnectionError(
+                request=httpx.Request(
+                    "POST",
+                    "https://api.anthropic.com/v1/messages",
+                ),
+            ),
+        ),
+    )
+
+    r1 = api_err.extract_from_transcript([{"text": _LONG_TEXT}])
+    r2 = net_err.extract_from_transcript([{"text": _LONG_TEXT}])
+
+    assert_that(r1.errors[0]).contains("500")
+    assert_that(r2.errors[0]).contains("Network error")
+
+
+def test_extractor_reports_unparseable_output() -> None:
+    """Non-JSON output produces a parse error instead of raising."""
+    result = LLMExtractor(
+        client=_fake_client(text="no json array at all"),
+    ).extract_from_transcript([{"text": _LONG_TEXT}])
+
+    assert_that(result.success).is_false()
+    assert_that(result.errors[0]).contains("No JSON array")
+
+
+def test_cleaner_applies_corrections_and_context() -> None:
+    """Cleanup parses corrections and forwards podcast context."""
+    payload = json.dumps(
+        {
+            "cleaned_text": "fixed transcript",
+            "corrections": [
+                {"original": "alot", "corrected": "a lot", "reason": "boundary"},
+            ],
+        },
+    )
+    client = _fake_client(text=payload)
+
+    result = TranscriptCleaner(client=client).cleanup_transcript(
+        _LONG_TEXT,
+        podcast_name="Example Show",
+        host_name="Host Example",
+        guest_name="Guest Example",
+        terminology=["podex"],
+    )
+
+    assert_that(result.cleaned_text).is_equal_to("fixed transcript")
+    assert_that(result.correction_count).is_equal_to(1)
+    sent = client.messages.calls[0]
+    assert_that(sent["system"]).is_equal_to(DEFAULT_CLEANUP_SYSTEM_PROMPT)
+    user_message = sent["messages"][0]["content"]
+    assert_that(user_message).contains("Example Show")
+    assert_that(user_message).contains("podex")
+
+
+def test_cleaner_short_text_and_parse_failure() -> None:
+    """Short inputs short-circuit; unparseable output records an error."""
+    untouched = TranscriptCleaner(client=_fake_client(text="{}"))
+    short = untouched.cleanup_transcript("tiny")
+    assert_that(short.cleaned_text).is_equal_to("tiny")
+    assert_that(untouched.client.messages.calls).is_empty()
+
+    broken = TranscriptCleaner(
+        client=_fake_client(text="not json"),
+    ).cleanup_transcript(_LONG_TEXT)
+    assert_that(broken.success).is_false()
+    assert_that(broken.cleaned_text).is_equal_to(_LONG_TEXT)
+
+
+def test_cleaner_records_api_error() -> None:
+    """An API failure keeps the original text and records the error."""
+    result = TranscriptCleaner(
+        client=_fake_client(error=_status_error(429)),
+    ).cleanup_transcript(_LONG_TEXT)
+
+    assert_that(result.errors[0]).contains("429")
+    assert_that(result.cleaned_text).is_equal_to(_LONG_TEXT)
+
+
+def test_prompt_config_composes_and_overrides(tmp_path: Path) -> None:
+    """Injected configs compose context prompts; custom prompts override."""
+    config = {
+        "podcast": {
+            "name": "Example Show",
+            "slug": "example-show",
+            "host": "Host Example",
+            "common_terminology": ["podex"],
+        },
+        "episodes": {
+            "1": {"guest": "Guest Example"},
+            "2": {"custom_prompt": "fully custom"},
+        },
+    }
+    path = tmp_path / "example-show.json"
+    path.write_text(json.dumps(config))
+
+    manager = PromptConfigManager(config_dir=tmp_path)
+    composed = manager.get_prompt("example-show", episode_number=1)
+    custom = manager.get_prompt("example-show", episode_number=2)
+
+    assert_that(composed).contains("Example Show")
+    assert_that(composed).contains("Guest Example")
+    assert_that(custom).is_equal_to("fully custom")
+    assert_that(manager.get_prompt("missing-show")).is_none()
+    assert_that(manager.list_configured_podcasts()).is_equal_to(["example-show"])
+
+
+def test_prompt_config_load_for_podcast_missing_dir(tmp_path: Path) -> None:
+    """A missing config file yields None rather than raising."""
+    assert_that(
+        PromptConfig.load_for_podcast("nope", config_dir=tmp_path),
+    ).is_none()
+
+
+def test_prompt_config_includes_guest_context(tmp_path: Path) -> None:
+    """Guest context, co-hosts, and terminology all reach the prompt."""
+    config = {
+        "podcast": {
+            "name": "Example Show",
+            "slug": "example-show",
+            "host": "Host Example",
+            "co_hosts": ["Co-host Example"],
+            "common_terminology": ["podex"],
+        },
+        "episodes": {
+            "3": {
+                "guests": ["Guest A", "Guest B"],
+                "terminology": ["alembic"],
+            },
+            "4": {
+                "guest": "Solo Guest",
+                "guest_context": {
+                    "name": "Solo Guest",
+                    "profession": "researcher",
+                    "background": "signal processing",
+                    "terminology": ["fourier"],
+                    "topics": ["audio"],
+                },
+            },
+        },
+    }
+    path = tmp_path / "example-show.json"
+    path.write_text(json.dumps(config))
+    manager = PromptConfigManager(config_dir=tmp_path)
+
+    multi = manager.get_prompt("example-show", episode_number=3)
+    contextual = manager.get_prompt("example-show", episode_number=4)
+    episode = manager.get_episode_config("example-show", episode_number=4)
+
+    assert_that(multi).contains("Guest A")
+    assert_that(multi).contains("Co-host Example")
+    assert_that(multi).contains("alembic")
+    assert_that(contextual).contains("researcher")
+    assert_that(contextual).contains("fourier")
+    assert_that(episode).is_not_none()
+    manager.clear_cache()
+
+
+def test_prompt_config_invalid_json_returns_none(tmp_path: Path) -> None:
+    """A corrupt config file logs and yields None instead of raising."""
+    (tmp_path / "broken.json").write_text("{not json")
+
+    assert_that(
+        PromptConfig.load_for_podcast("broken", config_dir=tmp_path),
+    ).is_none()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -39,6 +39,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.117.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/0d/8f71d535edb0d438f023bd825fb65f67c14fa88a2bd6b75f292a58a63de4/anthropic-0.117.0.tar.gz", hash = "sha256:98107f2b76439641e0ae2a1754087534b8f178dbab99d6eb1bc4b7bc8c744496", size = 989933, upload-time = "2026-07-16T19:36:13.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/4c/917d21d6619a4475cdafc6d13a69fdb3b901ddac57e76caca5a25c117b6d/anthropic-0.117.0-py3-none-any.whl", hash = "sha256:451a0a6905f11dff7663d13e4ee5dbf909eb8942b1d049803c7b937a13ac47ec", size = 998327, upload-time = "2026-07-16T19:36:11.225Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -323,6 +342,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "fakeredis"
 version = "2.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -536,6 +573,92 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -908,6 +1031,7 @@ version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "fastapi" },
     { name = "feedparser" },
@@ -937,6 +1061,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
+    { name = "anthropic", specifier = ">=0.40" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "feedparser", specifier = ">=6.0" },
@@ -1390,6 +1515,15 @@ name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
 
 [[package]]
 name = "sortedcontainers"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(extraction): add LLM extraction workflow behind the prompt injection seam`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The extraction-theme service layer from the #108 split, re-authored onto the **#29 load-don't-embed boundary** — this is the slice the #237 semgrep guard was built to protect:

- `services/prompts_default.py`: the **designated fallback module** — the only file allowed to contain prompt text (generic extraction + cleanup prompts, seeded from the #103 branch text per the #236 assessment, with the media-type list aligned to main's `MediaType` enum). Allowlisted by `backend/.semgrep/prompt-boundary.yaml`.
- `services/prompt_config.py`: the injection seam — loads tuned podex-ops prompt configs (podcast/episode/guest context, custom prompts) from JSON at runtime. No prompt text embedded.
- `services/llm_extraction.py` + `services/llm_transcript_cleanup.py`: `LLMExtractor`/`TranscriptCleaner` resolve **injected prompt → generic fallback**, with no inline prompt constants (the branch's `EXTRACTION_SYSTEM_PROMPT`/`CLEANUP_SYSTEM_PROMPT` embeds are gone). Re-authored from raw httpx onto the official `anthropic` SDK — built-in retry/backoff replaces the hand-rolled 429 sleep loop, typed error chain (`APIStatusError` → `APIConnectionError`), and the deprecated `claude-sonnet-4-20250514` default becomes `claude-opus-4-8`.
- `services/extraction.py`: heuristic mention extraction + `materialize_mentions` (ported as-is).
- New runtime dep: `anthropic`.

This closes #35 (extraction workflow) and **#236** (the designated module + enforcement are now both in place — the semgrep gate passes with prompt text present only in the allowlisted file). Candidate/review-queue persistence (#54/#55/#56 wiring) continues in the next slice.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #35
- Closes #236
- Relates to #55
- Relates to #108

## Details

Verified: `uv run lintro tst` (187 passed) at 85.3% coverage; ruff/mypy/bandit/pydoclint clean; the prompt-boundary semgrep scan passes over the full tree with the new prompt module present — proving the allowlist works with real prompt code, not just canaries. All API calls covered by stub clients; no network in tests.