### PR TITLE
feat(models): add media alias and external-reference models

### DIFF
--- a/backend/alembic/versions/0007_add_media_alias_refs.py
+++ b/backend/alembic/versions/0007_add_media_alias_refs.py
@@ -1,0 +1,88 @@
+"""Add media alias and external-reference tables.
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-07-18 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create media_aliases and media_external_refs."""
+    op.create_table(
+        "media_aliases",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("media_id", sa.Integer(), nullable=False),
+        sa.Column("alias", sa.String(length=500), nullable=False),
+        sa.Column("normalized_alias", sa.String(length=500), nullable=False),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("is_primary", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["media_id"], ["media.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "media_id",
+            "normalized_alias",
+            name="uq_media_aliases_media_normalized_alias",
+        ),
+    )
+    op.create_index("ix_media_aliases_media_id", "media_aliases", ["media_id"])
+    op.create_index(
+        "ix_media_aliases_normalized_alias",
+        "media_aliases",
+        ["normalized_alias"],
+    )
+    op.create_index("ix_media_aliases_source", "media_aliases", ["source"])
+
+    op.create_table(
+        "media_external_refs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("media_id", sa.Integer(), nullable=False),
+        sa.Column("source", sa.String(length=50), nullable=False),
+        sa.Column("external_id", sa.String(length=255), nullable=False),
+        sa.Column("url", sa.String(length=500), nullable=True),
+        sa.Column("label", sa.String(length=255), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["media_id"], ["media.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "media_id",
+            "source",
+            "external_id",
+            name="uq_media_external_refs_media_source_external_id",
+        ),
+    )
+    op.create_index(
+        "ix_media_external_refs_media_id",
+        "media_external_refs",
+        ["media_id"],
+    )
+    op.create_index(
+        "ix_media_external_refs_source",
+        "media_external_refs",
+        ["source"],
+    )
+    op.create_index(
+        "ix_media_external_refs_external_id",
+        "media_external_refs",
+        ["external_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop media alias and external-reference tables."""
+    op.drop_table("media_external_refs")
+    op.drop_table("media_aliases")

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -8,6 +8,8 @@ from podex.models.base import Base
 from podex.models.episode import DiscoverySource, Episode
 from podex.models.ingestion_run import IngestionRun, IngestionRunStatus
 from podex.models.media import Media, MediaType
+from podex.models.media_alias import MediaAlias, MediaAliasSourceType
+from podex.models.media_external_ref import MediaExternalRef, MediaExternalRefSource
 from podex.models.mention import Mention
 from podex.models.mention_candidate import MentionCandidate, MentionCandidateState
 from podex.models.mention_candidate_provenance import (
@@ -30,6 +32,10 @@ __all__ = [
     "IngestionRun",
     "IngestionRunStatus",
     "Media",
+    "MediaAlias",
+    "MediaAliasSourceType",
+    "MediaExternalRef",
+    "MediaExternalRefSource",
     "MediaType",
     "Mention",
     "MentionCandidate",

--- a/backend/src/podex/models/media.py
+++ b/backend/src/podex/models/media.py
@@ -2,12 +2,17 @@
 
 from datetime import datetime
 from enum import StrEnum, auto
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, Index, String, func
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.media_alias import MediaAlias
+    from podex.models.media_external_ref import MediaExternalRef
 
 
 class MediaType(StrEnum):
@@ -46,4 +51,9 @@ class Media(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
+    )
+
+    aliases: Mapped[list["MediaAlias"]] = relationship(back_populates="media")
+    external_refs: Mapped[list["MediaExternalRef"]] = relationship(
+        back_populates="media",
     )

--- a/backend/src/podex/models/media_alias.py
+++ b/backend/src/podex/models/media_alias.py
@@ -1,0 +1,49 @@
+"""Media alias model."""
+
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+
+class MediaAliasSourceType(StrEnum):
+    """Sources that can create canonical media aliases."""
+
+    REVIEW = auto()
+    MERGE = auto()
+    ENRICHMENT = auto()
+    MANUAL = auto()
+
+
+class MediaAlias(Base):
+    """Alternate title or alias for a canonical media record."""
+
+    __tablename__ = "media_aliases"
+    __table_args__ = (
+        UniqueConstraint(
+            "media_id",
+            "normalized_alias",
+            name="uq_media_aliases_media_normalized_alias",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    media_id: Mapped[int] = mapped_column(ForeignKey("media.id"), index=True)
+    alias: Mapped[str] = mapped_column(String(500))
+    normalized_alias: Mapped[str] = mapped_column(String(500), index=True)
+    source: Mapped[str] = mapped_column(
+        String(32),
+        default=MediaAliasSourceType.MANUAL.value,
+        index=True,
+    )
+    is_primary: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+
+    media: Mapped["Media"] = relationship(back_populates="aliases")

--- a/backend/src/podex/models/media_external_ref.py
+++ b/backend/src/podex/models/media_external_ref.py
@@ -1,0 +1,57 @@
+"""Media external reference model."""
+
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import JSON, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+
+class MediaExternalRefSource(StrEnum):
+    """Supported external reference sources for canonical media."""
+
+    DOI = auto()
+    GOOGLE_BOOKS = auto()
+    IMDB = auto()
+    MANUAL = auto()
+    OPEN_LIBRARY = auto()
+    PUBMED = auto()
+    SEMANTIC_SCHOLAR = auto()
+    TMDB = auto()
+    WIKIPEDIA = auto()
+
+
+class MediaExternalRef(Base):
+    """Canonical external identifier or URL for a media record."""
+
+    __tablename__ = "media_external_refs"
+    __table_args__ = (
+        UniqueConstraint(
+            "media_id",
+            "source",
+            "external_id",
+            name="uq_media_external_refs_media_source_external_id",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    media_id: Mapped[int] = mapped_column(ForeignKey("media.id"), index=True)
+    source: Mapped[str] = mapped_column(String(50), index=True)
+    external_id: Mapped[str] = mapped_column(String(255), index=True)
+    url: Mapped[str | None] = mapped_column(String(500))
+    label: Mapped[str | None] = mapped_column(String(255))
+    description: Mapped[str | None] = mapped_column(Text)
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    media: Mapped["Media"] = relationship(back_populates="external_refs")

--- a/backend/tests/test_media_alias_models.py
+++ b/backend/tests/test_media_alias_models.py
@@ -1,0 +1,58 @@
+"""Tests for media alias and external-reference models."""
+
+from assertpy import assert_that
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    Media,
+    MediaAlias,
+    MediaAliasSourceType,
+    MediaExternalRef,
+)
+from tests.conftest import seed_catalog_graph
+
+
+def test_media_alias_round_trips_with_source(db_session: Session) -> None:
+    """Aliases persist with normalization, source, and media linkage."""
+    graph = seed_catalog_graph(db_session)
+
+    alias = MediaAlias(
+        media_id=graph.media_id,
+        alias="Dune (Novel)",
+        normalized_alias="dune novel",
+        source=MediaAliasSourceType.REVIEW.value,
+        is_primary=True,
+    )
+    db_session.add(alias)
+    db_session.commit()
+
+    stored = db_session.execute(select(MediaAlias)).scalar_one()
+    assert_that(stored.normalized_alias).is_equal_to("dune novel")
+    assert_that(stored.source).is_equal_to(MediaAliasSourceType.REVIEW.value)
+    assert_that(stored.media.id).is_equal_to(graph.media_id)
+    media = db_session.get(Media, graph.media_id)
+    assert_that(media).is_not_none()
+    if media is not None:
+        assert_that(media.aliases).contains(stored)
+
+
+def test_media_external_ref_round_trips(db_session: Session) -> None:
+    """External refs persist source ids, urls, and metadata."""
+    graph = seed_catalog_graph(db_session)
+
+    ref = MediaExternalRef(
+        media_id=graph.media_id,
+        source="openlibrary",
+        external_id="OL893415W",
+        url="https://openlibrary.org/works/OL893415W",
+        label="Open Library",
+        metadata_json={"match": "title"},
+    )
+    db_session.add(ref)
+    db_session.commit()
+
+    stored = db_session.execute(select(MediaExternalRef)).scalar_one()
+    assert_that(stored.external_id).is_equal_to("OL893415W")
+    assert_that(stored.metadata_json).is_equal_to({"match": "title"})
+    assert_that(stored.media.external_refs).contains(stored)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(models): add media alias and external-reference models`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

First slice of the media enrichment + canonical-merge theme (old PR4 in the #108 split; source: the #103 branch):

- `MediaAlias`: normalized alternate titles per canonical media record — unique per `(media_id, normalized_alias)`, typed `MediaAliasSourceType` (`review/merge/enrichment/manual`), `is_primary` flag.
- `MediaExternalRef`: provider identifiers/URLs (`source` + `external_id`, unique per media) with label/description/metadata for enrichment provenance.
- `Media` gains `aliases` / `external_refs` relationships; migration `0007` with clean up/down.
- Deferred: `media_relation.py` (graph triples) belongs to the derivatives theme (#25).

Next slices: alias normalization + canonical matching services, enrichment providers, then the merge operations (which also unblock the deferred `review_queue.py` ops).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #12
- Relates to #13
- Relates to #108

## Details

Verified: `uv run lintro tst` (192 passed, incl. migration replay + drift guard) at 85.8% coverage; ruff/mypy/bandit/pydoclint clean.