### PR TITLE
feat(media): add alias normalization and canonical matching services

### DIFF
--- a/backend/src/podex/services/media_alias_repository.py
+++ b/backend/src/podex/services/media_alias_repository.py
@@ -1,0 +1,116 @@
+"""Database helpers for canonical media aliases."""
+
+from sqlalchemy.orm import Session
+
+from podex.models import Media, MediaAlias, MediaAliasSourceType
+from podex.services.media_aliases import (
+    CanonicalMediaCandidate,
+    CanonicalMediaMatch,
+    match_canonical_media,
+    normalize_media_alias,
+)
+
+
+def ensure_media_alias(
+    *,
+    db: Session,
+    media: Media,
+    alias: str | None,
+    source: MediaAliasSourceType = MediaAliasSourceType.REVIEW,
+    is_primary: bool = False,
+) -> MediaAlias | None:
+    """Ensure a normalized alias exists for a media record.
+
+    Args:
+        db: Database session.
+        media: Canonical media record.
+        alias: Alias text to persist.
+        source: Source of the alias.
+        is_primary: Whether this alias is the primary display title.
+
+    Returns:
+        Existing or newly created alias, or ``None`` when alias is empty.
+    """
+    normalized_alias = normalize_media_alias(alias)
+    if alias is None or normalized_alias is None:
+        return None
+
+    existing = (
+        db.query(MediaAlias)
+        .filter(MediaAlias.media_id == media.id)
+        .filter(MediaAlias.normalized_alias == normalized_alias)
+        .first()
+    )
+    if existing is not None:
+        return existing
+
+    media_alias = MediaAlias(
+        media_id=media.id,
+        alias=alias.strip(),
+        normalized_alias=normalized_alias,
+        source=source.value,
+        is_primary=is_primary,
+    )
+    db.add(media_alias)
+    db.flush()
+    return media_alias
+
+
+def find_canonical_media_match(
+    *,
+    db: Session,
+    title: str | None,
+    media_type: str | None,
+) -> CanonicalMediaMatch:
+    """Find a canonical media match using persisted aliases.
+
+    Args:
+        db: Database session.
+        title: Extracted title to resolve.
+        media_type: Extracted media type.
+
+    Returns:
+        Canonical media match result.
+    """
+    media_rows = (
+        db.query(Media).filter(Media.type == media_type).order_by(Media.id.asc()).all()
+    )
+    aliases_by_media_id = _load_aliases_by_media_id(
+        db=db,
+        media_ids=[media.id for media in media_rows],
+    )
+    candidates = [
+        CanonicalMediaCandidate(
+            media_id=media.id,
+            media_type=media.type,
+            title=media.title,
+            aliases=tuple(aliases_by_media_id.get(media.id, [])),
+        )
+        for media in media_rows
+    ]
+    return match_canonical_media(
+        title=title,
+        media_type=media_type,
+        candidates=candidates,
+    )
+
+
+def _load_aliases_by_media_id(
+    *,
+    db: Session,
+    media_ids: list[int],
+) -> dict[int, list[str]]:
+    """Load alias strings grouped by media id."""
+    if not media_ids:
+        return {}
+
+    aliases = (
+        db.query(MediaAlias)
+        .filter(MediaAlias.media_id.in_(media_ids))
+        .order_by(MediaAlias.is_primary.desc(), MediaAlias.id.asc())
+        .all()
+    )
+    grouped: dict[int, list[str]] = {media_id: [] for media_id in media_ids}
+    for alias in aliases:
+        grouped.setdefault(alias.media_id, []).append(alias.alias)
+    return grouped

--- a/backend/src/podex/services/media_aliases.py
+++ b/backend/src/podex/services/media_aliases.py
@@ -1,0 +1,294 @@
+"""Pure helpers for matching extracted media titles to canonical aliases."""
+
+from __future__ import annotations
+
+import string
+import unicodedata
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum, auto
+
+
+class MediaAliasSource(StrEnum):
+    """Source of a candidate alias value."""
+
+    TITLE = auto()
+    ALIAS = auto()
+
+
+class MediaAliasMatchReason(StrEnum):
+    """Reason explaining the outcome of canonical media alias matching."""
+
+    EXACT_TITLE = auto()
+    EXACT_ALIAS = auto()
+    EMPTY_TITLE = auto()
+    TYPE_MISMATCH = auto()
+    NO_MATCH = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateAlias:
+    """Normalized alias value attached to a canonical media candidate.
+
+    Attributes:
+        value: Original title or alias value.
+        normalized_value: Normalized value used for exact comparisons.
+        source: Whether the value came from the canonical title or alias list.
+    """
+
+    value: str
+    normalized_value: str
+    source: MediaAliasSource
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalMediaCandidate:
+    """Canonical media item available for alias matching.
+
+    Attributes:
+        media_id: Canonical media identifier.
+        media_type: Canonical media type value.
+        title: Canonical media title.
+        aliases: Known alternate titles or aliases for the media item.
+    """
+
+    media_id: int
+    media_type: str
+    title: str
+    aliases: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalMediaMatch:
+    """Result of matching an extracted title to canonical media.
+
+    Attributes:
+        candidate: Matched canonical candidate, if any.
+        matched_alias: Title or alias value that matched, if any.
+        confidence: Match confidence from 0.0 to 1.0.
+        reason: Machine-readable reason for the match result.
+    """
+
+    candidate: CanonicalMediaCandidate | None
+    matched_alias: CandidateAlias | None
+    confidence: float
+    reason: MediaAliasMatchReason
+
+    @property
+    def media_id(self) -> int | None:
+        """Return the matched media identifier when present.
+
+        Returns:
+            Canonical media identifier, or ``None`` when no candidate matched.
+        """
+        if self.candidate is None:
+            return None
+        return self.candidate.media_id
+
+
+def normalize_media_alias(value: str | None) -> str | None:
+    """Normalize a title or alias for replay-safe exact matching.
+
+    Args:
+        value: Raw title or alias text.
+
+    Returns:
+        Normalized text, or ``None`` when the input is empty.
+    """
+    if value is None:
+        return None
+
+    normalized = unicodedata.normalize("NFKD", value)
+    normalized = "".join(
+        character for character in normalized if not unicodedata.combining(character)
+    )
+    normalized = normalized.casefold()
+    punctuation_as_spaces = str.maketrans(
+        string.punctuation,
+        " " * len(string.punctuation),
+    )
+    normalized = normalized.translate(punctuation_as_spaces)
+    normalized = " ".join(normalized.split()).strip()
+    return normalized or None
+
+
+def normalize_media_title(value: str | None) -> str | None:
+    """Normalize a canonical or extracted media title.
+
+    Args:
+        value: Raw title text.
+
+    Returns:
+        Normalized title, or ``None`` when the input is empty.
+    """
+    return normalize_media_alias(value)
+
+
+def normalize_media_type(value: str | None) -> str | None:
+    """Normalize a media type value for compatibility checks.
+
+    Args:
+        value: Raw media type value.
+
+    Returns:
+        Normalized media type, or ``None`` when the input is empty.
+    """
+    if value is None:
+        return None
+
+    normalized = "_".join(value.casefold().replace("-", "_").split()).strip()
+    return normalized or None
+
+
+def media_types_are_compatible(
+    *,
+    requested_type: str | None,
+    candidate_type: str,
+) -> bool:
+    """Check whether an extracted type can match a canonical type.
+
+    Args:
+        requested_type: Media type from the extracted mention.
+        candidate_type: Canonical media type for the candidate.
+
+    Returns:
+        ``True`` when the media types are an exact normalized match.
+    """
+    normalized_requested = normalize_media_type(requested_type)
+    normalized_candidate = normalize_media_type(candidate_type)
+    return (
+        normalized_requested is not None
+        and normalized_candidate is not None
+        and normalized_requested == normalized_candidate
+    )
+
+
+def candidate_aliases(
+    *,
+    candidate: CanonicalMediaCandidate,
+) -> tuple[CandidateAlias, ...]:
+    """Build normalized alias values for a canonical media candidate.
+
+    Args:
+        candidate: Canonical media candidate.
+
+    Returns:
+        Tuple of normalized title and alias values in matching priority order.
+    """
+    aliases: list[CandidateAlias] = []
+
+    normalized_title = normalize_media_title(candidate.title)
+    if normalized_title is not None:
+        aliases.append(
+            CandidateAlias(
+                value=candidate.title,
+                normalized_value=normalized_title,
+                source=MediaAliasSource.TITLE,
+            )
+        )
+
+    seen = {alias.normalized_value for alias in aliases}
+    for value in candidate.aliases:
+        normalized_alias = normalize_media_alias(value)
+        if normalized_alias is None or normalized_alias in seen:
+            continue
+
+        aliases.append(
+            CandidateAlias(
+                value=value,
+                normalized_value=normalized_alias,
+                source=MediaAliasSource.ALIAS,
+            )
+        )
+        seen.add(normalized_alias)
+
+    return tuple(aliases)
+
+
+def match_canonical_media(
+    *,
+    title: str | None,
+    media_type: str | None,
+    candidates: Sequence[CanonicalMediaCandidate],
+) -> CanonicalMediaMatch:
+    """Choose the best canonical media candidate for an extracted title.
+
+    Args:
+        title: Extracted title or alias text.
+        media_type: Extracted media type.
+        candidates: Canonical candidates to search.
+
+    Returns:
+        Match result with confidence and reason.
+    """
+    normalized_title = normalize_media_title(title)
+    if normalized_title is None:
+        return CanonicalMediaMatch(
+            candidate=None,
+            matched_alias=None,
+            confidence=0.0,
+            reason=MediaAliasMatchReason.EMPTY_TITLE,
+        )
+
+    best_match: CanonicalMediaMatch | None = None
+    has_incompatible_exact_match = False
+
+    for candidate in candidates:
+        for alias in candidate_aliases(candidate=candidate):
+            if alias.normalized_value != normalized_title:
+                continue
+
+            if not media_types_are_compatible(
+                requested_type=media_type,
+                candidate_type=candidate.media_type,
+            ):
+                has_incompatible_exact_match = True
+                continue
+
+            match = _exact_match(candidate=candidate, alias=alias)
+            if best_match is None or match.confidence > best_match.confidence:
+                best_match = match
+
+    if best_match is not None:
+        return best_match
+
+    return CanonicalMediaMatch(
+        candidate=None,
+        matched_alias=None,
+        confidence=0.0,
+        reason=(
+            MediaAliasMatchReason.TYPE_MISMATCH
+            if has_incompatible_exact_match
+            else MediaAliasMatchReason.NO_MATCH
+        ),
+    )
+
+
+def _exact_match(
+    *,
+    candidate: CanonicalMediaCandidate,
+    alias: CandidateAlias,
+) -> CanonicalMediaMatch:
+    """Build a match result for a compatible exact alias value.
+
+    Args:
+        candidate: Canonical media candidate.
+        alias: Matched alias value.
+
+    Returns:
+        Exact match result.
+    """
+    if alias.source == MediaAliasSource.TITLE:
+        return CanonicalMediaMatch(
+            candidate=candidate,
+            matched_alias=alias,
+            confidence=1.0,
+            reason=MediaAliasMatchReason.EXACT_TITLE,
+        )
+
+    return CanonicalMediaMatch(
+        candidate=candidate,
+        matched_alias=alias,
+        confidence=0.95,
+        reason=MediaAliasMatchReason.EXACT_ALIAS,
+    )

--- a/backend/tests/test_media_alias_repository.py
+++ b/backend/tests/test_media_alias_repository.py
@@ -1,0 +1,62 @@
+"""Tests for persisted canonical media aliases."""
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import Media, MediaAlias, MediaAliasSourceType, MediaType
+from podex.services.media_alias_repository import (
+    ensure_media_alias,
+    find_canonical_media_match,
+)
+
+
+def test_ensure_media_alias_deduplicates_normalized_aliases(
+    db_session: Session,
+) -> None:
+    """Verify alias persistence is replay safe for normalized values."""
+    media = Media(type=MediaType.MOVIE.value, title="Star Wars")
+    db_session.add(media)
+    db_session.flush()
+
+    first = ensure_media_alias(
+        db=db_session,
+        media=media,
+        alias="A New Hope",
+        source=MediaAliasSourceType.REVIEW,
+    )
+    second = ensure_media_alias(
+        db=db_session,
+        media=media,
+        alias="a new hope",
+        source=MediaAliasSourceType.REVIEW,
+    )
+    db_session.commit()
+
+    assert_that(first).is_not_none()
+    assert_that(second).is_equal_to(first)
+    assert_that(db_session.query(MediaAlias).count()).is_equal_to(1)
+
+
+def test_find_canonical_media_match_uses_persisted_aliases(
+    db_session: Session,
+) -> None:
+    """Verify persisted aliases participate in canonical matching."""
+    media = Media(type=MediaType.MOVIE.value, title="Star Wars")
+    db_session.add(media)
+    db_session.flush()
+    ensure_media_alias(
+        db=db_session,
+        media=media,
+        alias="A New Hope",
+        source=MediaAliasSourceType.REVIEW,
+    )
+    db_session.commit()
+
+    result = find_canonical_media_match(
+        db=db_session,
+        title="a new hope",
+        media_type=MediaType.MOVIE.value,
+    )
+
+    assert_that(result.media_id).is_equal_to(media.id)
+    assert_that(result.reason.value).is_equal_to("exact_alias")

--- a/backend/tests/test_media_aliases.py
+++ b/backend/tests/test_media_aliases.py
@@ -1,0 +1,128 @@
+"""Tests for canonical media alias matching."""
+
+from assertpy import assert_that
+
+from podex.services.media_aliases import (
+    CanonicalMediaCandidate,
+    MediaAliasMatchReason,
+    MediaAliasSource,
+    match_canonical_media,
+    normalize_media_alias,
+    normalize_media_title,
+)
+
+
+def test_matches_exact_canonical_title() -> None:
+    """Verify exact title matches resolve to the canonical media candidate."""
+    candidate = CanonicalMediaCandidate(
+        media_id=10,
+        media_type="book",
+        title="The Left Hand of Darkness",
+    )
+
+    result = match_canonical_media(
+        title="The Left Hand of Darkness",
+        media_type="book",
+        candidates=[candidate],
+    )
+
+    assert_that(result.media_id).is_equal_to(10)
+    assert_that(result.candidate).is_equal_to(candidate)
+    assert_that(result.confidence).is_equal_to(1.0)
+    assert_that(result.reason).is_equal_to(MediaAliasMatchReason.EXACT_TITLE)
+    matched_alias = result.matched_alias
+    assert_that(matched_alias).is_not_none()
+    if matched_alias is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(matched_alias.source).is_equal_to(MediaAliasSource.TITLE)
+
+
+def test_matches_exact_alias() -> None:
+    """Verify exact alias matches resolve to the canonical media candidate."""
+    candidate = CanonicalMediaCandidate(
+        media_id=20,
+        media_type="movie",
+        title="Star Wars",
+        aliases=("A New Hope", "Star Wars Episode IV"),
+    )
+
+    result = match_canonical_media(
+        title="A New Hope",
+        media_type="movie",
+        candidates=[candidate],
+    )
+
+    assert_that(result.media_id).is_equal_to(20)
+    assert_that(result.confidence).is_equal_to(0.95)
+    assert_that(result.reason).is_equal_to(MediaAliasMatchReason.EXACT_ALIAS)
+    matched_alias = result.matched_alias
+    assert_that(matched_alias).is_not_none()
+    if matched_alias is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(matched_alias.value).is_equal_to("A New Hope")
+    assert_that(matched_alias.source).is_equal_to(MediaAliasSource.ALIAS)
+
+
+def test_rejects_type_mismatch_for_exact_alias_or_title() -> None:
+    """Verify exact text matches do not resolve when media types differ."""
+    candidate = CanonicalMediaCandidate(
+        media_id=30,
+        media_type="movie",
+        title="Dune",
+        aliases=("Dune Part One",),
+    )
+
+    result = match_canonical_media(
+        title="Dune Part One",
+        media_type="book",
+        candidates=[candidate],
+    )
+
+    assert_that(result.media_id).is_none()
+    assert_that(result.candidate).is_none()
+    assert_that(result.confidence).is_equal_to(0.0)
+    assert_that(result.reason).is_equal_to(MediaAliasMatchReason.TYPE_MISMATCH)
+
+
+def test_normalizes_titles_and_aliases_before_matching() -> None:
+    """Verify punctuation, accents, case, and spacing are normalized."""
+    candidate = CanonicalMediaCandidate(
+        media_id=40,
+        media_type="movie",
+        title="Amelie",
+        aliases=("  Amelie: Le Fabuleux Destin d'Amelie Poulain  ",),
+    )
+
+    result = match_canonical_media(
+        title="amelie le fabuleux destin d amelie poulain",
+        media_type="movie",
+        candidates=[candidate],
+    )
+
+    assert_that(normalize_media_title("  Amelie!!  ")).is_equal_to("amelie")
+    assert_that(normalize_media_alias("d'Amelie")).is_equal_to("d amelie")
+    assert_that(result.media_id).is_equal_to(40)
+    assert_that(result.reason).is_equal_to(MediaAliasMatchReason.EXACT_ALIAS)
+
+
+def test_returns_no_match_when_no_title_or_alias_matches() -> None:
+    """Verify unmatched titles return an explicit no-match result."""
+    candidates = [
+        CanonicalMediaCandidate(
+            media_id=50,
+            media_type="book",
+            title="Kindred",
+            aliases=("Octavia Butler's Kindred",),
+        )
+    ]
+
+    result = match_canonical_media(
+        title="Parable of the Sower",
+        media_type="book",
+        candidates=candidates,
+    )
+
+    assert_that(result.media_id).is_none()
+    assert_that(result.matched_alias).is_none()
+    assert_that(result.confidence).is_equal_to(0.0)
+    assert_that(result.reason).is_equal_to(MediaAliasMatchReason.NO_MATCH)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(media): add alias normalization and canonical matching services`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Second slice of the media theme (#108 old PR4; source: the #103 branch, tests ported alongside):

- `services/media_aliases.py`: pure normalization + matching — unicode folding, punctuation/article stripping, canonical-candidate matching with typed `MediaAliasMatchReason` and per-reason confidences.
- `services/media_alias_repository.py`: DB layer — `ensure_media_alias` (idempotent normalized-alias upsert against #257's unique constraint) and `find_canonical_media_match` resolving matches across titles and stored aliases.

Next: enrichment providers, then canonical merge + the deferred `review_queue.py` operations.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #12
- Relates to #13
- Relates to #108

## Details

Verified: `uv run lintro tst` (199 passed) at 86.0% coverage; ruff/mypy/bandit/pydoclint clean; no boundary-sensitive content (synonym/ranking data stays podex-ops).