### PR TITLE
feat(media): add enrichment provider framework with OpenLibrary and Wikipedia

### DIFF
--- a/backend/alembic/versions/0008_add_media_enrichment_columns.py
+++ b/backend/alembic/versions/0008_add_media_enrichment_columns.py
@@ -1,0 +1,46 @@
+"""Add enrichment identifier and provenance columns to media.
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-07-18 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_COLUMNS: list[sa.Column] = [
+    sa.Column("google_books_id", sa.String(length=50), nullable=True),
+    sa.Column("open_library_id", sa.String(length=50), nullable=True),
+    sa.Column("imdb_id", sa.String(length=20), nullable=True),
+    sa.Column("tmdb_id", sa.Integer(), nullable=True),
+    sa.Column("wikipedia_id", sa.String(length=100), nullable=True),
+    sa.Column("pubmed_id", sa.String(length=50), nullable=True),
+    sa.Column("doi", sa.String(length=100), nullable=True),
+    sa.Column("semantic_scholar_id", sa.String(length=50), nullable=True),
+    sa.Column("metadata_json", sa.JSON(), nullable=True),
+    sa.Column("verification_sources", sa.JSON(), nullable=True),
+    sa.Column("doi_verified", sa.Boolean(), nullable=True),
+    sa.Column("enriched_at", sa.DateTime(timezone=True), nullable=True),
+    sa.Column("enrichment_source", sa.String(length=50), nullable=True),
+    sa.Column("enrichment_confidence", sa.Float(), nullable=True),
+]
+
+
+def upgrade() -> None:
+    """Add enrichment columns to media."""
+    for column in _COLUMNS:
+        op.add_column("media", column)
+
+
+def downgrade() -> None:
+    """Remove enrichment columns from media."""
+    for column in reversed(_COLUMNS):
+        op.drop_column("media", column.name)

--- a/backend/src/podex/models/media.py
+++ b/backend/src/podex/models/media.py
@@ -2,9 +2,9 @@
 
 from datetime import datetime
 from enum import StrEnum, auto
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import DateTime, Index, String, func
+from sqlalchemy import JSON, Boolean, DateTime, Float, Index, String, func
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -48,6 +48,39 @@ class Media(Base):
     year: Mapped[int | None] = mapped_column(default=None)
     description: Mapped[str | None] = mapped_column(String(2000), default=None)
     cover_url: Mapped[str | None] = mapped_column(String(1000), default=None)
+    # External identifiers and provenance written by enrichment providers.
+    google_books_id: Mapped[str | None] = mapped_column(String(50), default=None)
+    open_library_id: Mapped[str | None] = mapped_column(String(50), default=None)
+    imdb_id: Mapped[str | None] = mapped_column(String(20), default=None)
+    tmdb_id: Mapped[int | None] = mapped_column(default=None)
+    wikipedia_id: Mapped[str | None] = mapped_column(String(100), default=None)
+    pubmed_id: Mapped[str | None] = mapped_column(String(50), default=None)
+    doi: Mapped[str | None] = mapped_column(String(100), default=None)
+    semantic_scholar_id: Mapped[str | None] = mapped_column(
+        String(50),
+        default=None,
+    )
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON,
+        default=None,
+    )
+    verification_sources: Mapped[list[str] | None] = mapped_column(
+        JSON,
+        default=None,
+    )
+    doi_verified: Mapped[bool | None] = mapped_column(Boolean, default=False)
+    enriched_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        default=None,
+    )
+    enrichment_source: Mapped[str | None] = mapped_column(
+        String(50),
+        default=None,
+    )
+    enrichment_confidence: Mapped[float | None] = mapped_column(
+        Float,
+        default=None,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/backend/src/podex/services/enrichment/__init__.py
+++ b/backend/src/podex/services/enrichment/__init__.py
@@ -1,0 +1,24 @@
+"""Enrichment providers for canonical media records.
+
+Providers land incrementally; this package exports the ones on main.
+"""
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+    RateLimiter,
+    VerifiedEnrichmentResult,
+)
+from podex.services.enrichment.open_library import OpenLibraryProvider
+from podex.services.enrichment.wikipedia import WikipediaProvider
+
+__all__ = [
+    "EnrichmentProvider",
+    "EnrichmentResult",
+    "EnrichmentSource",
+    "OpenLibraryProvider",
+    "RateLimiter",
+    "VerifiedEnrichmentResult",
+    "WikipediaProvider",
+]

--- a/backend/src/podex/services/enrichment/base.py
+++ b/backend/src/podex/services/enrichment/base.py
@@ -1,0 +1,178 @@
+"""Base enrichment provider protocol and data structures."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING, Any, ClassVar
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+
+class EnrichmentSource(StrEnum):
+    """Sources for media enrichment."""
+
+    GOOGLE_BOOKS = auto()
+    OPEN_LIBRARY = auto()
+    TMDB = auto()
+    TMDB_PERSON = auto()
+    OMDB = auto()
+    PUBMED = auto()
+    SEMANTIC_SCHOLAR = auto()
+    CROSSREF = auto()
+    SPOTIFY = auto()
+    ITUNES = auto()
+    WIKIPEDIA = auto()
+
+
+@dataclass
+class EnrichmentResult:
+    """Result of enriching a media item."""
+
+    source: EnrichmentSource
+    cover_url: str | None = None
+    description: str | None = None
+    external_ids: dict[str, str | int] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    confidence: float = 0.0
+
+    def has_useful_data(self) -> bool:
+        """Check if the result contains any useful enrichment data."""
+        return bool(
+            self.cover_url or self.description or self.external_ids or self.metadata
+        )
+
+
+@dataclass
+class VerifiedEnrichmentResult(EnrichmentResult):
+    """Enrichment result with multi-source verification.
+
+    This extends EnrichmentResult to track which sources confirmed the match
+    and whether DOI-based verification was used.
+    """
+
+    # Which sources confirmed this match
+    verified_by: list[EnrichmentSource] = field(default_factory=list)
+
+    # Individual results from each source (for debugging/audit)
+    source_results: dict[EnrichmentSource, EnrichmentResult] = field(
+        default_factory=dict,
+    )
+
+    # Was DOI used for verification?
+    doi_verified: bool = False
+
+
+class RateLimiter:
+    """Simple rate limiter for API calls.
+
+    Args:
+        requests_per_second: Maximum requests per second allowed.
+    """
+
+    def __init__(self, requests_per_second: float = 2.0) -> None:
+        self.min_interval = 1.0 / requests_per_second
+        self.last_request = 0.0
+
+    async def wait(self) -> None:
+        """Wait if necessary to respect rate limit."""
+        elapsed = time.time() - self.last_request
+        if elapsed < self.min_interval:
+            await asyncio.sleep(self.min_interval - elapsed)
+        self.last_request = time.time()
+
+    def wait_sync(self) -> None:
+        """Synchronous wait for rate limiting."""
+        elapsed = time.time() - self.last_request
+        if elapsed < self.min_interval:
+            time.sleep(self.min_interval - elapsed)
+        self.last_request = time.time()
+
+
+class EnrichmentProvider(ABC):
+    """Abstract base class for enrichment providers.
+
+    Args:
+        requests_per_second: Maximum requests per second.
+    """
+
+    source: ClassVar[EnrichmentSource]
+    rate_limiter: RateLimiter
+
+    def __init__(self, requests_per_second: float = 2.0) -> None:
+        self.rate_limiter = RateLimiter(requests_per_second)
+
+    @abstractmethod
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search for and enrich a media item.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        ...
+
+    @abstractmethod
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if this provider supports the given media type.
+
+        Args:
+            media_type: The type of media (book, movie, etc.).
+
+        Returns:
+            True if this provider can enrich this media type.
+        """
+        ...
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the provider's HTTP client and release resources."""
+        ...
+
+    def _calculate_title_similarity(self, title1: str, title2: str) -> float:
+        """Calculate similarity between two titles.
+
+        Simple case-insensitive comparison with normalization.
+        Returns a score between 0.0 and 1.0.
+        """
+        t1 = self._normalize_title(title1)
+        t2 = self._normalize_title(title2)
+
+        if t1 == t2:
+            return 1.0
+
+        # Check if one contains the other
+        if t1 in t2 or t2 in t1:
+            shorter = min(len(t1), len(t2))
+            longer = max(len(t1), len(t2))
+            return shorter / longer
+
+        # Calculate word overlap
+        words1 = set(t1.split())
+        words2 = set(t2.split())
+        if not words1 or not words2:
+            return 0.0
+
+        intersection = words1 & words2
+        union = words1 | words2
+        return len(intersection) / len(union)
+
+    def _normalize_title(self, title: str) -> str:
+        """Normalize a title for comparison."""
+        import re
+
+        # Lowercase
+        title = title.lower()
+        # Remove common articles
+        title = re.sub(r"^(the|a|an)\s+", "", title)
+        # Remove punctuation
+        title = re.sub(r"[^\w\s]", "", title)
+        # Normalize whitespace
+        title = " ".join(title.split())
+        return title

--- a/backend/src/podex/services/enrichment/open_library.py
+++ b/backend/src/podex/services/enrichment/open_library.py
@@ -1,0 +1,418 @@
+"""OpenLibrary enrichment provider.
+
+OpenLibrary is a free, open-source book database with no API key required.
+Used as a fallback for books when Google Books doesn't have data.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class OpenLibraryProvider(EnrichmentProvider):
+    """Enrich books from OpenLibrary (free, no API key).
+
+    Args:
+        requests_per_second: Rate limit for API calls.
+    """
+
+    BASE_URL = "https://openlibrary.org"
+    COVERS_URL = "https://covers.openlibrary.org/b"
+
+    source = EnrichmentSource.OPEN_LIBRARY
+
+    SUPPORTED_TYPES = {"book"}
+
+    def __init__(self, requests_per_second: float = 1.0) -> None:
+        super().__init__(requests_per_second)
+        self.client = httpx.Client(
+            timeout=30.0,
+            follow_redirects=True,
+        )
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if OpenLibrary supports this media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search OpenLibrary and enrich media item.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        # If we have an OpenLibrary ID, fetch directly
+        if media.open_library_id:
+            self.rate_limiter.wait_sync()
+            work = self._get_work(media.open_library_id)
+            if work:
+                return self._build_result_from_work(work, confidence=1.0)
+
+        self.rate_limiter.wait_sync()
+
+        # Search by title and author
+        results = self._search(media.title, media.author)
+
+        if not results:
+            logger.debug(f"No OpenLibrary results for: {media.title}")
+            return None
+
+        # Find best match
+        best_match = self._find_best_match(results, media)
+        if not best_match:
+            return None
+
+        doc, confidence = best_match
+
+        # Get work details for more complete data
+        work_key = doc.get("key")
+        if work_key:
+            self.rate_limiter.wait_sync()
+            work = self._get_work(work_key.replace("/works/", ""))
+            if work:
+                return self._build_result_from_work(
+                    work,
+                    confidence,
+                    search_doc=doc,
+                )
+
+        # Fall back to search result data only
+        return self._build_result_from_search(doc, confidence)
+
+    def _search(self, title: str, author: str | None) -> list[dict[str, Any]]:
+        """Search OpenLibrary.
+
+        Args:
+            title: Book title.
+            author: Optional author name.
+
+        Returns:
+            List of search result docs.
+        """
+        try:
+            params: dict[str, str | int] = {
+                "title": title,
+                "limit": 10,
+            }
+            if author:
+                params["author"] = author
+
+            response = self.client.get(
+                f"{self.BASE_URL}/search.json",
+                params=params,
+            )
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            result: list[dict[str, Any]] = data.get("docs", [])
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"OpenLibrary search error: {e}")
+            return []
+
+    def _get_work(self, work_id: str) -> dict[str, Any] | None:
+        """Fetch work details by ID.
+
+        Args:
+            work_id: OpenLibrary work ID (without /works/ prefix).
+
+        Returns:
+            Work data or None.
+        """
+        try:
+            response = self.client.get(
+                f"{self.BASE_URL}/works/{work_id}.json",
+            )
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"OpenLibrary work error for {work_id}: {e}")
+            return None
+
+    def _find_best_match(
+        self,
+        results: list[dict[str, Any]],
+        media: Media,
+    ) -> tuple[dict[str, Any], float] | None:
+        """Find best matching result.
+
+        Args:
+            results: Search results from OpenLibrary.
+            media: Original media item.
+
+        Returns:
+            Tuple of (doc, confidence) or None.
+        """
+        if not results:
+            return None
+
+        best_doc = None
+        best_score = 0.0
+
+        for doc in results[:5]:  # Check top 5 results
+            result_title = doc.get("title", "")
+
+            # Calculate title similarity
+            title_score = self._calculate_title_similarity(
+                media.title,
+                result_title,
+            )
+
+            # Check author match
+            author_boost = 0.0
+            if media.author:
+                authors = doc.get("author_name", [])
+                for author in authors:
+                    author_sim = self._calculate_title_similarity(
+                        media.author,
+                        author,
+                    )
+                    if author_sim > 0.7:
+                        author_boost = 0.15
+                        break
+
+            # Boost if publication year matches
+            year_boost = 0.0
+            if media.year:
+                first_publish = doc.get("first_publish_year")
+                if first_publish and first_publish == media.year:
+                    year_boost = 0.1
+
+            total_score = title_score + author_boost + year_boost
+
+            if total_score > best_score:
+                best_score = total_score
+                best_doc = doc
+
+        if best_doc and best_score >= 0.7:
+            return (best_doc, min(best_score, 1.0))
+
+        return None
+
+    def _get_cover_url(
+        self,
+        cover_id: int | str | None = None,
+        olid: str | None = None,
+        isbn: str | None = None,
+        size: str = "L",
+    ) -> str | None:
+        """Build cover URL from various identifiers.
+
+        Args:
+            cover_id: OpenLibrary cover ID.
+            olid: OpenLibrary ID (edition or work).
+            isbn: ISBN-10 or ISBN-13.
+            size: Size (S, M, L).
+
+        Returns:
+            Cover URL or None.
+        """
+        if cover_id:
+            return f"{self.COVERS_URL}/id/{cover_id}-{size}.jpg"
+        if olid:
+            return f"{self.COVERS_URL}/olid/{olid}-{size}.jpg"
+        if isbn:
+            return f"{self.COVERS_URL}/isbn/{isbn}-{size}.jpg"
+        return None
+
+    def _build_result_from_work(
+        self,
+        work: dict[str, Any],
+        confidence: float,
+        search_doc: dict[str, Any] | None = None,
+    ) -> EnrichmentResult:
+        """Build enrichment result from work data.
+
+        Args:
+            work: OpenLibrary work data.
+            confidence: Match confidence score.
+            search_doc: Optional search result doc with additional data.
+
+        Returns:
+            EnrichmentResult with all available data.
+        """
+        # Cover URL
+        cover_url = None
+        covers = work.get("covers", [])
+        if covers:
+            cover_url = self._get_cover_url(cover_id=covers[0])
+
+        # Fall back to search doc covers
+        if not cover_url and search_doc:
+            cover_i = search_doc.get("cover_i")
+            if cover_i:
+                cover_url = self._get_cover_url(cover_id=cover_i)
+
+        # Description
+        description = None
+        desc = work.get("description")
+        if isinstance(desc, dict):
+            description = desc.get("value")
+        elif isinstance(desc, str):
+            description = desc
+
+        # External IDs
+        work_key = work.get("key", "")
+        work_id = work_key.replace("/works/", "") if work_key else None
+        external_ids: dict[str, str | int] = {}
+        if work_id:
+            external_ids["open_library_id"] = work_id
+
+        # Get ISBN from search doc if available
+        if search_doc:
+            isbns = search_doc.get("isbn", [])
+            if isbns:
+                for isbn in isbns:
+                    if len(isbn) == 13:
+                        external_ids["isbn_13"] = isbn
+                        break
+                    elif len(isbn) == 10 and "isbn_10" not in external_ids:
+                        external_ids["isbn_10"] = isbn
+
+        # Build metadata
+        metadata: dict[str, Any] = {}
+
+        # Subjects/genres
+        subjects = work.get("subjects", [])
+        if subjects:
+            # Subjects can be strings or dicts
+            genre_list = []
+            for subj in subjects[:10]:  # Limit to 10
+                if isinstance(subj, dict):
+                    genre_list.append(subj.get("name", ""))
+                else:
+                    genre_list.append(str(subj))
+            metadata["genres"] = [g for g in genre_list if g]
+
+        # Add data from search doc
+        if search_doc:
+            # Authors
+            authors = search_doc.get("author_name", [])
+            if authors:
+                metadata["authors"] = authors
+
+            # First publish year
+            first_publish = search_doc.get("first_publish_year")
+            if first_publish:
+                metadata["first_publish_year"] = first_publish
+
+            # Number of editions
+            edition_count = search_doc.get("edition_count")
+            if edition_count:
+                metadata["edition_count"] = edition_count
+
+            # Languages
+            languages = search_doc.get("language", [])
+            if languages:
+                metadata["languages"] = languages
+
+            # Number of pages (median across editions)
+            pages = search_doc.get("number_of_pages_median")
+            if pages:
+                metadata["page_count"] = pages
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=cover_url,
+            description=description,
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def _build_result_from_search(
+        self,
+        doc: dict[str, Any],
+        confidence: float,
+    ) -> EnrichmentResult:
+        """Build enrichment result from search doc only.
+
+        Args:
+            doc: Search result document.
+            confidence: Match confidence score.
+
+        Returns:
+            EnrichmentResult with available data.
+        """
+        # Cover URL
+        cover_url = None
+        cover_i = doc.get("cover_i")
+        if cover_i:
+            cover_url = self._get_cover_url(cover_id=cover_i)
+
+        # External IDs
+        external_ids: dict[str, str | int] = {}
+        work_key = doc.get("key", "")
+        if work_key:
+            work_id = work_key.replace("/works/", "")
+            external_ids["open_library_id"] = work_id
+
+        isbns = doc.get("isbn", [])
+        if isbns:
+            for isbn in isbns:
+                if len(isbn) == 13:
+                    external_ids["isbn_13"] = isbn
+                    break
+                elif len(isbn) == 10 and "isbn_10" not in external_ids:
+                    external_ids["isbn_10"] = isbn
+
+        # Build metadata
+        metadata: dict[str, Any] = {}
+
+        # Authors
+        authors = doc.get("author_name", [])
+        if authors:
+            metadata["authors"] = authors
+
+        # Subjects/genres
+        subjects = doc.get("subject", [])
+        if subjects:
+            metadata["genres"] = subjects[:10]
+
+        # First publish year
+        first_publish = doc.get("first_publish_year")
+        if first_publish:
+            metadata["first_publish_year"] = first_publish
+
+        # Number of pages
+        pages = doc.get("number_of_pages_median")
+        if pages:
+            metadata["page_count"] = pages
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=cover_url,
+            description=None,  # Search doesn't include description
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> OpenLibraryProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/enrichment/open_library.py
+++ b/backend/src/podex/services/enrichment/open_library.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class OpenLibraryProvider(EnrichmentProvider):
+class OpenLibraryProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich books from OpenLibrary (free, no API key).
 
     Args:

--- a/backend/src/podex/services/enrichment/search_utils.py
+++ b/backend/src/podex/services/enrichment/search_utils.py
@@ -1,0 +1,306 @@
+"""Search utilities for flexible title matching.
+
+Provides functions to generate search variations and improve match rates
+across all enrichment providers.
+"""
+
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+
+
+def generate_search_variations(title: str, author: str | None = None) -> list[str]:
+    """Generate multiple search variations for a title.
+
+    Returns variations in priority order (most specific first).
+
+    Args:
+        title: Original title.
+        author: Optional author/creator name.
+
+    Returns:
+        List of search query variations to try.
+    """
+    variations = []
+    original = title.strip()
+
+    # 1. Original title (always first)
+    variations.append(original)
+
+    # 2. Strip leading articles
+    stripped = strip_articles(original)
+    if stripped != original:
+        variations.append(stripped)
+
+    # 3. Remove subtitle (after colon or dash)
+    main_title = remove_subtitle(original)
+    if main_title != original:
+        variations.append(main_title)
+        # Also try stripped version without subtitle
+        stripped_main = strip_articles(main_title)
+        if stripped_main != main_title:
+            variations.append(stripped_main)
+
+    # 4. Remove parenthetical info (year, country, etc.)
+    no_parens = remove_parentheticals(original)
+    if no_parens != original:
+        variations.append(no_parens)
+
+    # 5. Handle "X with Y" pattern -> try just "X"
+    without_with = remove_with_clause(original)
+    if without_with != original:
+        variations.append(without_with)
+
+    # 6. If author provided, try "title author" combination
+    if author:
+        # Get primary author (first name before comma or "and")
+        primary_author = get_primary_name(author)
+        if primary_author:
+            variations.append(f"{stripped} {primary_author}")
+
+    # 7. Extract key words (for very long titles)
+    if len(original.split()) > 5:
+        key_words = extract_key_words(original)
+        if key_words and key_words != original:
+            variations.append(key_words)
+
+    # Remove duplicates while preserving order
+    seen = set()
+    unique_variations = []
+    for v in variations:
+        v_lower = v.lower()
+        if v_lower not in seen and v.strip():
+            seen.add(v_lower)
+            unique_variations.append(v)
+
+    return unique_variations
+
+
+def strip_articles(title: str) -> str:
+    """Remove leading articles (The, A, An) from title."""
+    return re.sub(r"^(the|a|an)\s+", "", title, flags=re.IGNORECASE).strip()
+
+
+def remove_subtitle(title: str) -> str:
+    """Remove subtitle after colon or em-dash."""
+    # Handle "Title: Subtitle" or "Title - Subtitle"
+    patterns = [
+        r"^(.+?)\s*:\s*.+$",  # Colon
+        r"^(.+?)\s+[-–—]\s+.+$",  # Various dashes
+    ]
+    for pattern in patterns:
+        match = re.match(pattern, title)
+        if match:
+            main = match.group(1).strip()
+            # Only use if main title is substantial
+            if len(main) > 3:
+                return main
+    return title
+
+
+def remove_parentheticals(title: str) -> str:
+    """Remove parenthetical content like (2019) or (US)."""
+    cleaned = re.sub(r"\s*\([^)]*\)\s*", " ", title)
+    return " ".join(cleaned.split())
+
+
+def remove_with_clause(title: str) -> str:
+    """Remove 'with X' or 'starring X' clauses.
+
+    Handles: "The Tonight Show with David Letterman" -> "The Tonight Show"
+    """
+    patterns = [
+        r"^(.+?)\s+with\s+.+$",
+        r"^(.+?)\s+starring\s+.+$",
+        r"^(.+?)\s+featuring\s+.+$",
+        r"^(.+?)\s+hosted by\s+.+$",
+    ]
+    for pattern in patterns:
+        match = re.match(pattern, title, re.IGNORECASE)
+        if match:
+            main = match.group(1).strip()
+            if len(main) > 3:
+                return main
+    return title
+
+
+def get_primary_name(name: str) -> str | None:
+    """Extract primary name from author/creator string.
+
+    Handles: "John Smith, Jane Doe" -> "John Smith"
+             "John Smith and Jane Doe" -> "John Smith"
+    """
+    if not name:
+        return None
+
+    # Split on common separators
+    for sep in [",", " and ", " & ", ";"]:
+        if sep in name:
+            name = name.split(sep)[0].strip()
+            break
+
+    # Get last name for search purposes
+    parts = name.split()
+    if parts:
+        return parts[-1]  # Return last name
+    return None
+
+
+def extract_key_words(title: str) -> str:
+    """Extract key words from a long title.
+
+    Removes common words and returns significant terms.
+    """
+    stop_words = {
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "with",
+        "by",
+        "from",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "could",
+        "should",
+        "may",
+        "might",
+        "must",
+        "shall",
+        "can",
+        "that",
+        "this",
+        "these",
+        "those",
+        "it",
+        "its",
+    }
+
+    words = re.findall(r"\b\w+\b", title.lower())
+    key_words = [w for w in words if w not in stop_words and len(w) > 2]
+
+    # Return first 4 key words
+    return " ".join(key_words[:4])
+
+
+def normalize_title(title: str) -> str:
+    """Normalize title for comparison.
+
+    Lowercase, remove articles, remove punctuation, normalize whitespace.
+    """
+    title = title.lower().strip()
+    title = strip_articles(title)
+    title = re.sub(r"[^\w\s]", "", title)
+    title = " ".join(title.split())
+    return title
+
+
+def calculate_similarity(title1: str, title2: str) -> float:
+    """Calculate similarity between two titles.
+
+    Uses multiple strategies and returns the best score.
+
+    Args:
+        title1: First title.
+        title2: Second title.
+
+    Returns:
+        Similarity score between 0.0 and 1.0.
+    """
+    # Normalize both titles
+    norm1 = normalize_title(title1)
+    norm2 = normalize_title(title2)
+
+    if not norm1 or not norm2:
+        return 0.0
+
+    # Exact match after normalization
+    if norm1 == norm2:
+        return 1.0
+
+    # Sequence matcher (good for typos and minor differences)
+    seq_ratio = SequenceMatcher(None, norm1, norm2).ratio()
+
+    # Word overlap (good for reordered words)
+    words1 = set(norm1.split())
+    words2 = set(norm2.split())
+
+    if words1 and words2:
+        intersection = words1 & words2
+        union = words1 | words2
+        jaccard = len(intersection) / len(union)
+
+        # Weighted combination
+        # Higher weight on jaccard for longer titles
+        if len(words1) > 3 or len(words2) > 3:
+            return max(seq_ratio, jaccard * 1.1, (seq_ratio + jaccard) / 2)
+        return max(seq_ratio, jaccard)
+
+    return seq_ratio
+
+
+def is_likely_match(
+    search_title: str,
+    result_title: str,
+    threshold: float = 0.6,
+) -> tuple[bool, float]:
+    """Check if a result title is likely a match for the search title.
+
+    Args:
+        search_title: The title we searched for.
+        result_title: The title returned from the API.
+        threshold: Minimum similarity threshold.
+
+    Returns:
+        Tuple of (is_match, confidence_score).
+    """
+    similarity = calculate_similarity(search_title, result_title)
+
+    # Boost if one contains the other
+    norm_search = normalize_title(search_title)
+    norm_result = normalize_title(result_title)
+
+    if norm_search in norm_result or norm_result in norm_search:
+        # One is a substring of the other
+        shorter = min(len(norm_search), len(norm_result))
+        longer = max(len(norm_search), len(norm_result))
+        containment_ratio = shorter / longer if longer > 0 else 0
+        similarity = max(similarity, containment_ratio + 0.1)
+
+    is_match = similarity >= threshold
+    return is_match, min(similarity, 1.0)
+
+
+def clean_for_api_search(title: str) -> str:
+    """Clean a title for use in API search queries.
+
+    Removes characters that might confuse search APIs.
+    """
+    # Remove quotes
+    title = title.replace('"', "").replace("'", "")
+    # Remove special characters but keep spaces and alphanumeric
+    title = re.sub(r"[^\w\s-]", " ", title)
+    # Normalize whitespace
+    title = " ".join(title.split())
+    return title

--- a/backend/src/podex/services/enrichment/wikipedia.py
+++ b/backend/src/podex/services/enrichment/wikipedia.py
@@ -220,7 +220,7 @@ CATEGORY_TYPE_PATTERNS: dict[str, list[str]] = {
 }
 
 
-class WikipediaProvider(EnrichmentProvider):
+class WikipediaProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich media from Wikipedia with strict type validation.
 
     Wikipedia API is free with no authentication required.

--- a/backend/src/podex/services/enrichment/wikipedia.py
+++ b/backend/src/podex/services/enrichment/wikipedia.py
@@ -1,0 +1,678 @@
+"""Wikipedia API enrichment provider.
+
+Universal fallback provider that works for any media type.
+Especially useful for studies, historical events, places, and people.
+
+IMPORTANT: This provider validates that results match the expected media type
+to avoid incorrect matches (e.g., matching an album when searching for a study).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+from podex.services.enrichment.search_utils import (
+    calculate_similarity,
+    generate_search_variations,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+# Type indicators - positive signals that a Wikipedia article matches the expected type
+TYPE_POSITIVE_SIGNALS: dict[str, list[str]] = {
+    "study": [
+        "study",
+        "experiment",
+        "research",
+        "trial",
+        "clinical",
+        "medical",
+        "scientific",
+        "investigation",
+        "conducted",
+        "participants",
+        "subjects",
+        "findings",
+        "published",
+        "journal",
+    ],
+    "movie": [
+        "film",
+        "movie",
+        "directed by",
+        "starring",
+        "produced by",
+        "screenplay",
+        "box office",
+        "cinema",
+        "released",
+    ],
+    "tv_show": [
+        "television",
+        "tv series",
+        "sitcom",
+        "episodes",
+        "seasons",
+        "aired",
+        "broadcast",
+        "network",
+        "showrunner",
+    ],
+    "documentary": [
+        "documentary",
+        "film",
+        "directed",
+        "footage",
+        "narrator",
+    ],
+    "book": [
+        "novel",
+        "book",
+        "author",
+        "written by",
+        "published",
+        "literary",
+        "chapter",
+        "pages",
+        "isbn",
+    ],
+    "person": [
+        "born",
+        "died",
+        "is a",
+        "was a",
+        "known for",
+        "career",
+        "biography",
+    ],
+    "place": [
+        "located",
+        "city",
+        "town",
+        "country",
+        "region",
+        "population",
+        "geography",
+        "coordinates",
+    ],
+    "podcast": [
+        "podcast",
+        "hosted by",
+        "episodes",
+        "audio",
+    ],
+}
+
+# Type indicators - negative signals that a Wikipedia article is NOT the expected type
+TYPE_NEGATIVE_SIGNALS: dict[str, list[str]] = {
+    "study": [
+        "album",
+        "song",
+        "band",
+        "singer",
+        "musician",
+        "film",
+        "movie",
+        "novel",
+        "book",
+        "video game",
+        "discography",
+        "studio album",
+        "single",
+        "ep",
+        "soundtrack",
+    ],
+    "movie": [
+        "album",
+        "song",
+        "novel",
+        "book",
+        "video game",
+        "tv series",
+        "television series",
+    ],
+    "tv_show": [
+        "album",
+        "song",
+        "novel",
+        "film",
+        "movie",
+        "video game",
+    ],
+    "book": [
+        "album",
+        "song",
+        "film",
+        "movie",
+        "tv series",
+        "video game",
+    ],
+    "person": [
+        "album",
+        "film",
+        "novel",
+        "song",
+        "is a city",
+        "is a town",
+        "is a country",
+    ],
+    "place": [
+        "is an album",
+        "is a film",
+        "is a novel",
+        "is a song",
+        "born",
+    ],
+}
+
+# Category patterns that indicate article type
+CATEGORY_TYPE_PATTERNS: dict[str, list[str]] = {
+    "study": [
+        r"medical.*stud",
+        r"clinical.*trial",
+        r"experiment",
+        r"research",
+        r"health.*scandal",
+        r"medical.*ethic",
+        r"scientific.*misconduct",
+    ],
+    "movie": [
+        r"\d{4}.*film",
+        r"film.*by",
+        r"english.*film",
+        r"american.*film",
+    ],
+    "tv_show": [
+        r"television.*series",
+        r"tv.*series",
+        r"\d{4}.*television",
+        r"american.*television",
+    ],
+    "book": [
+        r"\d{4}.*novel",
+        r"book.*by",
+        r"fiction",
+    ],
+    "person": [
+        r"living.*people",
+        r"\d{4}.*birth",
+        r"\d{4}.*death",
+        r"people.*from",
+    ],
+    "album": [  # Used for negative matching
+        r"\d{4}.*album",
+        r"album.*by",
+        r"studio.*album",
+    ],
+}
+
+
+class WikipediaProvider(EnrichmentProvider):
+    """Enrich media from Wikipedia with strict type validation.
+
+    Wikipedia API is free with no authentication required.
+    Works as a universal fallback for any media type.
+
+    This provider validates that search results match the expected media type
+    to prevent incorrect matches (e.g., albums matching study searches).
+
+    Args:
+        requests_per_second: Rate limit for API calls.
+    """
+
+    API_URL = "https://en.wikipedia.org/w/api.php"
+
+    source = EnrichmentSource.WIKIPEDIA
+
+    SUPPORTED_TYPES = {
+        "book",
+        "movie",
+        "documentary",
+        "tv_show",
+        "study",
+        "podcast",
+        "article",
+        "standup_special",
+        "person",
+        "place",
+    }
+
+    def __init__(self, requests_per_second: float = 5.0) -> None:
+        super().__init__(requests_per_second)
+        self.client = httpx.Client(
+            timeout=30.0,
+            headers={
+                "User-Agent": "Podex/1.0 (Podcast Media Index; educational project)",
+            },
+        )
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Wikipedia supports all media types."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search Wikipedia and enrich media item with type validation.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found and validated, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        # For studies, try specific search queries first
+        if media.type in ("study", "article"):
+            result = self._search_for_study(media)
+            if result:
+                return result
+
+        # Generate search variations
+        variations = generate_search_variations(media.title, media.author)
+
+        # Add type-specific variations
+        type_variations = self._get_type_specific_variations(media)
+
+        # Prioritize type-specific variations for better accuracy
+        all_variations = type_variations + variations
+
+        # Remove duplicates while preserving order
+        seen = set()
+        unique_variations = []
+        for v in all_variations:
+            v_lower = v.lower()
+            if v_lower not in seen:
+                seen.add(v_lower)
+                unique_variations.append(v)
+
+        # Try each variation
+        for query in unique_variations:
+            self.rate_limiter.wait_sync()
+            results = self._search(query)
+
+            if not results:
+                continue
+
+            # Find best match with type validation
+            best_match = self._find_best_match_with_validation(results, media)
+            if best_match:
+                page_id, title, confidence = best_match
+                self.rate_limiter.wait_sync()
+                page_data = self._get_page_details(page_id)
+                if page_data:
+                    # Final validation using categories
+                    if self._validate_page_type(page_data, media.type):
+                        return self._build_result(page_data, confidence)
+                    else:
+                        logger.debug(
+                            f"Wikipedia page '{title}' failed type "
+                            f"validation for {media.type}"
+                        )
+
+        logger.debug(f"No valid Wikipedia results for: {media.title}")
+        return None
+
+    def _search_for_study(self, media: Media) -> EnrichmentResult | None:
+        """Specialized search for studies/experiments.
+
+        Uses more specific queries to find the actual study, not albums/songs.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        title = media.title
+
+        # Specific search queries for studies
+        study_queries = [
+            f"{title} syphilis study",  # For Tuskegee specifically
+            f"{title} medical experiment",
+            f"{title} clinical trial",
+            f"{title} research study",
+            f"{title} scientific study",
+            f"{title} experiment ethics",
+            f"{title} study scandal",
+        ]
+
+        for query in study_queries:
+            self.rate_limiter.wait_sync()
+            results = self._search(query)
+
+            if not results:
+                continue
+
+            for result in results[:3]:
+                page_id = result.get("pageid")
+                if page_id is None or not isinstance(page_id, int):
+                    continue
+                result_title: str = result.get("title", "")
+                snippet: str = (result.get("snippet") or "").lower()
+
+                # Check for strong study signals in snippet
+                study_signals = [
+                    "study",
+                    "experiment",
+                    "conducted",
+                    "participants",
+                    "subjects",
+                    "medical",
+                    "clinical",
+                    "research",
+                    "ethical",
+                    "syphilis",
+                    "trial",
+                ]
+                signal_count = sum(1 for s in study_signals if s in snippet)
+
+                # Check for negative signals (albums, songs, etc.)
+                negative_signals = [
+                    "album",
+                    "song",
+                    "discography",
+                    "musician",
+                    "band",
+                    "singer",
+                    "studio album",
+                ]
+                has_negative = any(s in snippet for s in negative_signals)
+
+                if signal_count >= 2 and not has_negative:
+                    # Good candidate - fetch and validate
+                    self.rate_limiter.wait_sync()
+                    page_data = self._get_page_details(page_id)
+                    if page_data and self._validate_page_type(page_data, "study"):
+                        confidence = min(0.85 + (signal_count * 0.02), 0.95)
+                        logger.info(
+                            f"Found study match for '{media.title}': {result_title}"
+                        )
+                        return self._build_result(page_data, confidence)
+
+        return None
+
+    def _get_type_specific_variations(self, media: Media) -> list[str]:
+        """Generate type-specific search variations."""
+        variations = []
+        title = media.title
+
+        if media.type == "study":
+            variations.extend(
+                [
+                    f"{title} study",
+                    f"{title} experiment",
+                    f"{title} medical study",
+                    f"{title} research",
+                ]
+            )
+        elif media.type == "movie":
+            variations.append(f"{title} film")
+            if media.year:
+                variations.append(f"{title} {media.year} film")
+        elif media.type == "tv_show":
+            variations.extend(
+                [
+                    f"{title} TV series",
+                    f"{title} television series",
+                ]
+            )
+        elif media.type == "book":
+            variations.append(f"{title} novel")
+            if media.author:
+                variations.append(f"{title} {media.author} book")
+        elif media.type == "documentary":
+            variations.extend(
+                [
+                    f"{title} documentary",
+                    f"{title} documentary film",
+                ]
+            )
+
+        return variations
+
+    def _search(self, query: str) -> list[dict[str, Any]]:
+        """Search Wikipedia for pages."""
+        params: dict[str, str | int] = {
+            "action": "query",
+            "list": "search",
+            "srsearch": query,
+            "srlimit": 10,
+            "format": "json",
+            "srprop": "snippet|titlesnippet|sectionsnippet",
+        }
+
+        try:
+            response = self.client.get(self.API_URL, params=params)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            result: list[dict[str, Any]] = data.get("query", {}).get("search", [])
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"Wikipedia search error: {e}")
+            return []
+
+    def _find_best_match_with_validation(
+        self,
+        results: list[dict[str, Any]],
+        media: Media,
+    ) -> tuple[int, str, float] | None:
+        """Find best matching result with type validation.
+
+        Args:
+            results: Search results from Wikipedia.
+            media: Original media item.
+
+        Returns:
+            Tuple of (page_id, title, confidence) or None.
+        """
+        if not results:
+            return None
+
+        candidates: list[tuple[int, str, float]] = []
+
+        for result in results[:7]:
+            page_id = result.get("pageid")
+            if page_id is None or not isinstance(page_id, int):
+                continue
+            result_title: str = result.get("title", "")
+            snippet = (result.get("snippet", "") or "").lower()
+
+            # Calculate base title similarity
+            title_score = calculate_similarity(media.title, result_title)
+
+            # Check for positive type signals
+            positive_signals = TYPE_POSITIVE_SIGNALS.get(media.type, [])
+            positive_count = sum(1 for s in positive_signals if s in snippet)
+            positive_boost = min(positive_count * 0.03, 0.15)
+
+            # Check for negative type signals - these are PENALTIES
+            negative_signals = TYPE_NEGATIVE_SIGNALS.get(media.type, [])
+            has_negative = any(s in snippet for s in negative_signals)
+            negative_penalty = 0.4 if has_negative else 0.0
+
+            # Special case: check result title for type indicators
+            result_title_lower = result_title.lower()
+            if media.type == "study" and any(
+                x in result_title_lower
+                for x in ["(album)", "(song)", "(single)", "(ep)"]
+            ):
+                # Penalize if result title contains album/song indicators
+                negative_penalty = 0.5
+
+            # Calculate final score
+            total_score = title_score + positive_boost - negative_penalty
+
+            # Only consider if score is reasonable and no strong negative signals
+            if total_score >= 0.4 and not (has_negative and positive_count < 2):
+                candidates.append((page_id, result_title, total_score))
+
+        if not candidates:
+            return None
+
+        # Sort by score and return best
+        candidates.sort(key=lambda x: x[2], reverse=True)
+        best = candidates[0]
+
+        if best[2] >= 0.5:
+            return (best[0], best[1], min(best[2], 0.9))
+
+        return None
+
+    def _validate_page_type(self, page: dict[str, Any], expected_type: str) -> bool:
+        """Validate that a Wikipedia page matches the expected media type.
+
+        Args:
+            page: Wikipedia page data with categories.
+            expected_type: Expected media type.
+
+        Returns:
+            True if the page appears to match the expected type.
+        """
+        categories = page.get("categories", [])
+        if not categories:
+            # No categories to validate - allow with lower confidence
+            return True
+
+        cat_titles = [c.get("title", "").lower() for c in categories]
+        cat_text = " ".join(cat_titles)
+
+        # Check for negative category patterns (wrong type)
+        if expected_type == "study":
+            # Reject if it's clearly an album, song, or film
+            album_patterns = CATEGORY_TYPE_PATTERNS.get("album", [])
+            for pattern in album_patterns:
+                if re.search(pattern, cat_text):
+                    logger.debug(f"Rejecting: matched album pattern '{pattern}'")
+                    return False
+
+            # Also check for explicit album/music categories
+            music_keywords = [
+                "albums",
+                "songs",
+                "singles",
+                "discograph",
+                "musician",
+                "jazz album",
+                "rock album",
+            ]
+            if any(kw in cat_text for kw in music_keywords):
+                logger.debug("Rejecting: has music-related categories")
+                return False
+
+        # Check for positive category patterns (right type)
+        positive_patterns = CATEGORY_TYPE_PATTERNS.get(expected_type, [])
+        for pattern in positive_patterns:
+            if re.search(pattern, cat_text):
+                return True
+
+        # If no strong positive match but also no negative, allow it
+        # (Wikipedia might not have perfect categories)
+        return True
+
+    def _get_page_details(self, page_id: int) -> dict[str, Any] | None:
+        """Get detailed page information including categories for validation."""
+        params: dict[str, str | int | bool] = {
+            "action": "query",
+            "pageids": page_id,
+            "prop": "extracts|pageimages|info|categories",
+            "exintro": True,
+            "explaintext": True,
+            "exsentences": 10,
+            "piprop": "thumbnail|original",
+            "pithumbsize": 500,
+            "inprop": "url",
+            "cllimit": 50,  # Get more categories for better validation
+            "format": "json",
+        }
+
+        try:
+            response = self.client.get(self.API_URL, params=params)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+
+            pages: dict[str, Any] = data.get("query", {}).get("pages", {})
+            if str(page_id) in pages:
+                result: dict[str, Any] = pages[str(page_id)]
+                return result
+            return None
+        except httpx.HTTPError as e:
+            logger.warning(f"Wikipedia page fetch error: {e}")
+            return None
+
+    def _build_result(
+        self, page: dict[str, Any], confidence: float
+    ) -> EnrichmentResult:
+        """Build enrichment result from Wikipedia page."""
+        page_id = page.get("pageid")
+        title = page.get("title", "")
+
+        # Get image URL
+        cover_url = None
+        if "thumbnail" in page:
+            cover_url = page["thumbnail"].get("source")
+        elif "original" in page:
+            cover_url = page["original"].get("source")
+
+        # Get extract as description
+        description = page.get("extract", "")
+        if description:
+            description = description.strip()
+            if len(description) > 1000:
+                sentences = description[:1000].split(". ")
+                description = ". ".join(sentences[:-1]) + "."
+
+        # External IDs
+        external_ids: dict[str, str | int] = {}
+        if page_id:
+            external_ids["wikipedia_id"] = title.replace(" ", "_")
+
+        # Build metadata
+        metadata: dict[str, Any] = {
+            "wikipedia_title": title,
+        }
+
+        # Get categories
+        categories = page.get("categories", [])
+        if categories:
+            cat_titles = [
+                c.get("title", "").replace("Category:", "") for c in categories[:10]
+            ]
+            metadata["wikipedia_categories"] = cat_titles
+
+        # Add Wikipedia URL
+        url = page.get("fullurl")
+        if url:
+            metadata["wikipedia_url"] = url
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=cover_url,
+            description=description,
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> WikipediaProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/tests/test_enrichment_providers.py
+++ b/backend/tests/test_enrichment_providers.py
@@ -1,0 +1,378 @@
+"""Tests for the enrichment provider base, utils, and free providers."""
+
+from typing import Any
+
+import httpx
+from assertpy import assert_that
+
+from podex.models import Media, MediaType
+from podex.services.enrichment import OpenLibraryProvider, WikipediaProvider
+from podex.services.enrichment.search_utils import (
+    calculate_similarity,
+    generate_search_variations,
+    normalize_title,
+    strip_articles,
+)
+
+
+def _media(title: str, media_type: MediaType = MediaType.BOOK) -> Media:
+    media = Media(type=media_type, title=title, author="Frank Herbert")
+    media.id = 1
+    return media
+
+
+def _mock_client(handler: Any) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_search_utils_normalize_and_variations() -> None:
+    """Titles normalize and search variations include stripped forms."""
+    assert_that(strip_articles("The Dune")).is_equal_to("Dune")
+    assert_that(normalize_title("Dune: Part Two!")).contains("dune")
+    variations = generate_search_variations(
+        "The Dune: A Saga (Deluxe)",
+        author="Frank Herbert",
+    )
+    assert_that(len(variations)).is_greater_than(1)
+    assert_that(calculate_similarity("Dune", "Dune")).is_equal_to(1.0)
+
+
+def test_open_library_enriches_book(monkeypatch: Any) -> None:
+    """A matching search doc plus work detail produce a useful result."""
+    search_payload = {
+        "docs": [
+            {
+                "key": "/works/OL893415W",
+                "title": "Dune",
+                "author_name": ["Frank Herbert"],
+                "first_publish_year": 1965,
+                "cover_i": 12345,
+            },
+        ],
+    }
+    work_payload = {
+        "key": "/works/OL893415W",
+        "title": "Dune",
+        "description": "A desert planet saga.",
+        "covers": [12345],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/search.json":
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(200, json=work_payload)
+
+    provider = OpenLibraryProvider(requests_per_second=1000)
+    provider.client = _mock_client(handler)
+    result = provider.search_and_enrich(_media("Dune"))
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+        assert_that(str(result.external_ids)).contains("OL893415W")
+
+
+def test_open_library_handles_no_results_and_errors() -> None:
+    """Empty results and HTTP errors both yield None, not exceptions."""
+    empty = OpenLibraryProvider(requests_per_second=1000)
+    empty.client = _mock_client(
+        lambda request: httpx.Response(200, json={"docs": []}),
+    )
+    erroring = OpenLibraryProvider(requests_per_second=1000)
+    erroring.client = _mock_client(
+        lambda request: httpx.Response(500, text="boom"),
+    )
+
+    assert_that(empty.search_and_enrich(_media("Nothing Here"))).is_none()
+    assert_that(erroring.search_and_enrich(_media("Dune"))).is_none()
+    assert_that(
+        empty.search_and_enrich(_media("Dune", MediaType.MOVIE)),
+    ).is_none()
+    empty.close()
+    erroring.close()
+
+
+def test_wikipedia_provider_returns_none_gracefully() -> None:
+    """Wikipedia provider degrades to None on empty search results."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"query": {"search": []}},
+        )
+
+    provider = WikipediaProvider(requests_per_second=1000)
+    provider.client = _mock_client(handler)
+    result = provider.search_and_enrich(_media("Completely Unknown Thing"))
+    provider.close()
+
+    assert_that(result).is_none()
+
+
+def test_wikipedia_provider_error_path() -> None:
+    """HTTP failures yield None rather than raising."""
+    provider = WikipediaProvider(requests_per_second=1000)
+    provider.client = _mock_client(
+        lambda request: httpx.Response(503, text="unavailable"),
+    )
+
+    assert_that(provider.search_and_enrich(_media("Dune"))).is_none()
+    provider.close()
+
+
+def test_wikipedia_enriches_book_via_search_and_page() -> None:
+    """A search hit plus page detail produce a useful Wikipedia result."""
+    search_payload = {
+        "query": {
+            "search": [
+                {
+                    "pageid": 42,
+                    "title": "Dune (novel)",
+                    "snippet": "science fiction novel by Frank Herbert",
+                },
+            ],
+        },
+    }
+    page_payload = {
+        "query": {
+            "pages": {
+                "42": {
+                    "pageid": 42,
+                    "title": "Dune (novel)",
+                    "extract": "Dune is a 1965 science fiction novel "
+                    "written by Frank Herbert about a desert planet.",
+                    "fullurl": "https://en.wikipedia.org/wiki/Dune_(novel)",
+                    "thumbnail": {
+                        "original": "https://upload.wikimedia.org/dune.jpg",
+                    },
+                    "categories": [
+                        {"title": "Category:1965 American novels"},
+                        {"title": "Category:Novels by Frank Herbert"},
+                    ],
+                },
+            },
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        if params.get("list") == "search":
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(200, json=page_payload)
+
+    provider = WikipediaProvider(requests_per_second=1000)
+    provider.client = _mock_client(handler)
+    result = provider.search_and_enrich(_media("Dune"))
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+        assert_that(result.description or "").contains("Frank Herbert")
+
+
+def test_search_utils_helper_coverage() -> None:
+    """Subtitle/parenthetical/name/keyword helpers behave as documented."""
+    from podex.services.enrichment.search_utils import (
+        extract_key_words,
+        get_primary_name,
+        is_likely_match,
+        remove_parentheticals,
+        remove_subtitle,
+        remove_with_clause,
+    )
+
+    assert_that(remove_subtitle("Dune: The Saga")).is_equal_to("Dune")
+    assert_that(remove_parentheticals("Dune (Deluxe)")).is_equal_to("Dune")
+    assert_that(remove_with_clause("An Evening with Frank Herbert")).does_not_contain(
+        "with Frank",
+    )
+    assert_that(get_primary_name("Frank Herbert, Kevin Anderson") or "").contains(
+        "Herbert",
+    )
+    assert_that(get_primary_name("Frank Herbert and Kevin Anderson") or "").contains(
+        "Herbert",
+    )
+    key_words = extract_key_words(
+        "The Complete and Utterly Definitive History of the Desert Planet",
+    )
+    assert_that(len(key_words)).is_greater_than(0)
+    likely, score = is_likely_match("Dune", "Dune")
+    assert_that(likely).is_true()
+    assert_that(score).is_greater_than(0.9)
+    unlikely, _ = is_likely_match("Dune", "Cooking with Gas")
+    assert_that(unlikely).is_false()
+
+
+def test_open_library_direct_id_fetch() -> None:
+    """A known open_library_id fetches the work directly at confidence 1."""
+    work_payload = {
+        "key": "/works/OL893415W",
+        "title": "Dune",
+        "description": {"type": "/type/text", "value": "Desert planet saga."},
+        "covers": [12345],
+        "subjects": ["Science fiction"],
+    }
+    provider = OpenLibraryProvider(requests_per_second=1000)
+    provider.client = _mock_client(
+        lambda request: httpx.Response(200, json=work_payload),
+    )
+    media = _media("Dune")
+    media.open_library_id = "OL893415W"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.confidence).is_equal_to(1.0)
+        assert_that(result.description or "").contains("Desert planet")
+
+
+def test_open_library_falls_back_to_search_doc() -> None:
+    """When the work fetch fails, the search doc still builds a result."""
+    search_payload = {
+        "docs": [
+            {
+                "key": "/works/OL893415W",
+                "title": "Dune",
+                "author_name": ["Frank Herbert"],
+                "first_publish_year": 1965,
+                "first_sentence": ["A desert planet."],
+                "cover_i": 12345,
+                "subject": ["Science fiction"],
+            },
+        ],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/search.json":
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(404, text="missing")
+
+    provider = OpenLibraryProvider(requests_per_second=1000)
+    provider.client = _mock_client(handler)
+    result = provider.search_and_enrich(_media("Dune"))
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_wikipedia_study_search_path() -> None:
+    """Study-type media walk the study flow through search and page fetch."""
+    search_payload = {
+        "query": {
+            "search": [
+                {
+                    "pageid": 77,
+                    "title": "Sleep and memory consolidation study",
+                    "snippet": "landmark research study on sleep",
+                },
+            ],
+        },
+    }
+    page_payload = {
+        "query": {
+            "pages": {
+                "77": {
+                    "pageid": 77,
+                    "title": "Sleep and memory consolidation study",
+                    "extract": "A landmark research study examining how "
+                    "sleep consolidates memory in controlled experiments.",
+                    "fullurl": "https://en.wikipedia.org/wiki/Sleep_study",
+                    "categories": [
+                        {"title": "Category:Clinical research"},
+                        {"title": "Category:Sleep studies"},
+                    ],
+                },
+            },
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        if params.get("list") == "search":
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(200, json=page_payload)
+
+    provider = WikipediaProvider(requests_per_second=1000)
+    provider.client = _mock_client(handler)
+    result = provider.search_and_enrich(
+        _media("Sleep and memory consolidation", MediaType.STUDY),
+    )
+    empty = WikipediaProvider(requests_per_second=1000)
+    empty.client = _mock_client(
+        lambda request: httpx.Response(200, json={"query": {"search": []}}),
+    )
+    none_result = empty.search_and_enrich(_media("Nothing", MediaType.STUDY))
+    provider.close()
+    empty.close()
+
+    assert_that(none_result).is_none()
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_base_title_similarity() -> None:
+    """The base similarity helper scores near-identical titles high."""
+    provider = OpenLibraryProvider(requests_per_second=1000)
+    same = provider._calculate_title_similarity("Dune", "Dune")
+    partial = provider._calculate_title_similarity("Dune", "The Dune Saga")
+    provider.close()
+
+    assert_that(same).is_equal_to(1.0)
+    assert_that(partial).is_less_than(1.0)
+
+
+def test_rate_limiter_and_context_managers() -> None:
+    """Rate limiting waits between calls; providers work as context managers."""
+    import asyncio
+
+    from podex.services.enrichment.base import RateLimiter
+
+    limiter = RateLimiter(requests_per_second=10000)
+    limiter.wait_sync()
+    limiter.wait_sync()
+    asyncio.run(limiter.wait())
+
+    with OpenLibraryProvider(requests_per_second=1000) as ol:
+        assert_that(
+            ol._calculate_title_similarity("Dune Saga", "Saga of Dune"),
+        ).is_greater_than(0.0)
+        assert_that(
+            ol._calculate_title_similarity("Dune", ""),
+        ).is_equal_to(0.0)
+    with WikipediaProvider(requests_per_second=1000) as wiki:
+        assert_that(wiki.supports_media_type("book")).is_true()
+
+
+def test_provider_mismatch_and_variation_paths() -> None:
+    """Low-similarity docs are rejected; movie-type variations execute."""
+    mismatch = OpenLibraryProvider(requests_per_second=1000)
+    mismatch.client = _mock_client(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "docs": [
+                    {
+                        "key": "/works/OL1W",
+                        "title": "Cooking with Gas",
+                        "author_name": ["Someone Else"],
+                    },
+                ],
+            },
+        ),
+    )
+    assert_that(mismatch.search_and_enrich(_media("Dune"))).is_none()
+    mismatch.close()
+
+    movie = WikipediaProvider(requests_per_second=1000)
+    movie.client = _mock_client(
+        lambda request: httpx.Response(200, json={"query": {"search": []}}),
+    )
+    assert_that(
+        movie.search_and_enrich(_media("Dune", MediaType.MOVIE)),
+    ).is_none()
+    movie.close()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(media): add enrichment provider framework with OpenLibrary and Wikipedia`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Third slice of the media theme (#108 old PR4; source: the #103 branch):

- `services/enrichment/base.py`: `EnrichmentProvider` ABC with typed `EnrichmentResult`/`VerifiedEnrichmentResult`, per-provider rate limiting, and title-similarity scoring.
- `services/enrichment/search_utils.py`: search-variation generation (subtitle/parenthetical/article stripping, key-word extraction, likely-match scoring).
- Providers: **OpenLibrary** (books — search → work detail → fallback-to-search-doc, direct-id fetch) and **Wikipedia** (universal fallback incl. the study-specific flow). Both keyless; API-key providers (TMDB/OMDB/Google Books/iTunes/academic trio) land next slice with the `MediaEnricher` registry + pipeline, so every provider ships tested.
- `Media` gains the enrichment identifier/provenance columns (`*_id`s, `doi`, `verification_sources`, `enriched_at`, `enrichment_source`, `enrichment_confidence`) via migration `0008`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #13
- Relates to #12
- Relates to #108

## Details

Verified: `uv run lintro tst` (212 passed, incl. migration replay + drift guard) at 85.0% coverage; ruff/mypy/bandit/pydoclint clean. Providers tested via `httpx.MockTransport` (happy paths, fallbacks, mismatch rejection, error paths) — no network in tests; credentials constructor-injected only.