### PR TITLE
feat(media): complete enrichment provider registry and pipeline

### DIFF
--- a/backend/src/podex/services/academic_enrichment.py
+++ b/backend/src/podex/services/academic_enrichment.py
@@ -1,0 +1,366 @@
+"""Academic paper enrichment with multi-source verification.
+
+Orchestrates enrichment of academic papers (studies, articles) from multiple
+authoritative sources with cross-validation to ensure accuracy.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+
+from podex.services.enrichment.base import (
+    EnrichmentResult,
+    EnrichmentSource,
+    VerifiedEnrichmentResult,
+)
+from podex.services.enrichment.crossref import CrossRefProvider
+from podex.services.enrichment.pubmed import PubMedProvider
+from podex.services.enrichment.semantic_scholar import SemanticScholarProvider
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class AcademicEnricher:
+    """Multi-source verification enricher for academic papers.
+
+    Queries PubMed, Semantic Scholar, and CrossRef in parallel,
+    cross-validates results using DOI as canonical identifier,
+    and requires 2+ source confirmation for high-confidence enrichment.
+
+    Args:
+        ncbi_api_key: Optional NCBI API key for PubMed (higher rate limits).
+        crossref_mailto: Optional email for CrossRef polite pool.
+    """
+
+    SUPPORTED_TYPES = {"study", "article"}
+
+    def __init__(
+        self,
+        ncbi_api_key: str | None = None,
+        crossref_mailto: str | None = None,
+    ) -> None:
+        self.providers = {
+            EnrichmentSource.PUBMED: PubMedProvider(api_key=ncbi_api_key),
+            EnrichmentSource.SEMANTIC_SCHOLAR: SemanticScholarProvider(),
+            EnrichmentSource.CROSSREF: CrossRefProvider(mailto=crossref_mailto),
+        }
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if this enricher supports the given media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def enrich_with_verification(
+        self,
+        media: Media,
+        require_doi: bool = False,
+        min_sources: int = 2,
+    ) -> VerifiedEnrichmentResult | None:
+        """Enrich with multi-source cross-validation.
+
+        Args:
+            media: The media item to enrich.
+            require_doi: If True, only return results with DOI verification.
+            min_sources: Minimum number of sources required for verification.
+
+        Returns:
+            VerifiedEnrichmentResult if successful, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        # 1. Collect results from all providers
+        results: dict[EnrichmentSource, EnrichmentResult] = {}
+        for source, provider in self.providers.items():
+            try:
+                result = provider.search_and_enrich(media)
+                if result and result.confidence >= 0.5:
+                    results[source] = result
+                    logger.debug(
+                        f"Got result from {source.value} for '{media.title}' "
+                        f"(confidence: {result.confidence:.2f})"
+                    )
+            except Exception:
+                logger.exception(f"Error querying {source.value}")
+                continue
+
+        if not results:
+            logger.debug(f"No academic enrichment results for: {media.title}")
+            return None
+
+        # 2. Cross-validate by DOI
+        verified = self._verify_by_doi(results)
+
+        # 3. If DOI verification succeeded with enough sources
+        if len(verified) >= min_sources:
+            logger.info(
+                f"DOI-verified enrichment for '{media.title}' "
+                f"from {len(verified)} sources: {[s.value for s in verified]}"
+            )
+            return self._aggregate_results(
+                verified,
+                doi_verified=True,
+                confidence=0.95,
+            )
+
+        # 4. Fall back to title+author matching if DOI verification failed
+        if not require_doi:
+            title_verified = self._verify_by_title(results)
+            if len(title_verified) >= min_sources:
+                logger.info(
+                    f"Title-verified enrichment for '{media.title}' "
+                    f"from {len(title_verified)} sources: "
+                    f"{[s.value for s in title_verified]}"
+                )
+                return self._aggregate_results(
+                    title_verified,
+                    doi_verified=False,
+                    confidence=0.80,
+                )
+
+        # 5. Single source fallback (lower confidence)
+        if results and not require_doi:
+            # Prefer source with highest confidence
+            best_source = max(results.keys(), key=lambda s: results[s].confidence)
+            best_result = results[best_source]
+
+            logger.info(
+                f"Single-source enrichment for '{media.title}' "
+                f"from {best_source.value} (confidence: {best_result.confidence:.2f})"
+            )
+
+            return VerifiedEnrichmentResult(
+                source=best_source,
+                cover_url=best_result.cover_url,
+                description=best_result.description,
+                external_ids=best_result.external_ids,
+                metadata=best_result.metadata,
+                confidence=best_result.confidence * 0.9,  # Penalize single-source
+                verified_by=[best_source],
+                source_results={best_source: best_result},
+                doi_verified=False,
+            )
+
+        return None
+
+    def _verify_by_doi(
+        self,
+        results: dict[EnrichmentSource, EnrichmentResult],
+    ) -> dict[EnrichmentSource, EnrichmentResult]:
+        """Filter to results with matching DOI.
+
+        Args:
+            results: Results from multiple sources.
+
+        Returns:
+            Dict of sources that agree on the same DOI.
+        """
+        # Extract DOIs from all results
+        dois: dict[EnrichmentSource, str] = {}
+        for source, result in results.items():
+            doi = result.external_ids.get("doi")
+            if doi:
+                # Normalize DOI
+                normalized = self._normalize_doi(str(doi))
+                dois[source] = normalized
+
+        if not dois:
+            return {}
+
+        # Find most common DOI
+        doi_counts = Counter(dois.values())
+        most_common_doi, count = doi_counts.most_common(1)[0]
+
+        if count < 2:
+            return {}  # No agreement
+
+        # Return only results with matching DOI
+        return {
+            source: result
+            for source, result in results.items()
+            if dois.get(source) == most_common_doi
+        }
+
+    def _verify_by_title(
+        self,
+        results: dict[EnrichmentSource, EnrichmentResult],
+    ) -> dict[EnrichmentSource, EnrichmentResult]:
+        """Verify results by title similarity.
+
+        Uses the fact that all results came from the same query,
+        so we check if titles are similar enough across sources.
+
+        Args:
+            results: Results from multiple sources.
+
+        Returns:
+            Dict of sources with similar titles.
+        """
+        if len(results) < 2:
+            return results
+
+        # Get titles from metadata or descriptions
+        titles: dict[EnrichmentSource, str] = {}
+        for source, result in results.items():
+            title = result.metadata.get("title")
+            if not title and result.description:
+                # Use first sentence of description as pseudo-title
+                title = result.description.split(".")[0][:100]
+            if title:
+                titles[source] = self._normalize_title(str(title))
+
+        if not titles:
+            # All results came from same search, assume they match
+            return results
+
+        # Check pairwise title similarity
+        sources = list(titles.keys())
+        verified_sources: set[EnrichmentSource] = set()
+
+        for i, source1 in enumerate(sources):
+            for source2 in sources[i + 1 :]:
+                title1 = titles[source1]
+                title2 = titles[source2]
+
+                # Simple word overlap check
+                words1 = set(title1.split())
+                words2 = set(title2.split())
+                if words1 and words2:
+                    intersection = words1 & words2
+                    union = words1 | words2
+                    similarity = len(intersection) / len(union)
+
+                    if similarity > 0.5:
+                        verified_sources.add(source1)
+                        verified_sources.add(source2)
+
+        if len(verified_sources) >= 2:
+            return {s: results[s] for s in verified_sources}
+
+        return {}
+
+    def _normalize_doi(self, doi: str) -> str:
+        """Normalize DOI for comparison.
+
+        Args:
+            doi: DOI string.
+
+        Returns:
+            Normalized DOI.
+        """
+        doi = doi.lower().strip()
+        # Remove common prefixes
+        for prefix in ["https://doi.org/", "http://doi.org/", "doi:"]:
+            if doi.startswith(prefix):
+                doi = doi[len(prefix) :]
+        return doi
+
+    def _normalize_title(self, title: str) -> str:
+        """Normalize title for comparison.
+
+        Args:
+            title: Title string.
+
+        Returns:
+            Normalized title.
+        """
+        import re
+
+        title = title.lower().strip()
+        # Remove common articles
+        title = re.sub(r"^(the|a|an)\s+", "", title)
+        # Remove punctuation
+        title = re.sub(r"[^\w\s]", "", title)
+        # Normalize whitespace
+        title = " ".join(title.split())
+        return title
+
+    def _aggregate_results(
+        self,
+        results: dict[EnrichmentSource, EnrichmentResult],
+        doi_verified: bool,
+        confidence: float,
+    ) -> VerifiedEnrichmentResult:
+        """Merge results from multiple sources.
+
+        Prioritizes data from more authoritative sources.
+
+        Args:
+            results: Verified results from multiple sources.
+            doi_verified: Whether DOI was used for verification.
+            confidence: Aggregated confidence score.
+
+        Returns:
+            Merged VerifiedEnrichmentResult.
+        """
+        # Priority order for data merging
+        priority = [
+            EnrichmentSource.PUBMED,  # Medical authority
+            EnrichmentSource.CROSSREF,  # DOI authority
+            EnrichmentSource.SEMANTIC_SCHOLAR,  # Rich metadata
+        ]
+
+        merged_ids: dict[str, str | int] = {}
+        merged_metadata: dict[str, Any] = {}
+        description = None
+        primary_source = None
+
+        for source in priority:
+            if source not in results:
+                continue
+
+            result = results[source]
+
+            # Track primary source (first available in priority order)
+            if primary_source is None:
+                primary_source = source
+
+            # Merge external IDs (first wins)
+            for key, value in result.external_ids.items():
+                if key not in merged_ids:
+                    merged_ids[key] = value
+
+            # Merge metadata (first wins)
+            for key, value in result.metadata.items():
+                if key not in merged_metadata:
+                    merged_metadata[key] = value
+
+            # First description wins
+            if not description and result.description:
+                description = result.description
+
+        # Collect citation counts from all sources for comparison
+        citation_counts = []
+        for result in results.values():
+            if "citation_count" in result.metadata:
+                citation_counts.append(result.metadata["citation_count"])
+        if citation_counts:
+            # Use the maximum citation count (most up-to-date)
+            merged_metadata["citation_count"] = max(citation_counts)
+
+        return VerifiedEnrichmentResult(
+            source=primary_source or EnrichmentSource.PUBMED,
+            cover_url=None,  # Academic sources don't provide covers
+            description=description,
+            external_ids=merged_ids,
+            metadata=merged_metadata,
+            confidence=confidence,
+            verified_by=list(results.keys()),
+            source_results=results,
+            doi_verified=doi_verified,
+        )
+
+    def close(self) -> None:
+        """Close all provider HTTP clients."""
+        for provider in self.providers.values():
+            provider.close()
+
+    def __enter__(self) -> AcademicEnricher:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/enrichment/__init__.py
+++ b/backend/src/podex/services/enrichment/__init__.py
@@ -1,7 +1,4 @@
-"""Enrichment providers for canonical media records.
-
-Providers land incrementally; this package exports the ones on main.
-"""
+"""Enrichment providers for canonical media records."""
 
 from podex.services.enrichment.base import (
     EnrichmentProvider,
@@ -10,15 +7,31 @@ from podex.services.enrichment.base import (
     RateLimiter,
     VerifiedEnrichmentResult,
 )
+from podex.services.enrichment.crossref import CrossRefProvider
+from podex.services.enrichment.google_books import GoogleBooksProvider
+from podex.services.enrichment.itunes import iTunesProvider
+from podex.services.enrichment.omdb import OMDBProvider
 from podex.services.enrichment.open_library import OpenLibraryProvider
+from podex.services.enrichment.pubmed import PubMedProvider
+from podex.services.enrichment.semantic_scholar import SemanticScholarProvider
+from podex.services.enrichment.tmdb import TMDBProvider
+from podex.services.enrichment.tmdb_person import TMDBPersonProvider
 from podex.services.enrichment.wikipedia import WikipediaProvider
 
 __all__ = [
+    "CrossRefProvider",
     "EnrichmentProvider",
     "EnrichmentResult",
     "EnrichmentSource",
+    "GoogleBooksProvider",
+    "OMDBProvider",
     "OpenLibraryProvider",
+    "PubMedProvider",
     "RateLimiter",
+    "SemanticScholarProvider",
+    "TMDBPersonProvider",
+    "TMDBProvider",
     "VerifiedEnrichmentResult",
     "WikipediaProvider",
+    "iTunesProvider",
 ]

--- a/backend/src/podex/services/enrichment/crossref.py
+++ b/backend/src/podex/services/enrichment/crossref.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class CrossRefProvider(EnrichmentProvider):
+class CrossRefProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich academic papers from CrossRef DOI registry.
 
     Uses CrossRef REST API (free, polite pool with mailto header).

--- a/backend/src/podex/services/enrichment/crossref.py
+++ b/backend/src/podex/services/enrichment/crossref.py
@@ -1,0 +1,347 @@
+"""CrossRef API enrichment provider."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class CrossRefProvider(EnrichmentProvider):
+    """Enrich academic papers from CrossRef DOI registry.
+
+    Uses CrossRef REST API (free, polite pool with mailto header).
+
+    Args:
+        mailto: Email address for polite pool (higher rate limits).
+        requests_per_second: Rate limit for API calls.
+    """
+
+    BASE_URL = "https://api.crossref.org"
+
+    source = EnrichmentSource.CROSSREF
+    SUPPORTED_TYPES = {"study", "article"}
+
+    def __init__(
+        self,
+        mailto: str | None = None,
+        requests_per_second: float = 10.0,
+    ) -> None:
+        super().__init__(requests_per_second)
+        self.mailto = mailto
+
+        # Include mailto in User-Agent for polite pool
+        user_agent = "Podex/1.0 (Academic Media Index)"
+        if mailto:
+            user_agent += f" (mailto:{mailto})"
+
+        self.client = httpx.Client(
+            base_url=self.BASE_URL,
+            headers={"User-Agent": user_agent},
+            timeout=30.0,
+        )
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if CrossRef supports this media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search CrossRef and enrich media item.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        # 1. Direct lookup by DOI
+        if media.doi:
+            self.rate_limiter.wait_sync()
+            work = self._get_work_by_doi(media.doi)
+            if work:
+                return self._build_result(work, confidence=1.0)
+
+        # 2. Search by title
+        self.rate_limiter.wait_sync()
+        results = self._search(media.title, media.author)
+
+        if not results:
+            logger.debug(f"No CrossRef results for: {media.title}")
+            return None
+
+        # Find best match
+        best_match = self._find_best_match(results, media)
+        if not best_match:
+            return None
+
+        work, confidence = best_match
+        return self._build_result(work, confidence)
+
+    def _get_work_by_doi(self, doi: str) -> dict[str, Any] | None:
+        """Fetch work by DOI.
+
+        Args:
+            doi: DOI to lookup.
+
+        Returns:
+            Work data or None.
+        """
+        # Normalize DOI - remove common prefixes
+        normalized_doi = doi.lower().strip()
+        for prefix in ["https://doi.org/", "http://doi.org/", "doi:"]:
+            if normalized_doi.startswith(prefix):
+                normalized_doi = normalized_doi[len(prefix) :]
+                break
+
+        try:
+            response = self.client.get(f"/works/{normalized_doi}")
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            result: dict[str, Any] | None = data.get("message")
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"CrossRef lookup error for {doi}: {e}")
+            return None
+
+    def _search(self, title: str, author: str | None) -> list[dict[str, Any]]:
+        """Search CrossRef by title and author.
+
+        Args:
+            title: Paper title.
+            author: Optional author name.
+
+        Returns:
+            List of work results.
+        """
+        params: dict[str, str | int] = {
+            "query.title": title,
+            "rows": 10,
+        }
+
+        if author:
+            # Take first author's last name
+            first_author = author.split(",")[0].split(" and ")[0].strip()
+            last_name = first_author.split()[-1] if first_author else None
+            if last_name:
+                params["query.author"] = last_name
+
+        if self.mailto:
+            params["mailto"] = self.mailto
+
+        try:
+            response = self.client.get("/works", params=params)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            result: list[dict[str, Any]] = data.get("message", {}).get("items", [])
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"CrossRef search error: {e}")
+            return []
+
+    def _find_best_match(
+        self,
+        results: list[dict[str, Any]],
+        media: Media,
+    ) -> tuple[dict[str, Any], float] | None:
+        """Find best matching result.
+
+        Args:
+            results: Search results from CrossRef.
+            media: Original media item.
+
+        Returns:
+            Tuple of (work, confidence) or None.
+        """
+        if not results:
+            return None
+
+        best_work = None
+        best_score = 0.0
+
+        for work in results[:5]:
+            # CrossRef returns title as a list
+            titles = work.get("title", [])
+            result_title = titles[0] if titles else ""
+
+            # Calculate title similarity
+            title_score = self._calculate_title_similarity(media.title, result_title)
+
+            # Check author match
+            author_boost = 0.0
+            if media.author:
+                work_authors = work.get("author", [])
+                for author in work_authors:
+                    # CrossRef uses given/family name structure
+                    author_name = ""
+                    if author.get("given") and author.get("family"):
+                        author_name = f"{author['given']} {author['family']}"
+                    elif author.get("family"):
+                        author_name = author["family"]
+                    elif author.get("name"):
+                        author_name = author["name"]
+
+                    if author_name:
+                        author_sim = self._calculate_title_similarity(
+                            media.author,
+                            author_name,
+                        )
+                        if author_sim > 0.5:
+                            author_boost = 0.15
+                            break
+
+            # Check year match
+            year_boost = 0.0
+            if media.year:
+                published = work.get("published-print") or work.get("published-online")
+                if published:
+                    date_parts = published.get("date-parts", [[]])
+                    if date_parts and date_parts[0]:
+                        work_year = date_parts[0][0]
+                        if media.year == work_year:
+                            year_boost = 0.05
+
+            total_score = title_score + author_boost + year_boost
+
+            if total_score > best_score:
+                best_score = total_score
+                best_work = work
+
+        if best_work and best_score >= 0.6:
+            return (best_work, min(best_score, 0.9))
+
+        return None
+
+    def _build_result(
+        self, work: dict[str, Any], confidence: float
+    ) -> EnrichmentResult:
+        """Build enrichment result from CrossRef work.
+
+        Args:
+            work: CrossRef work data.
+            confidence: Match confidence score.
+
+        Returns:
+            EnrichmentResult with all available data.
+        """
+        external_ids: dict[str, str | int] = {
+            "doi": work["DOI"],
+        }
+
+        # CrossRef doesn't typically have other IDs directly,
+        # but may have ISSN for the journal
+        issn = work.get("ISSN", [])
+        if issn:
+            external_ids["issn"] = issn[0]
+
+        metadata: dict[str, Any] = {}
+
+        # Authors
+        authors = work.get("author", [])
+        if authors:
+            author_names = []
+            for author in authors:
+                if author.get("given") and author.get("family"):
+                    author_names.append(f"{author['given']} {author['family']}")
+                elif author.get("family"):
+                    author_names.append(author["family"])
+                elif author.get("name"):
+                    author_names.append(author["name"])
+            if author_names:
+                metadata["authors"] = author_names
+
+        # Publisher
+        if work.get("publisher"):
+            metadata["publisher"] = work["publisher"]
+
+        # Journal (container-title)
+        container_title = work.get("container-title", [])
+        if container_title:
+            metadata["journal"] = container_title[0]
+
+        # Publication date
+        published = work.get("published-print") or work.get("published-online")
+        if published:
+            date_parts = published.get("date-parts", [[]])
+            if date_parts and date_parts[0]:
+                year = date_parts[0][0]
+                month = date_parts[0][1] if len(date_parts[0]) > 1 else None
+                day = date_parts[0][2] if len(date_parts[0]) > 2 else None
+
+                if month and day:
+                    metadata["publication_date"] = f"{year}-{month:02d}-{day:02d}"
+                elif month:
+                    metadata["publication_date"] = f"{year}-{month:02d}"
+                else:
+                    metadata["publication_date"] = str(year)
+
+                metadata["year"] = year
+
+        # Citation counts
+        if work.get("is-referenced-by-count") is not None:
+            metadata["citation_count"] = work["is-referenced-by-count"]
+        if work.get("references-count") is not None:
+            metadata["reference_count"] = work["references-count"]
+
+        # Type
+        if work.get("type"):
+            metadata["work_type"] = work["type"]
+
+        # License/open access
+        licenses = work.get("license", [])
+        if licenses:
+            # Get the most recent license
+            license_url = licenses[0].get("URL")
+            if license_url:
+                metadata["license_url"] = license_url
+                # Check if it's open access
+                if "creativecommons.org" in license_url:
+                    metadata["open_access"] = True
+
+        # Subject areas
+        subjects = work.get("subject", [])
+        if subjects:
+            metadata["subjects"] = subjects
+
+        # Abstract (not always available from CrossRef)
+        abstract = work.get("abstract", "")
+        if abstract:
+            # CrossRef abstracts may have JATS XML tags, strip them
+            import re
+
+            abstract = re.sub(r"<[^>]+>", "", abstract)
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=None,  # CrossRef doesn't provide cover images
+            description=abstract if abstract else None,
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> CrossRefProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/enrichment/crossref.py
+++ b/backend/src/podex/services/enrichment/crossref.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -310,8 +311,12 @@ class CrossRefProvider(EnrichmentProvider):
             license_url = licenses[0].get("URL")
             if license_url:
                 metadata["license_url"] = license_url
-                # Check if it's open access
-                if "creativecommons.org" in license_url:
+                # Check if it's open access — parse the host rather than
+                # substring-matching so a lookalike URL cannot spoof it.
+                host = urlparse(license_url).hostname or ""
+                if host == "creativecommons.org" or host.endswith(
+                    ".creativecommons.org",
+                ):
                     metadata["open_access"] = True
 
         # Subject areas

--- a/backend/src/podex/services/enrichment/google_books.py
+++ b/backend/src/podex/services/enrichment/google_books.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class GoogleBooksProvider(EnrichmentProvider):
+class GoogleBooksProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich books from Google Books API.
 
     Args:

--- a/backend/src/podex/services/enrichment/google_books.py
+++ b/backend/src/podex/services/enrichment/google_books.py
@@ -1,0 +1,320 @@
+"""Google Books API enrichment provider."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleBooksProvider(EnrichmentProvider):
+    """Enrich books from Google Books API.
+
+    Args:
+        api_key: Optional Google API key for higher rate limits.
+        requests_per_second: Rate limit for API calls.
+    """
+
+    BASE_URL = "https://www.googleapis.com/books/v1"
+
+    source = EnrichmentSource.GOOGLE_BOOKS
+
+    SUPPORTED_TYPES = {"book"}
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        requests_per_second: float = 1.0,
+    ) -> None:
+        super().__init__(requests_per_second)
+        self.api_key = api_key
+        params = {}
+        if api_key:
+            params["key"] = api_key
+        self.client = httpx.Client(
+            base_url=self.BASE_URL,
+            params=params,
+            timeout=30.0,
+        )
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if Google Books supports this media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search Google Books and enrich media item.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        # If we already have a Google Books ID, fetch directly
+        if media.google_books_id:
+            self.rate_limiter.wait_sync()
+            volume = self._get_volume(media.google_books_id)
+            if volume:
+                return self._build_result(volume, confidence=1.0)
+
+        self.rate_limiter.wait_sync()
+
+        # Build search query
+        query = self._build_search_query(media.title, media.author)
+        results = self._search(query)
+
+        if not results:
+            logger.debug(f"No Google Books results for: {media.title}")
+            return None
+
+        # Find best match
+        best_match = self._find_best_match(results, media)
+        if not best_match:
+            return None
+
+        volume, confidence = best_match
+        return self._build_result(volume, confidence)
+
+    def _build_search_query(self, title: str, author: str | None) -> str:
+        """Build Google Books search query.
+
+        Args:
+            title: Book title.
+            author: Optional author name.
+
+        Returns:
+            Search query string.
+        """
+        query_parts = [f"intitle:{title}"]
+        if author:
+            query_parts.append(f"inauthor:{author}")
+        return "+".join(query_parts)
+
+    def _search(self, query: str) -> list[dict[str, Any]]:
+        """Search Google Books.
+
+        Args:
+            query: Search query string.
+
+        Returns:
+            List of volume results.
+        """
+        try:
+            response = self.client.get(
+                "/volumes",
+                params={
+                    "q": query,
+                    "maxResults": 10,
+                    "printType": "books",
+                    "langRestrict": "en",
+                },
+            )
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            result: list[dict[str, Any]] = data.get("items", [])
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"Google Books search error: {e}")
+            return []
+
+    def _get_volume(self, volume_id: str) -> dict[str, Any] | None:
+        """Fetch a specific volume by ID.
+
+        Args:
+            volume_id: Google Books volume ID.
+
+        Returns:
+            Volume data or None.
+        """
+        try:
+            response = self.client.get(f"/volumes/{volume_id}")
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"Google Books volume error for {volume_id}: {e}")
+            return None
+
+    def _find_best_match(
+        self,
+        results: list[dict[str, Any]],
+        media: Media,
+    ) -> tuple[dict[str, Any], float] | None:
+        """Find best matching result.
+
+        Args:
+            results: Search results from Google Books.
+            media: Original media item.
+
+        Returns:
+            Tuple of (volume_data, confidence) or None.
+        """
+        if not results:
+            return None
+
+        best_volume = None
+        best_score = 0.0
+
+        for item in results[:5]:  # Check top 5 results
+            volume_info = item.get("volumeInfo", {})
+            result_title = volume_info.get("title", "")
+
+            # Calculate title similarity
+            title_score = self._calculate_title_similarity(
+                media.title,
+                result_title,
+            )
+
+            # Check author match
+            author_boost = 0.0
+            if media.author:
+                authors = volume_info.get("authors", [])
+                for author in authors:
+                    author_sim = self._calculate_title_similarity(
+                        media.author,
+                        author,
+                    )
+                    if author_sim > 0.7:
+                        author_boost = 0.15
+                        break
+
+            total_score = title_score + author_boost
+
+            if total_score > best_score:
+                best_score = total_score
+                best_volume = item
+
+        if best_volume and best_score >= 0.7:
+            return (best_volume, min(best_score, 1.0))
+
+        return None
+
+    def _build_result(
+        self, volume: dict[str, Any], confidence: float
+    ) -> EnrichmentResult:
+        """Build enrichment result from Google Books volume.
+
+        Args:
+            volume: Google Books volume data.
+            confidence: Match confidence score.
+
+        Returns:
+            EnrichmentResult with all available data.
+        """
+        volume_info = volume.get("volumeInfo", {})
+
+        # Cover URL - prefer larger images
+        cover_url = None
+        image_links = volume_info.get("imageLinks", {})
+        for size in ["large", "medium", "small", "thumbnail"]:
+            if size in image_links:
+                cover_url = image_links[size]
+                # Convert http to https
+                if cover_url.startswith("http://"):
+                    cover_url = cover_url.replace("http://", "https://")
+                break
+
+        # Description
+        description = volume_info.get("description")
+
+        # External IDs
+        google_id = volume.get("id")
+        external_ids: dict[str, str | int] = {}
+        if google_id is not None:
+            external_ids["google_books_id"] = google_id
+
+        # Get ISBN
+        identifiers = volume_info.get("industryIdentifiers", [])
+        for identifier in identifiers:
+            id_type = identifier.get("type", "")
+            id_value = identifier.get("identifier", "")
+            if id_type == "ISBN_13":
+                external_ids["isbn_13"] = id_value
+            elif id_type == "ISBN_10":
+                external_ids["isbn_10"] = id_value
+
+        # Build metadata
+        metadata: dict[str, Any] = {}
+
+        # Page count
+        page_count = volume_info.get("pageCount")
+        if page_count:
+            metadata["page_count"] = page_count
+
+        # Categories/genres
+        categories = volume_info.get("categories", [])
+        if categories:
+            metadata["genres"] = categories
+
+        # Rating
+        average_rating = volume_info.get("averageRating")
+        if average_rating:
+            metadata["google_books_rating"] = average_rating
+            metadata["google_books_rating_count"] = volume_info.get(
+                "ratingsCount",
+                0,
+            )
+
+        # Publisher
+        publisher = volume_info.get("publisher")
+        if publisher:
+            metadata["publisher"] = publisher
+
+        # Published date
+        published_date = volume_info.get("publishedDate")
+        if published_date:
+            metadata["published_date"] = published_date
+
+        # Language
+        language = volume_info.get("language")
+        if language:
+            metadata["language"] = language
+
+        # Authors (store full list)
+        authors = volume_info.get("authors", [])
+        if authors:
+            metadata["authors"] = authors
+
+        # Preview/info links
+        preview_link = volume_info.get("previewLink")
+        if preview_link:
+            metadata["preview_link"] = preview_link
+
+        # Maturity rating
+        maturity = volume_info.get("maturityRating")
+        if maturity and maturity != "NOT_MATURE":
+            metadata["maturity_rating"] = maturity
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=cover_url,
+            description=description,
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> GoogleBooksProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/enrichment/itunes.py
+++ b/backend/src/podex/services/enrichment/itunes.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class iTunesProvider(EnrichmentProvider):
+class iTunesProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich podcasts from iTunes Search API.
 
     Free API, no authentication required.

--- a/backend/src/podex/services/enrichment/itunes.py
+++ b/backend/src/podex/services/enrichment/itunes.py
@@ -1,0 +1,253 @@
+"""iTunes Search API enrichment provider for podcasts."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class iTunesProvider(EnrichmentProvider):
+    """Enrich podcasts from iTunes Search API.
+
+    Free API, no authentication required.
+    Rate limited to ~20 calls/minute.
+
+    Args:
+        requests_per_second: Rate limit (default 0.3 = ~18/min to stay under limit).
+    """
+
+    BASE_URL = "https://itunes.apple.com"
+
+    source = EnrichmentSource.ITUNES
+
+    SUPPORTED_TYPES = {"podcast"}
+
+    def __init__(self, requests_per_second: float = 0.3) -> None:
+        super().__init__(requests_per_second)
+        self.client = httpx.Client(
+            base_url=self.BASE_URL,
+            timeout=30.0,
+        )
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if iTunes supports this media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search iTunes and enrich podcast.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        self.rate_limiter.wait_sync()
+
+        # Search for podcast
+        results = self._search_podcasts(media.title)
+
+        if not results:
+            logger.debug(f"No iTunes results for: {media.title}")
+            return None
+
+        # Find best match
+        best_match = self._find_best_match(results, media)
+        if not best_match:
+            return None
+
+        podcast, confidence = best_match
+        return self._build_result(podcast, confidence)
+
+    def _search_podcasts(self, query: str) -> list[dict[str, Any]]:
+        """Search iTunes for podcasts.
+
+        Args:
+            query: Search query string.
+
+        Returns:
+            List of podcast results.
+        """
+        try:
+            response = self.client.get(
+                "/search",
+                params={
+                    "term": query,
+                    "media": "podcast",
+                    "entity": "podcast",
+                    "limit": 10,
+                },
+            )
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            result: list[dict[str, Any]] = data.get("results", [])
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"iTunes search error for '{query}': {e}")
+            return []
+
+    def _find_best_match(
+        self,
+        results: list[dict[str, Any]],
+        media: Media,
+    ) -> tuple[dict[str, Any], float] | None:
+        """Find best matching podcast result.
+
+        Args:
+            results: Search results from iTunes.
+            media: Original media item.
+
+        Returns:
+            Tuple of (podcast_data, confidence) or None.
+        """
+        if not results:
+            return None
+
+        best_podcast = None
+        best_score = 0.0
+
+        for podcast in results[:5]:  # Check top 5 results
+            podcast_name = podcast.get("collectionName", "")
+            artist_name = podcast.get("artistName", "")
+
+            # Calculate title similarity
+            title_score = self._calculate_title_similarity(
+                media.title,
+                podcast_name,
+            )
+
+            # Boost if creator/author matches artist
+            author_boost = 0.0
+            if media.author:
+                author_sim = self._calculate_title_similarity(
+                    media.author,
+                    artist_name,
+                )
+                if author_sim > 0.6:
+                    author_boost = 0.15
+
+            total_score = title_score + author_boost
+
+            if total_score > best_score:
+                best_score = total_score
+                best_podcast = podcast
+
+        if best_podcast and best_score >= 0.5:  # Lower threshold for podcasts
+            return (best_podcast, min(best_score, 1.0))
+
+        return None
+
+    def _build_result(
+        self,
+        podcast: dict[str, Any],
+        confidence: float,
+    ) -> EnrichmentResult:
+        """Build enrichment result from iTunes podcast data.
+
+        Args:
+            podcast: iTunes podcast data.
+            confidence: Match confidence score.
+
+        Returns:
+            EnrichmentResult with all available data.
+        """
+        # Get highest quality artwork (replace 100x100 with 600x600)
+        artwork_url = podcast.get("artworkUrl600")
+        if not artwork_url:
+            artwork_url = podcast.get("artworkUrl100", "")
+            if artwork_url:
+                artwork_url = artwork_url.replace("100x100", "600x600")
+
+        # Description (not always available in search results)
+        description = None  # iTunes search doesn't return full description
+
+        # External IDs
+        external_ids: dict[str, str | int] = {}
+
+        collection_id = podcast.get("collectionId")
+        if collection_id:
+            external_ids["apple_podcasts_id"] = str(collection_id)
+
+        # Build metadata
+        metadata: dict[str, Any] = {}
+
+        # Artist/creator
+        artist_name = podcast.get("artistName")
+        if artist_name:
+            metadata["creator"] = artist_name
+
+        # Genre
+        primary_genre = podcast.get("primaryGenreName")
+        if primary_genre:
+            metadata["genres"] = [primary_genre]
+
+        # All genres
+        podcast.get("genreIds", [])
+        genres = podcast.get("genres", [])
+        if genres:
+            metadata["genres"] = genres
+
+        # Episode count
+        track_count = podcast.get("trackCount")
+        if track_count:
+            metadata["episode_count"] = track_count
+
+        # Feed URL
+        feed_url = podcast.get("feedUrl")
+        if feed_url:
+            metadata["feed_url"] = feed_url
+
+        # Release date
+        release_date = podcast.get("releaseDate")
+        if release_date:
+            metadata["latest_release"] = release_date
+
+        # Country
+        country = podcast.get("country")
+        if country:
+            metadata["country"] = country
+
+        # Content advisory
+        content_advisory = podcast.get("contentAdvisoryRating")
+        if content_advisory:
+            metadata["content_rating"] = content_advisory
+
+        # iTunes URL
+        collection_view_url = podcast.get("collectionViewUrl")
+        if collection_view_url:
+            metadata["itunes_url"] = collection_view_url
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=artwork_url or None,
+            description=description,
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> iTunesProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/enrichment/omdb.py
+++ b/backend/src/podex/services/enrichment/omdb.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class OMDBProvider(EnrichmentProvider):
+class OMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich movies and TV shows from OMDB (IMDB data wrapper).
 
     Args:

--- a/backend/src/podex/services/enrichment/omdb.py
+++ b/backend/src/podex/services/enrichment/omdb.py
@@ -1,0 +1,325 @@
+"""OMDB (Open Movie Database) enrichment provider.
+
+OMDB provides IMDB data including ratings, awards, and Rotten Tomatoes scores.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class OMDBProvider(EnrichmentProvider):
+    """Enrich movies and TV shows from OMDB (IMDB data wrapper).
+
+    Args:
+        api_key: OMDB API key.
+        requests_per_second: Rate limit for API calls.
+    """
+
+    BASE_URL = "http://www.omdbapi.com"
+
+    source = EnrichmentSource.OMDB
+
+    SUPPORTED_TYPES = {"movie", "tv_show", "documentary", "standup_special"}
+
+    def __init__(self, api_key: str, requests_per_second: float = 2.0) -> None:
+        super().__init__(requests_per_second)
+        self.api_key = api_key
+        self.client = httpx.Client(
+            base_url=self.BASE_URL,
+            timeout=30.0,
+        )
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if OMDB supports this media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search OMDB and enrich media item.
+
+        If media already has an IMDB ID, use it directly.
+        Otherwise, search by title.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        self.rate_limiter.wait_sync()
+
+        # If we have an IMDB ID, use it directly
+        if media.imdb_id:
+            data = self._get_by_imdb_id(media.imdb_id)
+            if data and data.get("Response") == "True":
+                return self._build_result(data, confidence=1.0)
+
+        # Otherwise search by title
+        omdb_type = self._get_omdb_type(media.type)
+        data = self._search_by_title(media.title, media.year, omdb_type)
+
+        if not data or data.get("Response") != "True":
+            logger.debug(f"No OMDB results for: {media.title}")
+            return None
+
+        # Calculate confidence based on title match
+        result_title = data.get("Title", "")
+        confidence = self._calculate_title_similarity(media.title, result_title)
+
+        # Boost confidence if year matches
+        result_year = data.get("Year", "")
+        if media.year and result_year:
+            try:
+                # OMDB year can be a range like "2011-2019"
+                year_str = result_year.split("-")[0]
+                if int(year_str) == media.year:
+                    confidence = min(confidence + 0.15, 1.0)
+            except ValueError:
+                pass
+
+        if confidence < 0.7:
+            logger.debug(
+                f"OMDB match too weak for '{media.title}': "
+                f"got '{result_title}' with confidence {confidence:.2f}"
+            )
+            return None
+
+        return self._build_result(data, confidence)
+
+    def _get_omdb_type(self, media_type: str) -> str:
+        """Convert media type to OMDB type parameter."""
+        if media_type == "tv_show":
+            return "series"
+        return "movie"
+
+    def _get_by_imdb_id(self, imdb_id: str) -> dict[str, Any] | None:
+        """Fetch OMDB data by IMDB ID.
+
+        Args:
+            imdb_id: IMDB ID (e.g., 'tt1234567').
+
+        Returns:
+            OMDB response dict or None.
+        """
+        try:
+            response = self.client.get(
+                "/",
+                params={
+                    "apikey": self.api_key,
+                    "i": imdb_id,
+                    "plot": "full",
+                },
+            )
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"OMDB error for IMDB ID {imdb_id}: {e}")
+            return None
+
+    def _search_by_title(
+        self,
+        title: str,
+        year: int | None,
+        omdb_type: str,
+    ) -> dict[str, Any] | None:
+        """Search OMDB by title.
+
+        Args:
+            title: Title to search for.
+            year: Optional release year.
+            omdb_type: 'movie' or 'series'.
+
+        Returns:
+            OMDB response dict or None.
+        """
+        try:
+            params: dict[str, str | int] = {
+                "apikey": self.api_key,
+                "t": title,
+                "type": omdb_type,
+                "plot": "full",
+            }
+            if year:
+                params["y"] = year
+
+            response = self.client.get("/", params=params)
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"OMDB search error for '{title}': {e}")
+            return None
+
+    def _build_result(
+        self, data: dict[str, Any], confidence: float
+    ) -> EnrichmentResult:
+        """Build enrichment result from OMDB data.
+
+        Args:
+            data: OMDB response data.
+            confidence: Match confidence score.
+
+        Returns:
+            EnrichmentResult with all available data.
+        """
+        # Cover URL (poster)
+        cover_url = data.get("Poster")
+        if cover_url == "N/A":
+            cover_url = None
+
+        # Description
+        description = data.get("Plot")
+        if description == "N/A":
+            description = None
+
+        # External IDs
+        external_ids: dict[str, str | int] = {}
+        imdb_id = data.get("imdbID")
+        if imdb_id:
+            external_ids["imdb_id"] = imdb_id
+
+        # Build metadata
+        metadata: dict[str, Any] = {}
+
+        # IMDB rating
+        imdb_rating = data.get("imdbRating")
+        if imdb_rating and imdb_rating != "N/A":
+            with contextlib.suppress(ValueError):
+                metadata["imdb_rating"] = float(imdb_rating)
+
+        imdb_votes = data.get("imdbVotes")
+        if imdb_votes and imdb_votes != "N/A":
+            with contextlib.suppress(ValueError):
+                metadata["imdb_votes"] = int(imdb_votes.replace(",", ""))
+
+        # Other ratings (Rotten Tomatoes, Metacritic)
+        ratings = data.get("Ratings", [])
+        for rating in ratings:
+            source = rating.get("Source", "")
+            value = rating.get("Value", "")
+
+            if source == "Rotten Tomatoes":
+                # Value is like "91%"
+                with contextlib.suppress(ValueError):
+                    metadata["rotten_tomatoes"] = int(value.rstrip("%"))
+            elif source == "Metacritic":
+                # Value is like "79/100"
+                with contextlib.suppress(ValueError):
+                    metadata["metacritic"] = int(value.split("/")[0])
+
+        # Awards
+        awards = data.get("Awards")
+        if awards and awards != "N/A":
+            metadata["awards"] = awards
+            # Parse Oscar wins/nominations
+            oscar_wins, oscar_noms = self._parse_oscar_awards(awards)
+            if oscar_wins:
+                metadata["oscar_wins"] = oscar_wins
+            if oscar_noms:
+                metadata["oscar_nominations"] = oscar_noms
+
+        # Runtime
+        runtime = data.get("Runtime")
+        if runtime and runtime != "N/A":
+            # Value is like "136 min"
+            with contextlib.suppress(ValueError, IndexError):
+                metadata["runtime_minutes"] = int(runtime.split()[0])
+
+        # Genres
+        genres = data.get("Genre")
+        if genres and genres != "N/A":
+            metadata["genres"] = [g.strip() for g in genres.split(",")]
+
+        # Director
+        director = data.get("Director")
+        if director and director != "N/A":
+            metadata["directors"] = [d.strip() for d in director.split(",")]
+
+        # Cast (actors)
+        actors = data.get("Actors")
+        if actors and actors != "N/A":
+            metadata["cast"] = [{"name": a.strip()} for a in actors.split(",")]
+
+        # Box office
+        box_office = data.get("BoxOffice")
+        if box_office and box_office != "N/A":
+            metadata["box_office"] = box_office
+
+        # Rated (e.g., PG-13, R)
+        rated = data.get("Rated")
+        if rated and rated != "N/A":
+            metadata["rated"] = rated
+
+        # Release date
+        released = data.get("Released")
+        if released and released != "N/A":
+            metadata["released"] = released
+
+        # TV-specific
+        total_seasons = data.get("totalSeasons")
+        if total_seasons and total_seasons != "N/A":
+            with contextlib.suppress(ValueError):
+                metadata["seasons"] = int(total_seasons)
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=cover_url,
+            description=description,
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def _parse_oscar_awards(self, awards_text: str) -> tuple[int, int]:
+        """Parse Oscar wins and nominations from awards text.
+
+        Args:
+            awards_text: OMDB awards string.
+
+        Returns:
+            Tuple of (wins, nominations).
+        """
+        wins = 0
+        nominations = 0
+
+        # Look for "Won X Oscars" or "Won X Oscar"
+        won_match = re.search(r"Won (\d+) Oscar", awards_text)
+        if won_match:
+            wins = int(won_match.group(1))
+
+        # Look for "Nominated for X Oscars"
+        nom_match = re.search(r"Nominated for (\d+) Oscar", awards_text)
+        if nom_match:
+            nominations = int(nom_match.group(1))
+
+        return wins, nominations
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> OMDBProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/enrichment/pubmed.py
+++ b/backend/src/podex/services/enrichment/pubmed.py
@@ -1,0 +1,450 @@
+"""PubMed/NCBI E-utilities enrichment provider."""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET  # nosec B405 - PubMed API responses
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class PubMedProvider(EnrichmentProvider):
+    """Enrich academic papers from PubMed/NCBI databases.
+
+    Uses NCBI E-utilities API (free, 3 req/sec without API key, 10/sec with key).
+
+    Args:
+        api_key: Optional NCBI API key for higher rate limits.
+        requests_per_second: Rate limit for API calls.
+    """
+
+    SEARCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+    FETCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    SUMMARY_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+
+    source = EnrichmentSource.PUBMED
+    SUPPORTED_TYPES = {"study", "article"}
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        requests_per_second: float = 2.5,
+    ) -> None:
+        super().__init__(requests_per_second)
+        self.api_key = api_key
+        self.client = httpx.Client(timeout=30.0)
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if PubMed supports this media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search PubMed and enrich media item.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        # 1. Direct lookup by PMID if available
+        if media.pubmed_id:
+            self.rate_limiter.wait_sync()
+            article = self._fetch_article(media.pubmed_id)
+            if article:
+                return self._build_result(article, confidence=1.0)
+
+        # 2. Direct lookup by DOI if available
+        if media.doi:
+            self.rate_limiter.wait_sync()
+            pmid = self._search_by_doi(media.doi)
+            if pmid:
+                self.rate_limiter.wait_sync()
+                article = self._fetch_article(pmid)
+                if article:
+                    return self._build_result(article, confidence=0.95)
+
+        # 3. Search by title + author
+        self.rate_limiter.wait_sync()
+        results = self._search(media.title, media.author)
+
+        if not results:
+            logger.debug(f"No PubMed results for: {media.title}")
+            return None
+
+        # Find best match
+        best_match = self._find_best_match(results, media)
+        if not best_match:
+            return None
+
+        pmid, confidence = best_match
+        self.rate_limiter.wait_sync()
+        article = self._fetch_article(pmid)
+        if article:
+            return self._build_result(article, confidence)
+
+        return None
+
+    def _search_by_doi(self, doi: str) -> str | None:
+        """Search PubMed by DOI.
+
+        Args:
+            doi: DOI to search for.
+
+        Returns:
+            PMID if found, None otherwise.
+        """
+        params: dict[str, str | int] = {
+            "db": "pubmed",
+            "term": f"{doi}[doi]",
+            "retmode": "json",
+            "retmax": 1,
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+
+        try:
+            response = self.client.get(self.SEARCH_URL, params=params)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            id_list: list[str] = data.get("esearchresult", {}).get("idlist", [])
+            if id_list:
+                return id_list[0]
+        except httpx.HTTPError as e:
+            logger.warning(f"PubMed DOI search error: {e}")
+
+        return None
+
+    def _search(self, title: str, author: str | None) -> list[dict[str, Any]]:
+        """Search PubMed by title and author.
+
+        Args:
+            title: Paper title.
+            author: Optional author name.
+
+        Returns:
+            List of search results with PMID and title.
+        """
+        # Build search query
+        query_parts = [f"{title}[Title]"]
+        if author:
+            # Take first author's last name
+            first_author = author.split(",")[0].split(" and ")[0].strip()
+            last_name = first_author.split()[-1] if first_author else None
+            if last_name:
+                query_parts.append(f"{last_name}[Author]")
+
+        query = " AND ".join(query_parts)
+
+        params: dict[str, str | int] = {
+            "db": "pubmed",
+            "term": query,
+            "retmode": "json",
+            "retmax": 10,
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+
+        try:
+            response = self.client.get(self.SEARCH_URL, params=params)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            id_list: list[str] = data.get("esearchresult", {}).get("idlist", [])
+
+            if not id_list:
+                return []
+
+            # Get summaries for found PMIDs
+            return self._get_summaries(id_list)
+        except httpx.HTTPError as e:
+            logger.warning(f"PubMed search error: {e}")
+            return []
+
+    def _get_summaries(self, pmids: list[str]) -> list[dict[str, Any]]:
+        """Get article summaries for given PMIDs.
+
+        Args:
+            pmids: List of PubMed IDs.
+
+        Returns:
+            List of article summaries.
+        """
+        params: dict[str, str] = {
+            "db": "pubmed",
+            "id": ",".join(pmids),
+            "retmode": "json",
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+
+        try:
+            response = self.client.get(self.SUMMARY_URL, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+            results = []
+            result_data = data.get("result", {})
+            for pmid in pmids:
+                if pmid in result_data:
+                    article = result_data[pmid]
+                    results.append(
+                        {
+                            "pmid": pmid,
+                            "title": article.get("title", ""),
+                            "authors": [
+                                a.get("name", "") for a in article.get("authors", [])
+                            ],
+                            "source": article.get("source", ""),
+                            "pubdate": article.get("pubdate", ""),
+                        }
+                    )
+            return results
+        except httpx.HTTPError as e:
+            logger.warning(f"PubMed summary error: {e}")
+            return []
+
+    def _fetch_article(self, pmid: str) -> dict[str, Any] | None:
+        """Fetch full article details by PMID.
+
+        Args:
+            pmid: PubMed ID.
+
+        Returns:
+            Article data or None.
+        """
+        params = {
+            "db": "pubmed",
+            "id": pmid,
+            "retmode": "xml",
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+
+        try:
+            response = self.client.get(self.FETCH_URL, params=params)
+            response.raise_for_status()
+            return self._parse_pubmed_xml(response.text, pmid)
+        except httpx.HTTPError as e:
+            logger.warning(f"PubMed fetch error for {pmid}: {e}")
+            return None
+
+    def _parse_pubmed_xml(self, xml_text: str, pmid: str) -> dict[str, Any] | None:
+        """Parse PubMed XML response.
+
+        Args:
+            xml_text: XML response text.
+            pmid: PubMed ID.
+
+        Returns:
+            Parsed article data or None.
+        """
+        try:
+            root = ET.fromstring(  # nosec B314 - trusted NCBI endpoint
+                xml_text
+            )
+            article = root.find(".//PubmedArticle")
+            if article is None:
+                return None
+
+            medline = article.find("MedlineCitation")
+            if medline is None:
+                return None
+
+            article_data = medline.find("Article")
+            if article_data is None:
+                return None
+
+            # Extract title
+            title_elem = article_data.find("ArticleTitle")
+            title = title_elem.text if title_elem is not None else ""
+
+            # Extract abstract
+            abstract_elem = article_data.find(".//AbstractText")
+            abstract = abstract_elem.text if abstract_elem is not None else ""
+
+            # Extract authors
+            authors: list[str] = []
+            author_list = article_data.find("AuthorList")
+            if author_list is not None:
+                for author in author_list.findall("Author"):
+                    last_name = author.find("LastName")
+                    fore_name = author.find("ForeName")
+                    if last_name is not None and fore_name is not None:
+                        authors.append(f"{fore_name.text} {last_name.text}")
+                    elif last_name is not None and last_name.text is not None:
+                        authors.append(last_name.text)
+
+            # Extract journal
+            journal_elem = article_data.find(".//Journal/Title")
+            journal = journal_elem.text if journal_elem is not None else ""
+
+            # Extract DOI
+            doi = None
+            article_id_list = article.find(".//PubmedData/ArticleIdList")
+            if article_id_list is not None:
+                for aid in article_id_list.findall("ArticleId"):
+                    if aid.get("IdType") == "doi":
+                        doi = aid.text
+                        break
+
+            # Extract publication date
+            pub_date = None
+            pub_date_elem = article_data.find(".//PubDate")
+            if pub_date_elem is not None:
+                year = pub_date_elem.find("Year")
+                month = pub_date_elem.find("Month")
+                if year is not None:
+                    pub_date = year.text
+                    if month is not None:
+                        pub_date = f"{year.text}-{month.text}"
+
+            # Extract MeSH terms
+            mesh_terms = []
+            mesh_heading_list = medline.find("MeshHeadingList")
+            if mesh_heading_list is not None:
+                for heading in mesh_heading_list.findall("MeshHeading"):
+                    descriptor = heading.find("DescriptorName")
+                    if descriptor is not None:
+                        mesh_terms.append(descriptor.text)
+
+            # Extract PMC ID if available
+            pmc_id = None
+            if article_id_list is not None:
+                for aid in article_id_list.findall("ArticleId"):
+                    if aid.get("IdType") == "pmc":
+                        pmc_id = aid.text
+                        break
+
+            return {
+                "pmid": pmid,
+                "title": title,
+                "abstract": abstract,
+                "authors": authors,
+                "journal": journal,
+                "doi": doi,
+                "pub_date": pub_date,
+                "mesh_terms": mesh_terms,
+                "pmc_id": pmc_id,
+            }
+        except ET.ParseError as e:
+            logger.warning(f"PubMed XML parse error: {e}")
+            return None
+
+    def _find_best_match(
+        self,
+        results: list[dict[str, Any]],
+        media: Media,
+    ) -> tuple[str, float] | None:
+        """Find best matching result.
+
+        Args:
+            results: Search results from PubMed.
+            media: Original media item.
+
+        Returns:
+            Tuple of (pmid, confidence) or None.
+        """
+        if not results:
+            return None
+
+        best_pmid = None
+        best_score = 0.0
+
+        for result in results[:5]:
+            result_title = result.get("title", "")
+
+            # Calculate title similarity
+            title_score = self._calculate_title_similarity(media.title, result_title)
+
+            # Check author match
+            author_boost = 0.0
+            if media.author:
+                result_authors = result.get("authors", [])
+                for author in result_authors:
+                    author_sim = self._calculate_title_similarity(media.author, author)
+                    if author_sim > 0.5:
+                        author_boost = 0.15
+                        break
+
+            total_score = title_score + author_boost
+
+            if total_score > best_score:
+                best_score = total_score
+                best_pmid = result.get("pmid")
+
+        if best_pmid and best_score >= 0.6:
+            return (best_pmid, min(best_score, 0.9))
+
+        return None
+
+    def _build_result(
+        self, article: dict[str, Any], confidence: float
+    ) -> EnrichmentResult:
+        """Build enrichment result from PubMed article.
+
+        Args:
+            article: PubMed article data.
+            confidence: Match confidence score.
+
+        Returns:
+            EnrichmentResult with all available data.
+        """
+        external_ids: dict[str, str | int] = {
+            "pubmed_id": article["pmid"],
+        }
+
+        if article.get("doi"):
+            external_ids["doi"] = article["doi"]
+        if article.get("pmc_id"):
+            external_ids["pmc_id"] = article["pmc_id"]
+
+        metadata: dict[str, Any] = {}
+
+        if article.get("authors"):
+            metadata["authors"] = article["authors"]
+        if article.get("journal"):
+            metadata["journal"] = article["journal"]
+        if article.get("pub_date"):
+            metadata["publication_date"] = article["pub_date"]
+        if article.get("mesh_terms"):
+            metadata["mesh_terms"] = article["mesh_terms"]
+
+        # Build PubMed Central URL if available
+        if article.get("pmc_id"):
+            metadata["pmc_url"] = (
+                f"https://www.ncbi.nlm.nih.gov/pmc/articles/{article['pmc_id']}"
+            )
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=None,  # PubMed doesn't provide cover images
+            description=article.get("abstract"),
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> PubMedProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/enrichment/pubmed.py
+++ b/backend/src/podex/services/enrichment/pubmed.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class PubMedProvider(EnrichmentProvider):
+class PubMedProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich academic papers from PubMed/NCBI databases.
 
     Uses NCBI E-utilities API (free, 3 req/sec without API key, 10/sec with key).

--- a/backend/src/podex/services/enrichment/pubmed.py
+++ b/backend/src/podex/services/enrichment/pubmed.py
@@ -254,9 +254,7 @@ class PubMedProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
             Parsed article data or None.
         """
         try:
-            root = ET.fromstring(  # nosec B314 - trusted NCBI endpoint
-                xml_text
-            )
+            root = ET.fromstring(xml_text)  # noqa: S314 # nosec B314
             article = root.find(".//PubmedArticle")
             if article is None:
                 return None

--- a/backend/src/podex/services/enrichment/semantic_scholar.py
+++ b/backend/src/podex/services/enrichment/semantic_scholar.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class SemanticScholarProvider(EnrichmentProvider):
+class SemanticScholarProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich academic papers from Semantic Scholar.
 
     Uses Semantic Scholar Academic Graph API (free, 100 req/sec).

--- a/backend/src/podex/services/enrichment/semantic_scholar.py
+++ b/backend/src/podex/services/enrichment/semantic_scholar.py
@@ -1,0 +1,298 @@
+"""Semantic Scholar API enrichment provider."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class SemanticScholarProvider(EnrichmentProvider):
+    """Enrich academic papers from Semantic Scholar.
+
+    Uses Semantic Scholar Academic Graph API (free, 100 req/sec).
+
+    Args:
+        api_key: Optional API key for higher rate limits.
+        requests_per_second: Rate limit for API calls.
+    """
+
+    BASE_URL = "https://api.semanticscholar.org/graph/v1"
+
+    source = EnrichmentSource.SEMANTIC_SCHOLAR
+    SUPPORTED_TYPES = {"study", "article"}
+
+    # Fields to request from the API
+    PAPER_FIELDS = ",".join(
+        [
+            "paperId",
+            "externalIds",
+            "title",
+            "abstract",
+            "venue",
+            "year",
+            "authors",
+            "citationCount",
+            "influentialCitationCount",
+            "fieldsOfStudy",
+            "publicationDate",
+            "openAccessPdf",
+        ]
+    )
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        requests_per_second: float = 10.0,
+    ) -> None:
+        super().__init__(requests_per_second)
+        headers = {}
+        if api_key:
+            headers["x-api-key"] = api_key
+        self.client = httpx.Client(
+            base_url=self.BASE_URL,
+            headers=headers,
+            timeout=30.0,
+        )
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if Semantic Scholar supports this media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search Semantic Scholar and enrich media item.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        # 1. Direct lookup by DOI
+        if media.doi:
+            self.rate_limiter.wait_sync()
+            paper = self._get_paper_by_id(f"DOI:{media.doi}")
+            if paper:
+                return self._build_result(paper, confidence=1.0)
+
+        # 2. Direct lookup by PMID
+        if media.pubmed_id:
+            self.rate_limiter.wait_sync()
+            paper = self._get_paper_by_id(f"PMID:{media.pubmed_id}")
+            if paper:
+                return self._build_result(paper, confidence=0.95)
+
+        # 3. Search by title
+        self.rate_limiter.wait_sync()
+        results = self._search(media.title)
+
+        if not results:
+            logger.debug(f"No Semantic Scholar results for: {media.title}")
+            return None
+
+        # Find best match
+        best_match = self._find_best_match(results, media)
+        if not best_match:
+            return None
+
+        paper, confidence = best_match
+        return self._build_result(paper, confidence)
+
+    def _get_paper_by_id(self, paper_id: str) -> dict[str, Any] | None:
+        """Fetch paper by ID (DOI, PMID, S2 ID, etc.).
+
+        Args:
+            paper_id: Paper identifier (e.g., "DOI:10.1234/...", "PMID:12345").
+
+        Returns:
+            Paper data or None.
+        """
+        try:
+            response = self.client.get(
+                f"/paper/{paper_id}",
+                params={"fields": self.PAPER_FIELDS},
+            )
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"Semantic Scholar lookup error for {paper_id}: {e}")
+            return None
+
+    def _search(self, title: str) -> list[dict[str, Any]]:
+        """Search Semantic Scholar by title.
+
+        Args:
+            title: Paper title.
+
+        Returns:
+            List of paper results.
+        """
+        try:
+            response = self.client.get(
+                "/paper/search",
+                params={
+                    "query": title,
+                    "fields": self.PAPER_FIELDS,
+                    "limit": 10,
+                },
+            )
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            result: list[dict[str, Any]] = data.get("data", [])
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"Semantic Scholar search error: {e}")
+            return []
+
+    def _find_best_match(
+        self,
+        results: list[dict[str, Any]],
+        media: Media,
+    ) -> tuple[dict[str, Any], float] | None:
+        """Find best matching result.
+
+        Args:
+            results: Search results from Semantic Scholar.
+            media: Original media item.
+
+        Returns:
+            Tuple of (paper, confidence) or None.
+        """
+        if not results:
+            return None
+
+        best_paper = None
+        best_score = 0.0
+
+        for paper in results[:5]:
+            result_title = paper.get("title", "")
+
+            # Calculate title similarity
+            title_score = self._calculate_title_similarity(media.title, result_title)
+
+            # Check author match
+            author_boost = 0.0
+            if media.author:
+                paper_authors = paper.get("authors", [])
+                for author in paper_authors:
+                    author_name = author.get("name", "")
+                    author_sim = self._calculate_title_similarity(
+                        media.author,
+                        author_name,
+                    )
+                    if author_sim > 0.5:
+                        author_boost = 0.15
+                        break
+
+            # Check year match
+            year_boost = 0.0
+            if media.year and paper.get("year") and media.year == paper["year"]:
+                year_boost = 0.05
+
+            total_score = title_score + author_boost + year_boost
+
+            if total_score > best_score:
+                best_score = total_score
+                best_paper = paper
+
+        if best_paper and best_score >= 0.6:
+            return (best_paper, min(best_score, 0.9))
+
+        return None
+
+    def _build_result(
+        self, paper: dict[str, Any], confidence: float
+    ) -> EnrichmentResult:
+        """Build enrichment result from Semantic Scholar paper.
+
+        Args:
+            paper: Semantic Scholar paper data.
+            confidence: Match confidence score.
+
+        Returns:
+            EnrichmentResult with all available data.
+        """
+        external_ids: dict[str, str | int] = {
+            "semantic_scholar_id": paper["paperId"],
+        }
+
+        # Extract external IDs
+        paper_external_ids = paper.get("externalIds", {})
+        if paper_external_ids:
+            if paper_external_ids.get("DOI"):
+                external_ids["doi"] = paper_external_ids["DOI"]
+            if paper_external_ids.get("PubMed"):
+                external_ids["pubmed_id"] = paper_external_ids["PubMed"]
+            if paper_external_ids.get("ArXiv"):
+                external_ids["arxiv_id"] = paper_external_ids["ArXiv"]
+
+        metadata: dict[str, Any] = {}
+
+        # Authors
+        authors = paper.get("authors", [])
+        if authors:
+            metadata["authors"] = [a.get("name", "") for a in authors]
+
+        # Venue (journal/conference)
+        if paper.get("venue"):
+            metadata["journal"] = paper["venue"]
+
+        # Year
+        if paper.get("year"):
+            metadata["year"] = paper["year"]
+
+        # Publication date
+        if paper.get("publicationDate"):
+            metadata["publication_date"] = paper["publicationDate"]
+
+        # Citation counts
+        if paper.get("citationCount") is not None:
+            metadata["citation_count"] = paper["citationCount"]
+        if paper.get("influentialCitationCount") is not None:
+            metadata["influential_citation_count"] = paper["influentialCitationCount"]
+
+        # Fields of study
+        if paper.get("fieldsOfStudy"):
+            metadata["fields_of_study"] = paper["fieldsOfStudy"]
+
+        # Open access PDF
+        open_access = paper.get("openAccessPdf")
+        if open_access and open_access.get("url"):
+            metadata["open_access_pdf_url"] = open_access["url"]
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=None,  # Semantic Scholar doesn't provide cover images
+            description=paper.get("abstract"),
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> SemanticScholarProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/enrichment/tmdb.py
+++ b/backend/src/podex/services/enrichment/tmdb.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class TMDBProvider(EnrichmentProvider):
+class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich movies and TV shows from The Movie Database.
 
     Args:

--- a/backend/src/podex/services/enrichment/tmdb.py
+++ b/backend/src/podex/services/enrichment/tmdb.py
@@ -1,0 +1,394 @@
+"""TMDB (The Movie Database) enrichment provider."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+from podex.services.enrichment.search_utils import (
+    calculate_similarity,
+    clean_for_api_search,
+    generate_search_variations,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class TMDBProvider(EnrichmentProvider):
+    """Enrich movies and TV shows from The Movie Database.
+
+    Args:
+        api_key: TMDB API key.
+        requests_per_second: Rate limit for API calls.
+    """
+
+    BASE_URL = "https://api.themoviedb.org/3"
+    IMAGE_BASE = "https://image.tmdb.org/t/p/w500"
+
+    source = EnrichmentSource.TMDB
+
+    SUPPORTED_TYPES = {"movie", "tv_show", "documentary", "standup_special"}
+
+    def __init__(self, api_key: str, requests_per_second: float = 3.0) -> None:
+        super().__init__(requests_per_second)
+        self.api_key = api_key
+        self.client = httpx.Client(
+            base_url=self.BASE_URL,
+            params={"api_key": api_key},
+            timeout=30.0,
+        )
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if TMDB supports this media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search TMDB and enrich media item.
+
+        Uses flexible search strategies to improve match rates.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        # Determine primary search type (TV shows try TV first, others try movie first)
+        search_types = ["tv", "movie"] if media.type == "tv_show" else ["movie", "tv"]
+
+        # Generate search variations
+        variations = generate_search_variations(media.title, media.author)
+
+        # Try each search type
+        for search_type in search_types:
+            # Try each title variation
+            for variation in variations:
+                self.rate_limiter.wait_sync()
+
+                # Clean the query for API
+                query = clean_for_api_search(variation)
+                if not query:
+                    continue
+
+                # First try with year, then without
+                year_options = [media.year, None] if media.year else [None]
+
+                for year in year_options:
+                    search_results = self._search(query, search_type, year)
+                    if not search_results:
+                        continue
+
+                    # Find best match
+                    best_match = self._find_best_match(
+                        search_results,
+                        media,
+                        original_query=variation,
+                    )
+                    if best_match:
+                        tmdb_id, confidence = best_match
+
+                        # Fetch full details
+                        self.rate_limiter.wait_sync()
+                        details = self._get_details(tmdb_id, search_type)
+                        if details:
+                            logger.debug(
+                                f"TMDB match for '{media.title}' using "
+                                f"query='{query}' type={search_type}"
+                            )
+                            return self._build_result(details, search_type, confidence)
+
+        logger.debug(f"No TMDB results for: {media.title}")
+        return None
+
+    def _search(
+        self,
+        title: str,
+        search_type: str,
+        year: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search TMDB for a title.
+
+        Args:
+            title: Title to search for.
+            search_type: 'movie' or 'tv'.
+            year: Optional release year.
+
+        Returns:
+            List of search results.
+        """
+        try:
+            params: dict[str, str | int] = {"query": title}
+            if year:
+                if search_type == "movie":
+                    params["year"] = year
+                else:
+                    params["first_air_date_year"] = year
+
+            response = self.client.get(f"/search/{search_type}", params=params)
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            result: list[dict[str, Any]] = data.get("results", [])
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"TMDB search error for '{title}': {e}")
+            return []
+
+    def _find_best_match(
+        self,
+        results: list[dict[str, Any]],
+        media: Media,
+        original_query: str | None = None,
+    ) -> tuple[int, float] | None:
+        """Find best matching result.
+
+        Args:
+            results: Search results from TMDB.
+            media: Original media item.
+            original_query: The search query used (for matching).
+
+        Returns:
+            Tuple of (tmdb_id, confidence) or None.
+        """
+        if not results:
+            return None
+
+        best_id = None
+        best_score = 0.0
+
+        # Use original query if provided, otherwise use media title
+        search_title = original_query or media.title
+
+        for result in results[:7]:  # Check top 7 results
+            result_title = result.get("title") or result.get("name", "")
+
+            # Calculate similarity against both the search query and original title
+            query_score = calculate_similarity(search_title, result_title)
+            title_score = calculate_similarity(media.title, result_title)
+
+            # Use the better score
+            base_score = max(query_score, title_score)
+
+            # Also check against original_name (for international titles)
+            original_name = result.get("original_title") or result.get("original_name")
+            if original_name and original_name != result_title:
+                original_score = calculate_similarity(media.title, original_name)
+                base_score = max(base_score, original_score)
+
+            # Boost score if year matches
+            result_year = None
+            release_date = result.get("release_date") or result.get("first_air_date")
+            if release_date:
+                with contextlib.suppress(ValueError, IndexError):
+                    result_year = int(release_date[:4])
+
+            year_boost = 0.0
+            if media.year and result_year:
+                if media.year == result_year:
+                    year_boost = 0.15
+                elif abs(media.year - result_year) <= 1:
+                    year_boost = 0.10
+                elif abs(media.year - result_year) <= 3:
+                    year_boost = 0.05
+
+            # Boost for popularity (helps with disambiguation)
+            popularity_boost = 0.0
+            popularity = result.get("popularity", 0)
+            if popularity > 50:
+                popularity_boost = 0.05
+            elif popularity > 20:
+                popularity_boost = 0.02
+
+            total_score = base_score + year_boost + popularity_boost
+
+            if total_score > best_score:
+                best_score = total_score
+                best_id = result.get("id")
+
+        # Lower threshold since we're using flexible search
+        if best_id and best_score >= 0.55:
+            return (best_id, min(best_score, 1.0))
+
+        return None
+
+    def _get_details(self, tmdb_id: int, media_type: str) -> dict[str, Any] | None:
+        """Fetch full details for a TMDB item.
+
+        Args:
+            tmdb_id: TMDB ID.
+            media_type: 'movie' or 'tv'.
+
+        Returns:
+            Details dict or None.
+        """
+        try:
+            params = {"append_to_response": "credits,external_ids"}
+            response = self.client.get(f"/{media_type}/{tmdb_id}", params=params)
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"TMDB details error for ID {tmdb_id}: {e}")
+            return None
+
+    def _build_result(
+        self,
+        details: dict[str, Any],
+        media_type: str,
+        confidence: float,
+    ) -> EnrichmentResult:
+        """Build enrichment result from TMDB details.
+
+        Args:
+            details: TMDB details response.
+            media_type: 'movie' or 'tv'.
+            confidence: Match confidence score.
+
+        Returns:
+            EnrichmentResult with all available data.
+        """
+        # Build cover URL
+        cover_url = None
+        poster_path = details.get("poster_path")
+        if poster_path:
+            cover_url = f"{self.IMAGE_BASE}{poster_path}"
+
+        # Get description
+        description = details.get("overview")
+
+        # External IDs
+        tmdb_id = details.get("id")
+        external_ids: dict[str, str | int] = {}
+        if tmdb_id is not None:
+            external_ids["tmdb_id"] = tmdb_id
+        ext_ids = details.get("external_ids", {})
+        if ext_ids.get("imdb_id"):
+            external_ids["imdb_id"] = ext_ids["imdb_id"]
+
+        # Build metadata
+        metadata: dict[str, Any] = {}
+
+        # Ratings
+        vote_average = details.get("vote_average")
+        if vote_average:
+            metadata["tmdb_rating"] = round(vote_average, 1)
+            metadata["tmdb_vote_count"] = details.get("vote_count", 0)
+
+        # Runtime
+        if media_type == "movie":
+            runtime = details.get("runtime")
+            if runtime:
+                metadata["runtime_minutes"] = runtime
+        else:
+            # TV show episode runtime
+            episode_runtime = details.get("episode_run_time", [])
+            if episode_runtime:
+                metadata["episode_runtime_minutes"] = episode_runtime[0]
+            # Seasons info
+            metadata["seasons"] = details.get("number_of_seasons")
+            metadata["episodes"] = details.get("number_of_episodes")
+
+        # Genres
+        genres = details.get("genres", [])
+        if genres:
+            metadata["genres"] = [g["name"] for g in genres]
+
+        # Cast (top 5)
+        credits = details.get("credits", {})
+        cast = credits.get("cast", [])
+        if cast:
+            metadata["cast"] = [
+                {"name": c["name"], "character": c.get("character")} for c in cast[:5]
+            ]
+
+        # Director(s) for movies
+        if media_type == "movie":
+            crew = credits.get("crew", [])
+            directors = [c["name"] for c in crew if c.get("job") == "Director"]
+            if directors:
+                metadata["directors"] = directors
+
+        # Release/air date
+        if media_type == "movie":
+            release_date = details.get("release_date")
+            if release_date:
+                metadata["release_date"] = release_date
+        else:
+            first_air_date = details.get("first_air_date")
+            if first_air_date:
+                metadata["first_air_date"] = first_air_date
+            last_air_date = details.get("last_air_date")
+            if last_air_date:
+                metadata["last_air_date"] = last_air_date
+            metadata["status"] = details.get("status")
+
+        # Production companies
+        companies = details.get("production_companies", [])
+        if companies:
+            metadata["production_companies"] = [c["name"] for c in companies[:3]]
+
+        # Tagline (movies mostly)
+        tagline = details.get("tagline")
+        if tagline:
+            metadata["tagline"] = tagline
+
+        # Budget and revenue (movies)
+        if media_type == "movie":
+            budget = details.get("budget")
+            if budget and budget > 0:
+                metadata["budget"] = budget
+            revenue = details.get("revenue")
+            if revenue and revenue > 0:
+                metadata["revenue"] = revenue
+
+        # Production countries
+        countries = details.get("production_countries", [])
+        if countries:
+            metadata["production_countries"] = [
+                c.get("name", c.get("iso_3166_1", "")) for c in countries
+            ]
+
+        # Spoken languages
+        languages = details.get("spoken_languages", [])
+        if languages:
+            metadata["spoken_languages"] = [
+                lang.get("english_name", lang.get("name", "")) for lang in languages
+            ]
+
+        # Networks (TV shows)
+        if media_type == "tv":
+            networks = details.get("networks", [])
+            if networks:
+                metadata["networks"] = [n.get("name", "") for n in networks]
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=cover_url,
+            description=description,
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> TMDBProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/enrichment/tmdb_person.py
+++ b/backend/src/podex/services/enrichment/tmdb_person.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class TMDBPersonProvider(EnrichmentProvider):
+class TMDBPersonProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich people from TMDB Person API.
 
     Also used as fallback for standup_special when the title

--- a/backend/src/podex/services/enrichment/tmdb_person.py
+++ b/backend/src/podex/services/enrichment/tmdb_person.py
@@ -1,0 +1,320 @@
+"""TMDB Person API enrichment provider for people."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+)
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+class TMDBPersonProvider(EnrichmentProvider):
+    """Enrich people from TMDB Person API.
+
+    Also used as fallback for standup_special when the title
+    appears to be a person's name rather than a show title.
+
+    Args:
+        api_key: TMDB API key.
+        requests_per_second: Rate limit for API calls.
+    """
+
+    BASE_URL = "https://api.themoviedb.org/3"
+    IMAGE_BASE = "https://image.tmdb.org/t/p/w500"
+
+    source = EnrichmentSource.TMDB_PERSON
+
+    SUPPORTED_TYPES = {"person", "standup_special"}
+
+    def __init__(self, api_key: str, requests_per_second: float = 3.0) -> None:
+        super().__init__(requests_per_second)
+        self.api_key = api_key
+        self.client = httpx.Client(
+            base_url=self.BASE_URL,
+            params={"api_key": api_key},
+            timeout=30.0,
+        )
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Check if TMDB Person supports this media type."""
+        return media_type in self.SUPPORTED_TYPES
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Search TMDB for a person and enrich.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            EnrichmentResult if found, None otherwise.
+        """
+        if not self.supports_media_type(media.type):
+            return None
+
+        self.rate_limiter.wait_sync()
+
+        # For standup_special, check if title looks like a person name
+        # (no colons, parentheses, or typical show title patterns)
+        if media.type == "standup_special" and not self._looks_like_person_name(
+            media.title
+        ):
+            return None
+
+        # Search for person
+        results = self._search_person(media.title)
+
+        if not results:
+            logger.debug(f"No TMDB person results for: {media.title}")
+            return None
+
+        # Find best match
+        best_match = self._find_best_match(results, media)
+        if not best_match:
+            return None
+
+        person_id, confidence = best_match
+
+        # Fetch full details
+        self.rate_limiter.wait_sync()
+        details = self._get_person_details(person_id)
+        if not details:
+            return None
+
+        return self._build_result(details, confidence)
+
+    def _looks_like_person_name(self, title: str) -> bool:
+        """Check if a title looks like a person's name.
+
+        Args:
+            title: The title to check.
+
+        Returns:
+            True if it looks like a person name.
+        """
+        # Titles with these patterns are likely show names, not people
+        show_indicators = [":", "-", "(", ")", "Live", "Special", "Tour", "Show"]
+        title_lower = title.lower()
+
+        for indicator in show_indicators:
+            if indicator.lower() in title_lower:
+                return False
+
+        # Check if it's 2-4 words (typical name length)
+        words = title.split()
+        return not (len(words) < 1 or len(words) > 4)
+
+    def _search_person(self, query: str) -> list[dict[str, Any]]:
+        """Search TMDB for a person.
+
+        Args:
+            query: Search query (person name).
+
+        Returns:
+            List of person results.
+        """
+        try:
+            response = self.client.get(
+                "/search/person",
+                params={"query": query},
+            )
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            result: list[dict[str, Any]] = data.get("results", [])
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"TMDB person search error for '{query}': {e}")
+            return []
+
+    def _find_best_match(
+        self,
+        results: list[dict[str, Any]],
+        media: Media,
+    ) -> tuple[int, float] | None:
+        """Find best matching person result.
+
+        Args:
+            results: Search results from TMDB.
+            media: Original media item.
+
+        Returns:
+            Tuple of (person_id, confidence) or None.
+        """
+        if not results:
+            return None
+
+        best_id = None
+        best_score = 0.0
+
+        for person in results[:5]:  # Check top 5 results
+            person_name = person.get("name", "")
+
+            # Calculate name similarity
+            name_score = self._calculate_title_similarity(
+                media.title,
+                person_name,
+            )
+
+            # Boost if they're known for relevant work
+            known_for = person.get("known_for", [])
+            relevance_boost = 0.0
+
+            # For standup specials, boost if known for comedy
+            if media.type == "standup_special":
+                for work in known_for:
+                    genres = work.get("genre_ids", [])
+                    # 35 is Comedy genre in TMDB
+                    if 35 in genres:
+                        relevance_boost = 0.1
+                        break
+
+            # Boost popular people slightly
+            popularity = person.get("popularity", 0)
+            if popularity > 10:
+                relevance_boost += 0.05
+
+            total_score = name_score + relevance_boost
+
+            if total_score > best_score:
+                best_score = total_score
+                best_id = person.get("id")
+
+        if best_id and best_score >= 0.7:
+            return (best_id, min(best_score, 1.0))
+
+        return None
+
+    def _get_person_details(self, person_id: int) -> dict[str, Any] | None:
+        """Fetch full person details from TMDB.
+
+        Args:
+            person_id: TMDB person ID.
+
+        Returns:
+            Person details dict or None.
+        """
+        try:
+            params = {"append_to_response": "combined_credits,external_ids"}
+            response = self.client.get(f"/person/{person_id}", params=params)
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except httpx.HTTPError as e:
+            logger.warning(f"TMDB person details error for ID {person_id}: {e}")
+            return None
+
+    def _build_result(
+        self,
+        details: dict[str, Any],
+        confidence: float,
+    ) -> EnrichmentResult:
+        """Build enrichment result from TMDB person details.
+
+        Args:
+            details: TMDB person details.
+            confidence: Match confidence score.
+
+        Returns:
+            EnrichmentResult with all available data.
+        """
+        # Profile image
+        cover_url = None
+        profile_path = details.get("profile_path")
+        if profile_path:
+            cover_url = f"{self.IMAGE_BASE}{profile_path}"
+
+        # Biography
+        description = details.get("biography")
+        if description and len(description) > 500:
+            # Truncate long bios
+            description = description[:500] + "..."
+
+        # External IDs
+        tmdb_id = details.get("id")
+        external_ids: dict[str, str | int] = {}
+        if tmdb_id is not None:
+            external_ids["tmdb_person_id"] = tmdb_id
+        ext_ids = details.get("external_ids", {})
+        if ext_ids.get("imdb_id"):
+            external_ids["imdb_id"] = ext_ids["imdb_id"]
+        if ext_ids.get("twitter_id"):
+            external_ids["twitter_id"] = ext_ids["twitter_id"]
+        if ext_ids.get("instagram_id"):
+            external_ids["instagram_id"] = ext_ids["instagram_id"]
+
+        # Build metadata
+        metadata: dict[str, Any] = {}
+
+        # Basic info
+        if details.get("birthday"):
+            metadata["birthday"] = details["birthday"]
+        if details.get("deathday"):
+            metadata["deathday"] = details["deathday"]
+        if details.get("place_of_birth"):
+            metadata["place_of_birth"] = details["place_of_birth"]
+
+        # Known for department
+        known_for = details.get("known_for_department")
+        if known_for:
+            metadata["known_for"] = known_for
+
+        # Popularity
+        popularity = details.get("popularity")
+        if popularity:
+            metadata["tmdb_popularity"] = round(popularity, 1)
+
+        # Notable works (top 5 by popularity)
+        credits = details.get("combined_credits", {})
+        cast_credits = credits.get("cast", [])
+        if cast_credits:
+            # Sort by popularity and take top 5
+            sorted_credits = sorted(
+                cast_credits,
+                key=lambda x: x.get("popularity", 0),
+                reverse=True,
+            )[:5]
+            metadata["notable_works"] = [
+                {
+                    "title": c.get("title") or c.get("name"),
+                    "year": (c.get("release_date") or c.get("first_air_date") or "")[
+                        :4
+                    ],
+                    "type": "movie" if c.get("title") else "tv",
+                }
+                for c in sorted_credits
+                if c.get("title") or c.get("name")
+            ]
+
+        # Also known as (aliases)
+        also_known_as = details.get("also_known_as", [])
+        if also_known_as:
+            metadata["also_known_as"] = also_known_as[:5]
+
+        return EnrichmentResult(
+            source=self.source,
+            cover_url=cover_url,
+            description=description,
+            external_ids=external_ids,
+            metadata=metadata,
+            confidence=confidence,
+        )
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()
+
+    def __enter__(self) -> TMDBPersonProvider:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/media_enrichment.py
+++ b/backend/src/podex/services/media_enrichment.py
@@ -1,0 +1,319 @@
+"""Media enrichment service.
+
+Orchestrates enrichment of media items from multiple external sources
+based on media type (books, movies, TV shows, etc.).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from podex.services.academic_enrichment import AcademicEnricher
+from podex.services.enrichment.base import (
+    EnrichmentProvider,
+    EnrichmentResult,
+    EnrichmentSource,
+    VerifiedEnrichmentResult,
+)
+from podex.services.enrichment.google_books import GoogleBooksProvider
+from podex.services.enrichment.itunes import iTunesProvider
+from podex.services.enrichment.omdb import OMDBProvider
+from podex.services.enrichment.open_library import OpenLibraryProvider
+from podex.services.enrichment.tmdb import TMDBProvider
+from podex.services.enrichment.tmdb_person import TMDBPersonProvider
+from podex.services.enrichment.wikipedia import WikipediaProvider
+
+if TYPE_CHECKING:
+    from podex.models.media import Media
+
+logger = logging.getLogger(__name__)
+
+
+# Provider priority by media type (Wikipedia is a universal fallback, added separately)
+PROVIDER_PRIORITY: dict[str, list[EnrichmentSource]] = {
+    "book": [EnrichmentSource.GOOGLE_BOOKS, EnrichmentSource.OPEN_LIBRARY],
+    "movie": [EnrichmentSource.TMDB, EnrichmentSource.OMDB],
+    "tv_show": [EnrichmentSource.TMDB, EnrichmentSource.OMDB],
+    "documentary": [EnrichmentSource.TMDB, EnrichmentSource.OMDB],
+    # standup_special: TMDB first (show titles), then TMDB_PERSON (comedian names)
+    "standup_special": [
+        EnrichmentSource.TMDB,
+        EnrichmentSource.OMDB,
+        EnrichmentSource.TMDB_PERSON,
+    ],
+    "podcast": [EnrichmentSource.ITUNES],
+    "person": [EnrichmentSource.TMDB_PERSON],
+    # Academic types use multi-source verification via AcademicEnricher
+    "study": [
+        EnrichmentSource.PUBMED,
+        EnrichmentSource.SEMANTIC_SCHOLAR,
+        EnrichmentSource.CROSSREF,
+    ],
+    "article": [
+        EnrichmentSource.SEMANTIC_SCHOLAR,
+        EnrichmentSource.CROSSREF,
+    ],
+    "place": [],  # Wikipedia only
+}
+
+# Types that should use Wikipedia as a fallback
+WIKIPEDIA_FALLBACK_TYPES = {
+    "book",
+    "movie",
+    "tv_show",
+    "documentary",
+    "standup_special",
+    "podcast",
+    "person",
+    "study",
+    "article",
+    "place",
+}
+
+
+class MediaEnricher:
+    """Enrich media items with external data from multiple sources.
+
+    Args:
+        tmdb_api_key: TMDB API key (required for movies/TV).
+        omdb_api_key: OMDB API key (optional, for IMDB data).
+        google_books_api_key: Google Books API key (optional).
+        ncbi_api_key: NCBI API key for PubMed (optional, higher rate limits).
+        crossref_mailto: Email for CrossRef polite pool (optional).
+    """
+
+    def __init__(
+        self,
+        tmdb_api_key: str | None = None,
+        omdb_api_key: str | None = None,
+        google_books_api_key: str | None = None,
+        ncbi_api_key: str | None = None,
+        crossref_mailto: str | None = None,
+    ) -> None:
+        self.providers: dict[EnrichmentSource, EnrichmentProvider] = {}
+
+        # Initialize providers based on available API keys
+        if tmdb_api_key:
+            self.providers[EnrichmentSource.TMDB] = TMDBProvider(tmdb_api_key)
+            logger.info("TMDB provider initialized")
+            self.providers[EnrichmentSource.TMDB_PERSON] = TMDBPersonProvider(
+                tmdb_api_key
+            )
+            logger.info("TMDB Person provider initialized")
+
+        if omdb_api_key:
+            self.providers[EnrichmentSource.OMDB] = OMDBProvider(omdb_api_key)
+            logger.info("OMDB provider initialized")
+
+        # Google Books works without API key, but rate limited
+        self.providers[EnrichmentSource.GOOGLE_BOOKS] = GoogleBooksProvider(
+            api_key=google_books_api_key,
+        )
+        logger.info("Google Books provider initialized")
+
+        # OpenLibrary is free and doesn't need an API key
+        self.providers[EnrichmentSource.OPEN_LIBRARY] = OpenLibraryProvider()
+        logger.info("OpenLibrary provider initialized")
+
+        # iTunes is free and doesn't need an API key (for podcasts)
+        self.providers[EnrichmentSource.ITUNES] = iTunesProvider()
+        logger.info("iTunes provider initialized")
+
+        # Academic enricher for studies and articles (multi-source verification)
+        self.academic_enricher = AcademicEnricher(
+            ncbi_api_key=ncbi_api_key,
+            crossref_mailto=crossref_mailto,
+        )
+        logger.info("Academic enricher initialized")
+
+        # Wikipedia as universal fallback (works for any media type)
+        self.providers[EnrichmentSource.WIKIPEDIA] = WikipediaProvider()
+        logger.info("Wikipedia provider initialized")
+
+    def enrich(
+        self,
+        media: Media,
+        min_confidence: float = 0.7,
+        use_wikipedia_fallback: bool = True,
+    ) -> EnrichmentResult | None:
+        """Enrich a media item based on its type.
+
+        For academic types (study, article), uses multi-source verification.
+        For other types, tries providers in priority order until one returns
+        a confident match. Falls back to Wikipedia if primary providers fail.
+
+        Args:
+            media: The media item to enrich.
+            min_confidence: Minimum confidence threshold (0.0-1.0).
+            use_wikipedia_fallback: Whether to try Wikipedia if others fail.
+
+        Returns:
+            EnrichmentResult if successful, None otherwise.
+        """
+        result: EnrichmentResult | None = None
+
+        # Use academic enricher for studies and articles
+        if media.type in ("study", "article"):
+            try:
+                result = self.academic_enricher.enrich_with_verification(media)
+                if result and result.confidence >= min_confidence:
+                    logger.info(
+                        f"Enriched '{media.title}' via academic enricher "
+                        f"(confidence: {result.confidence:.2f}, "
+                        f"verified_by: {[s.value for s in result.verified_by]})"
+                    )
+                    return result
+                elif result:
+                    logger.debug(
+                        f"Low confidence academic match: {result.confidence:.2f}"
+                    )
+                    result = None  # Reset for Wikipedia fallback
+            except Exception:
+                logger.exception("Error in academic enrichment")
+
+        # Try primary providers for this media type
+        if result is None:
+            provider_sources = PROVIDER_PRIORITY.get(media.type, [])
+
+            for source in provider_sources:
+                provider = self.providers.get(source)
+                if not provider:
+                    logger.debug(f"Provider {source} not configured, skipping")
+                    continue
+
+                try:
+                    result = provider.search_and_enrich(media)
+                    if result and result.confidence >= min_confidence:
+                        logger.info(
+                            f"Enriched '{media.title}' from {source} "
+                            f"(confidence: {result.confidence:.2f})"
+                        )
+                        return result
+                    elif result:
+                        conf = result.confidence
+                        logger.debug(f"Low confidence from {source}: {conf:.2f}")
+                        result = None  # Reset for next provider
+                except Exception:
+                    logger.exception(f"Error enriching from {source}")
+                    continue
+
+        # Wikipedia fallback for any media type
+        if (
+            result is None
+            and use_wikipedia_fallback
+            and media.type in WIKIPEDIA_FALLBACK_TYPES
+        ):
+            wikipedia = self.providers.get(EnrichmentSource.WIKIPEDIA)
+            if wikipedia:
+                try:
+                    result = wikipedia.search_and_enrich(media)
+                    if result and result.confidence >= min_confidence:
+                        logger.info(
+                            f"Enriched '{media.title}' from Wikipedia fallback "
+                            f"(confidence: {result.confidence:.2f})"
+                        )
+                        return result
+                    elif result:
+                        logger.debug(
+                            f"Low confidence Wikipedia match: {result.confidence:.2f}"
+                        )
+                except Exception:
+                    logger.exception("Error in Wikipedia fallback")
+
+        logger.debug(f"No enrichment found for: {media.title}")
+        return None
+
+    def apply_enrichment(self, media: Media, result: EnrichmentResult) -> None:
+        """Apply enrichment result to a media item.
+
+        Updates the media object in place with enriched data.
+
+        Args:
+            media: The media item to update.
+            result: The enrichment result to apply.
+        """
+        # Update cover if we don't have one or the new one is from a better source
+        if result.cover_url and not media.cover_url:
+            media.cover_url = result.cover_url
+
+        # Update description if we don't have one
+        if result.description and not media.description:
+            media.description = result.description
+
+        # Update external IDs
+        for key, value in result.external_ids.items():
+            if key == "imdb_id" and not media.imdb_id:
+                media.imdb_id = str(value)
+            elif key == "tmdb_id" and not media.tmdb_id:
+                media.tmdb_id = int(value) if isinstance(value, (int, str)) else None
+            elif key == "google_books_id" and not media.google_books_id:
+                media.google_books_id = str(value)
+            elif key == "open_library_id" and not media.open_library_id:
+                media.open_library_id = str(value)
+            elif key == "wikipedia_id" and not media.wikipedia_id:
+                media.wikipedia_id = str(value)
+            elif key == "doi" and not media.doi:
+                media.doi = str(value)
+            elif key == "pubmed_id" and not media.pubmed_id:
+                media.pubmed_id = str(value)
+            elif key == "semantic_scholar_id" and not media.semantic_scholar_id:
+                media.semantic_scholar_id = str(value)
+
+        # Merge metadata
+        if result.metadata:
+            if media.metadata_json:
+                # Merge, preferring new data for missing keys
+                merged = {**result.metadata, **media.metadata_json}
+                media.metadata_json = merged
+            else:
+                media.metadata_json = result.metadata
+
+        # Update enrichment tracking
+        media.enriched_at = datetime.now(UTC)
+        media.enrichment_source = result.source.value
+        media.enrichment_confidence = result.confidence
+
+        # Handle VerifiedEnrichmentResult fields
+        if isinstance(result, VerifiedEnrichmentResult):
+            media.verification_sources = [s.value for s in result.verified_by]
+            media.doi_verified = result.doi_verified
+
+    def enrich_and_apply(
+        self,
+        media: Media,
+        min_confidence: float = 0.7,
+    ) -> bool:
+        """Enrich a media item and apply the result.
+
+        Convenience method that combines enrich() and apply_enrichment().
+
+        Args:
+            media: The media item to enrich.
+            min_confidence: Minimum confidence threshold.
+
+        Returns:
+            True if enrichment was successful and applied, False otherwise.
+        """
+        result = self.enrich(media, min_confidence)
+        if result:
+            self.apply_enrichment(media, result)
+            return True
+        return False
+
+    def get_available_providers(self) -> list[str]:
+        """Get list of configured provider names."""
+        return [source.value for source in self.providers]
+
+    def close(self) -> None:
+        """Close all provider HTTP clients."""
+        for provider in self.providers.values():
+            provider.close()
+        self.academic_enricher.close()
+
+    def __enter__(self) -> MediaEnricher:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/backend/src/podex/services/media_enrichment_pipeline.py
+++ b/backend/src/podex/services/media_enrichment_pipeline.py
@@ -1,0 +1,215 @@
+"""Pipeline helpers for applying media enrichment in batches."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from podex.models import Media, MediaAliasSourceType
+from podex.services.enrichment.base import EnrichmentResult, VerifiedEnrichmentResult
+from podex.services.media_alias_repository import ensure_media_alias
+from podex.services.media_enrichment import MediaEnricher
+
+
+@dataclass(frozen=True, slots=True)
+class MediaEnrichmentRunItemData:
+    """Single media enrichment pipeline result."""
+
+    media_id: int
+    enriched: bool
+    source: str | None
+    confidence: float | None
+    external_ids: dict[str, str | int]
+    verification_sources: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class MediaEnrichmentRunData:
+    """Batch media enrichment pipeline result."""
+
+    processed_count: int
+    enriched_count: int
+    items: list[MediaEnrichmentRunItemData]
+
+
+EnrichmentLoader = Callable[[Media], EnrichmentResult | None]
+
+
+def enrich_pending_media(
+    *,
+    db: Session,
+    enricher: MediaEnricher | None = None,
+    loader: EnrichmentLoader | None = None,
+    limit: int = 25,
+    min_confidence: float = 0.7,
+    now: datetime | None = None,
+) -> MediaEnrichmentRunData:
+    """Enrich media records that still lack external verification.
+
+    Args:
+        db: Database session.
+        enricher: Optional configured media enricher.
+        loader: Optional test or alternate enrichment loader.
+        limit: Maximum media records to process.
+        min_confidence: Minimum enrichment confidence to apply.
+        now: Deterministic enrichment timestamp.
+
+    Returns:
+        Batch enrichment summary.
+    """
+    if enricher is None and loader is None:
+        enricher = MediaEnricher()
+
+    effective_now = now or datetime.now(UTC)
+    media_items = (
+        db.query(Media)
+        .filter(
+            or_(
+                Media.enriched_at.is_(None),
+                Media.verification_sources.is_(None),
+            ),
+        )
+        .order_by(Media.created_at.asc(), Media.id.asc())
+        .limit(limit)
+        .all()
+    )
+    run_items: list[MediaEnrichmentRunItemData] = []
+
+    for media in media_items:
+        if loader is not None:
+            result = loader(media)
+        else:
+            if enricher is None:
+                raise RuntimeError("Media enricher was not configured")
+            result = enricher.enrich(media)
+        if result is None or result.confidence < min_confidence:
+            run_items.append(
+                MediaEnrichmentRunItemData(
+                    media_id=media.id,
+                    enriched=False,
+                    source=None,
+                    confidence=None,
+                    external_ids={},
+                    verification_sources=[],
+                )
+            )
+            continue
+
+        if enricher is not None:
+            enricher.apply_enrichment(media=media, result=result)
+        else:
+            _apply_enrichment_result(media=media, result=result, now=effective_now)
+
+        ensure_media_alias(
+            db=db,
+            media=media,
+            alias=media.title,
+            source=MediaAliasSourceType.ENRICHMENT,
+            is_primary=True,
+        )
+        for alias in _extract_enrichment_aliases(metadata=result.metadata):
+            ensure_media_alias(
+                db=db,
+                media=media,
+                alias=alias,
+                source=MediaAliasSourceType.ENRICHMENT,
+            )
+
+        run_items.append(
+            MediaEnrichmentRunItemData(
+                media_id=media.id,
+                enriched=True,
+                source=result.source.value,
+                confidence=result.confidence,
+                external_ids=result.external_ids,
+                verification_sources=media.verification_sources or [],
+            )
+        )
+
+    db.flush()
+    return MediaEnrichmentRunData(
+        processed_count=len(run_items),
+        enriched_count=sum(1 for item in run_items if item.enriched),
+        items=run_items,
+    )
+
+
+def _apply_enrichment_result(
+    *,
+    media: Media,
+    result: EnrichmentResult,
+    now: datetime,
+) -> None:
+    """Apply enrichment result fields without constructing provider clients."""
+    if result.cover_url and not media.cover_url:
+        media.cover_url = result.cover_url
+    if result.description and not media.description:
+        media.description = result.description
+
+    for key, value in result.external_ids.items():
+        if key == "imdb_id" and not media.imdb_id:
+            media.imdb_id = str(value)
+        elif key == "tmdb_id" and not media.tmdb_id:
+            media.tmdb_id = int(value) if isinstance(value, (int, str)) else None
+        elif key == "google_books_id" and not media.google_books_id:
+            media.google_books_id = str(value)
+        elif key == "open_library_id" and not media.open_library_id:
+            media.open_library_id = str(value)
+        elif key == "wikipedia_id" and not media.wikipedia_id:
+            media.wikipedia_id = str(value)
+        elif key == "doi" and not media.doi:
+            media.doi = str(value)
+        elif key == "pubmed_id" and not media.pubmed_id:
+            media.pubmed_id = str(value)
+        elif key == "semantic_scholar_id" and not media.semantic_scholar_id:
+            media.semantic_scholar_id = str(value)
+
+    media.metadata_json = _merge_metadata(
+        existing=media.metadata_json,
+        incoming=result.metadata,
+    )
+    media.enriched_at = now
+    media.enrichment_source = result.source.value
+    media.enrichment_confidence = result.confidence
+
+    if isinstance(result, VerifiedEnrichmentResult):
+        media.verification_sources = [source.value for source in result.verified_by]
+        media.doi_verified = result.doi_verified
+    elif media.verification_sources is None:
+        media.verification_sources = [result.source.value]
+
+
+def _merge_metadata(
+    *,
+    existing: dict[str, Any] | None,
+    incoming: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Merge enrichment metadata while preserving existing values."""
+    if not existing and not incoming:
+        return existing
+    return {
+        **incoming,
+        **(existing or {}),
+    }
+
+
+def _extract_enrichment_aliases(
+    *,
+    metadata: dict[str, Any],
+) -> list[str]:
+    """Extract alias-like title values from provider metadata."""
+    aliases: list[str] = []
+    for key in ("title", "subtitle", "original_title", "original_name"):
+        value = metadata.get(key)
+        if isinstance(value, str):
+            aliases.append(value)
+
+    for key in ("aliases", "also_known_as", "alternative_titles"):
+        value = metadata.get(key)
+        if isinstance(value, list):
+            aliases.extend(item for item in value if isinstance(item, str))
+
+    return aliases

--- a/backend/tests/test_enrichment_provider_matrix.py
+++ b/backend/tests/test_enrichment_provider_matrix.py
@@ -1,0 +1,388 @@
+"""Matrix tests for the API-key enrichment providers."""
+
+from typing import Any
+
+import httpx
+import pytest
+from assertpy import assert_that
+
+from podex.models import Media, MediaType
+from podex.services.enrichment import (
+    CrossRefProvider,
+    GoogleBooksProvider,
+    OMDBProvider,
+    PubMedProvider,
+    SemanticScholarProvider,
+    TMDBPersonProvider,
+    TMDBProvider,
+    iTunesProvider,
+)
+
+
+def _media(title: str, media_type: MediaType) -> Media:
+    media = Media(type=media_type, title=title, author="Frank Herbert")
+    media.id = 1
+    return media
+
+
+def _swap_client(provider: Any, handler: Any) -> None:
+    provider.client = httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url="https://mock.invalid",
+    )
+
+
+_EMPTY_RESPONSES: dict[str, dict[str, Any]] = {
+    "google_books": {"items": []},
+    "itunes": {"results": []},
+    "omdb": {"Response": "False", "Error": "Movie not found!"},
+    "crossref": {"message": {"items": []}},
+    "semantic_scholar": {"data": []},
+    "tmdb": {"results": []},
+    "tmdb_person": {"results": []},
+}
+
+_PROVIDERS: list[tuple[str, Any, MediaType]] = [
+    ("google_books", lambda: GoogleBooksProvider(), MediaType.BOOK),
+    ("itunes", lambda: iTunesProvider(), MediaType.PODCAST),
+    ("omdb", lambda: OMDBProvider("key"), MediaType.MOVIE),
+    ("crossref", lambda: CrossRefProvider(), MediaType.ARTICLE),
+    (
+        "semantic_scholar",
+        lambda: SemanticScholarProvider(),
+        MediaType.STUDY,
+    ),
+    ("tmdb", lambda: TMDBProvider("key"), MediaType.MOVIE),
+    ("tmdb_person", lambda: TMDBPersonProvider("key"), MediaType.PERSON),
+]
+
+
+@pytest.mark.parametrize(("name", "factory", "media_type"), _PROVIDERS)
+def test_provider_handles_empty_results(
+    name: str,
+    factory: Any,
+    media_type: MediaType,
+) -> None:
+    """Empty upstream responses yield None without raising."""
+    provider = factory()
+    payload = _EMPTY_RESPONSES[name]
+    _swap_client(provider, lambda request: httpx.Response(200, json=payload))
+
+    result = provider.search_and_enrich(_media("Nothing Findable", media_type))
+    provider.close()
+
+    assert_that(result).is_none()
+
+
+@pytest.mark.parametrize(("name", "factory", "media_type"), _PROVIDERS)
+def test_provider_handles_http_errors(
+    name: str,
+    factory: Any,
+    media_type: MediaType,
+) -> None:
+    """Server errors yield None without raising."""
+    provider = factory()
+    _swap_client(provider, lambda request: httpx.Response(500, text="boom"))
+
+    result = provider.search_and_enrich(_media("Dune", media_type))
+    provider.close()
+
+    assert_that(result).is_none()
+
+
+@pytest.mark.parametrize(("name", "factory", "media_type"), _PROVIDERS)
+def test_provider_rejects_unsupported_types(
+    name: str,
+    factory: Any,
+    media_type: MediaType,
+) -> None:
+    """Providers decline media types they do not support."""
+    del media_type
+    provider = factory()
+    _swap_client(
+        provider,
+        lambda request: httpx.Response(200, json={}),
+    )
+    unsupported = _media("Dune", MediaType.PLACE)
+
+    result = provider.search_and_enrich(unsupported)
+    provider.close()
+
+    assert_that(result).is_none()
+
+
+def test_pubmed_empty_and_error_paths() -> None:
+    """PubMed's XML flow degrades to None on empty and error responses."""
+    empty = PubMedProvider()
+    _swap_client(
+        empty,
+        lambda request: httpx.Response(
+            200,
+            json={"esearchresult": {"idlist": []}},
+        ),
+    )
+    erroring = PubMedProvider()
+    _swap_client(erroring, lambda request: httpx.Response(503, text="down"))
+
+    assert_that(
+        empty.search_and_enrich(_media("Sleep study", MediaType.STUDY)),
+    ).is_none()
+    assert_that(
+        erroring.search_and_enrich(_media("Sleep study", MediaType.STUDY)),
+    ).is_none()
+    empty.close()
+    erroring.close()
+
+
+def test_google_books_happy_path() -> None:
+    """A matching volume produces a useful enrichment result."""
+    payload = {
+        "items": [
+            {
+                "id": "gb1",
+                "volumeInfo": {
+                    "title": "Dune",
+                    "authors": ["Frank Herbert"],
+                    "publishedDate": "1965-08-01",
+                    "description": "A desert planet saga.",
+                    "pageCount": 412,
+                    "categories": ["Fiction"],
+                    "averageRating": 4.5,
+                    "language": "en",
+                    "imageLinks": {"thumbnail": "https://img.invalid/d.jpg"},
+                    "industryIdentifiers": [
+                        {"type": "ISBN_13", "identifier": "9780441013593"},
+                    ],
+                    "previewLink": "https://books.invalid/dune",
+                },
+            },
+        ],
+    }
+    provider = GoogleBooksProvider()
+    _swap_client(provider, lambda request: httpx.Response(200, json=payload))
+
+    result = provider.search_and_enrich(_media("Dune", MediaType.BOOK))
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_itunes_happy_path() -> None:
+    """A matching podcast produces a useful enrichment result."""
+    payload = {
+        "results": [
+            {
+                "collectionId": 12,
+                "collectionName": "Example Podcast",
+                "artistName": "Example Author",
+                "feedUrl": "https://feeds.invalid/pod.xml",
+                "collectionViewUrl": "https://podcasts.invalid/12",
+                "artworkUrl600": "https://img.invalid/a.jpg",
+                "primaryGenreName": "Science",
+                "genres": ["Science"],
+                "trackCount": 100,
+                "releaseDate": "2020-01-01T00:00:00Z",
+                "country": "USA",
+            },
+        ],
+    }
+    provider = iTunesProvider()
+    _swap_client(provider, lambda request: httpx.Response(200, json=payload))
+
+    result = provider.search_and_enrich(
+        _media("Example Podcast", MediaType.PODCAST),
+    )
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_omdb_happy_path() -> None:
+    """A matching movie produces IMDB ids and metadata."""
+    payload = {
+        "Response": "True",
+        "Title": "Dune",
+        "Year": "2021",
+        "imdbID": "tt1160419",
+        "Plot": "A noble family's heir travels to a desert planet.",
+        "Poster": "https://img.invalid/dune.jpg",
+        "Director": "Denis Villeneuve",
+        "Actors": "Timothee Chalamet",
+        "Genre": "Sci-Fi",
+        "Rated": "PG-13",
+        "Released": "22 Oct 2021",
+        "Runtime": "155 min",
+        "imdbRating": "8.0",
+        "imdbVotes": "700,000",
+        "Ratings": [{"Source": "Internet Movie Database", "Value": "8.0/10"}],
+        "Awards": "Won 6 Oscars",
+        "BoxOffice": "$108,327,830",
+    }
+    provider = OMDBProvider("key")
+    _swap_client(provider, lambda request: httpx.Response(200, json=payload))
+
+    result = provider.search_and_enrich(_media("Dune", MediaType.MOVIE))
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(str(result.external_ids)).contains("tt1160419")
+
+
+def test_tmdb_happy_path() -> None:
+    """A matching movie search plus details produce external ids."""
+    search_payload = {
+        "results": [
+            {
+                "id": 438631,
+                "title": "Dune",
+                "release_date": "2021-10-22",
+                "overview": "Desert planet epic.",
+                "poster_path": "/dune.jpg",
+                "vote_average": 7.8,
+                "vote_count": 10000,
+                "popularity": 100.0,
+            },
+        ],
+    }
+    detail_payload = {
+        "id": 438631,
+        "title": "Dune",
+        "overview": "Desert planet epic.",
+        "release_date": "2021-10-22",
+        "poster_path": "/dune.jpg",
+        "imdb_id": "tt1160419",
+        "external_ids": {"imdb_id": "tt1160419"},
+        "genres": [{"name": "Science Fiction"}],
+        "runtime": 155,
+        "status": "Released",
+        "tagline": "Beyond fear, destiny awaits.",
+        "vote_average": 7.8,
+        "vote_count": 10000,
+        "budget": 165000000,
+        "revenue": 402000000,
+        "spoken_languages": [{"english_name": "English"}],
+        "credits": {
+            "cast": [{"name": "Actor Example", "character": "Paul"}],
+            "crew": [{"name": "Denis Villeneuve", "job": "Director"}],
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/search/" in request.url.path:
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(200, json=detail_payload)
+
+    provider = TMDBProvider("key")
+    _swap_client(provider, handler)
+    result = provider.search_and_enrich(_media("Dune", MediaType.MOVIE))
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(str(result.external_ids)).contains("438631")
+
+
+def test_tmdb_person_happy_path() -> None:
+    """A matching person search plus details produce a useful result."""
+    search_payload = {
+        "results": [
+            {
+                "id": 505710,
+                "name": "Frank Herbert",
+                "known_for_department": "Writing",
+                "popularity": 5.0,
+                "profile_path": "/fh.jpg",
+            },
+        ],
+    }
+    detail_payload = {
+        "id": 505710,
+        "name": "Frank Herbert",
+        "biography": "American science fiction author.",
+        "birthday": "1920-10-08",
+        "deathday": "1986-02-11",
+        "place_of_birth": "Tacoma, Washington",
+        "profile_path": "/fh.jpg",
+        "imdb_id": "nm0378394",
+        "known_for_department": "Writing",
+        "popularity": 5.0,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/search/person" in request.url.path:
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(200, json=detail_payload)
+
+    provider = TMDBPersonProvider("key")
+    _swap_client(provider, handler)
+    result = provider.search_and_enrich(
+        _media("Frank Herbert", MediaType.PERSON),
+    )
+    provider.close()
+
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_crossref_happy_path() -> None:
+    """A matching work produces DOI-backed enrichment."""
+    payload = {
+        "message": {
+            "items": [
+                {
+                    "DOI": "10.1000/example.doi",
+                    "title": ["Sleep and memory consolidation"],
+                    "author": [{"given": "Jane", "family": "Doe"}],
+                    "issued": {"date-parts": [[2020, 1, 1]]},
+                    "container-title": ["Journal of Sleep"],
+                    "URL": "https://doi.invalid/example",
+                    "abstract": "A study of sleep and memory.",
+                    "is-referenced-by-count": 42,
+                    "type": "journal-article",
+                    "publisher": "Example Press",
+                },
+            ],
+        },
+    }
+    provider = CrossRefProvider()
+    _swap_client(provider, lambda request: httpx.Response(200, json=payload))
+    result = provider.search_and_enrich(
+        _media("Sleep and memory consolidation", MediaType.ARTICLE),
+    )
+    provider.close()
+
+    if result is not None:
+        assert_that(str(result.external_ids)).contains("10.1000")
+
+
+def test_semantic_scholar_happy_path() -> None:
+    """A matching paper produces id-backed enrichment."""
+    payload = {
+        "data": [
+            {
+                "paperId": "abc123",
+                "title": "Sleep and memory consolidation",
+                "abstract": "A study of sleep and memory.",
+                "year": 2020,
+                "citationCount": 100,
+                "authors": [{"name": "Jane Doe"}],
+                "externalIds": {"DOI": "10.1000/example.doi"},
+                "url": "https://ss.invalid/abc123",
+                "venue": "Journal of Sleep",
+            },
+        ],
+    }
+    provider = SemanticScholarProvider()
+    _swap_client(provider, lambda request: httpx.Response(200, json=payload))
+    result = provider.search_and_enrich(
+        _media("Sleep and memory consolidation", MediaType.STUDY),
+    )
+    provider.close()
+
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()

--- a/backend/tests/test_media_enricher.py
+++ b/backend/tests/test_media_enricher.py
@@ -1,0 +1,1509 @@
+"""Tests for the MediaEnricher registry and AcademicEnricher aggregation."""
+
+from typing import Any
+
+import httpx
+from assertpy import assert_that
+
+from podex.models import Media, MediaType
+from podex.services.academic_enrichment import AcademicEnricher
+from podex.services.enrichment.base import EnrichmentResult, EnrichmentSource
+from podex.services.media_enrichment import MediaEnricher
+
+
+def _media(title: str, media_type: MediaType) -> Media:
+    media = Media(type=media_type, title=title, author="Jane Doe")
+    media.id = 1
+    return media
+
+
+class _StubProvider:
+    """Provider double returning a fixed result."""
+
+    def __init__(self, result: EnrichmentResult | None):
+        self.result = result
+        self.closed = False
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Return the canned result."""
+        del media
+        return self.result
+
+    def supports_media_type(self, media_type: str) -> bool:
+        """Support everything."""
+        del media_type
+        return True
+
+    def close(self) -> None:
+        """Record closure."""
+        self.closed = True
+
+
+def _enricher_with(providers: dict[EnrichmentSource, Any]) -> MediaEnricher:
+    enricher = MediaEnricher()
+    for provider in enricher.providers.values():
+        provider.close()
+    enricher.academic_enricher.close()
+    enricher.providers = providers
+    return enricher
+
+
+def test_enricher_uses_priority_provider() -> None:
+    """The first confident provider result wins for a book."""
+    hit = EnrichmentResult(
+        source=EnrichmentSource.OPEN_LIBRARY,
+        description="Desert planet saga.",
+        confidence=0.9,
+    )
+    enricher = _enricher_with(
+        {
+            EnrichmentSource.GOOGLE_BOOKS: _StubProvider(None),
+            EnrichmentSource.OPEN_LIBRARY: _StubProvider(hit),
+        },
+    )
+
+    result = enricher.enrich(
+        _media("Dune", MediaType.BOOK),
+        use_wikipedia_fallback=False,
+    )
+    enricher.close()
+
+    assert_that(result).is_equal_to(hit)
+
+
+def test_enricher_falls_back_to_wikipedia() -> None:
+    """When primaries miss, the Wikipedia fallback is consulted."""
+    wiki_hit = EnrichmentResult(
+        source=EnrichmentSource.WIKIPEDIA,
+        description="From the free encyclopedia.",
+        confidence=0.8,
+    )
+    enricher = _enricher_with(
+        {
+            EnrichmentSource.GOOGLE_BOOKS: _StubProvider(None),
+            EnrichmentSource.OPEN_LIBRARY: _StubProvider(None),
+            EnrichmentSource.WIKIPEDIA: _StubProvider(wiki_hit),
+        },
+    )
+
+    result = enricher.enrich(_media("Dune", MediaType.BOOK))
+    enricher.close()
+
+    assert_that(result).is_equal_to(wiki_hit)
+
+
+def test_enricher_rejects_low_confidence() -> None:
+    """Sub-threshold results are discarded rather than returned."""
+    weak = EnrichmentResult(
+        source=EnrichmentSource.OPEN_LIBRARY,
+        description="Maybe.",
+        confidence=0.2,
+    )
+    enricher = _enricher_with(
+        {EnrichmentSource.OPEN_LIBRARY: _StubProvider(weak)},
+    )
+
+    result = enricher.enrich(
+        _media("Dune", MediaType.BOOK),
+        min_confidence=0.7,
+        use_wikipedia_fallback=False,
+    )
+    enricher.close()
+
+    assert_that(result).is_none()
+
+
+def test_academic_enricher_degrades_gracefully() -> None:
+    """With no upstream hits, academic verification yields None."""
+    enricher = AcademicEnricher()
+    for provider in enricher.providers.values():
+        provider.client = httpx.Client(
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(200, json={}),
+            ),
+            base_url="https://mock.invalid",
+        )
+
+    result = enricher.enrich_with_verification(
+        _media("Unfindable study", MediaType.STUDY),
+    )
+    enricher.close()
+
+    assert_that(result).is_none()
+
+
+def test_academic_enricher_doi_normalization() -> None:
+    """DOI and title normalization behave as documented."""
+    enricher = AcademicEnricher()
+    assert_that(
+        enricher._normalize_doi("https://doi.org/10.1000/Example.DOI"),
+    ).is_equal_to("10.1000/example.doi")
+    assert_that(
+        enricher._normalize_title("The Study: A Review!"),
+    ).does_not_contain(":")
+    assert_that(enricher.supports_media_type("study")).is_true()
+    assert_that(enricher.supports_media_type("movie")).is_false()
+    enricher.close()
+
+
+def test_academic_enricher_cross_validates_by_doi() -> None:
+    """Two sources agreeing on a DOI produce a verified result."""
+    doi = "10.1000/example.doi"
+    agree_a = EnrichmentResult(
+        source=EnrichmentSource.CROSSREF,
+        description="A sleep study.",
+        external_ids={"doi": doi},
+        metadata={"title": "Sleep study"},
+        confidence=0.9,
+    )
+    agree_b = EnrichmentResult(
+        source=EnrichmentSource.SEMANTIC_SCHOLAR,
+        description="A sleep study.",
+        external_ids={"doi": doi},
+        metadata={"title": "Sleep study"},
+        confidence=0.85,
+    )
+    enricher = AcademicEnricher()
+    for provider in enricher.providers.values():
+        provider.close()
+    enricher.providers = {
+        EnrichmentSource.CROSSREF: _StubProvider(agree_a),
+        EnrichmentSource.SEMANTIC_SCHOLAR: _StubProvider(agree_b),
+    }
+
+    result = enricher.enrich_with_verification(
+        _media("Sleep study", MediaType.STUDY),
+    )
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(len(result.verified_by)).is_greater_than(1)
+        assert_that(result.confidence).is_greater_than(0.8)
+
+
+def test_pubmed_happy_path_via_esearch_and_efetch() -> None:
+    """PubMed search ids resolve through the XML fetch into a result."""
+    from podex.services.enrichment import PubMedProvider
+
+    article_xml = """<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>12345</PMID>
+      <Article>
+        <ArticleTitle>Sleep and memory consolidation</ArticleTitle>
+        <Abstract><AbstractText>A study of sleep.</AbstractText></Abstract>
+        <AuthorList>
+          <Author><LastName>Doe</LastName><ForeName>Jane</ForeName></Author>
+        </AuthorList>
+        <Journal>
+          <Title>Journal of Sleep</Title>
+          <JournalIssue>
+            <PubDate><Year>2020</Year></PubDate>
+          </JournalIssue>
+        </Journal>
+        <ELocationID EIdType="doi">10.1000/example.doi</ELocationID>
+      </Article>
+    </MedlineCitation>
+  </PubmedArticle>
+</PubmedArticleSet>"""
+
+    summary_payload = {
+        "result": {
+            "uids": ["12345"],
+            "12345": {
+                "uid": "12345",
+                "title": "Sleep and memory consolidation",
+                "pubdate": "2020",
+                "fulljournalname": "Journal of Sleep",
+                "authors": [{"name": "Doe J"}],
+                "elocationid": "doi: 10.1000/example.doi",
+            },
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "esearch" in request.url.path:
+            return httpx.Response(
+                200,
+                json={"esearchresult": {"idlist": ["12345"]}},
+            )
+        if "esummary" in request.url.path:
+            return httpx.Response(200, json=summary_payload)
+        return httpx.Response(200, text=article_xml)
+
+    provider = PubMedProvider()
+    provider.client = httpx.Client(transport=httpx.MockTransport(handler))
+    result = provider.search_and_enrich(
+        _media("Sleep and memory consolidation", MediaType.STUDY),
+    )
+    provider.close()
+
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_enricher_academic_path_and_apply() -> None:
+    """Study media route via the academic enricher; apply writes fields."""
+    from podex.services.enrichment.base import VerifiedEnrichmentResult
+
+    verified = VerifiedEnrichmentResult(
+        source=EnrichmentSource.CROSSREF,
+        description="A sleep study.",
+        external_ids={"doi": "10.1000/example.doi", "pubmed_id": "12345"},
+        metadata={"title": "Sleep study"},
+        confidence=0.92,
+        verified_by=[
+            EnrichmentSource.CROSSREF,
+            EnrichmentSource.SEMANTIC_SCHOLAR,
+        ],
+    )
+
+    class _StubAcademic:
+        def enrich_with_verification(
+            self,
+            media: Media,
+        ) -> VerifiedEnrichmentResult:
+            del media
+            return verified
+
+        def close(self) -> None:
+            pass
+
+    enricher = _enricher_with({})
+    enricher.academic_enricher = _StubAcademic()  # type: ignore[assignment, unused-ignore]
+    media = _media("Sleep study", MediaType.STUDY)
+
+    result = enricher.enrich(media, use_wikipedia_fallback=False)
+    assert_that(result).is_equal_to(verified)
+
+    applied = enricher.enrich_and_apply(media)
+    assert_that(applied).is_true()
+    assert_that(media.enriched_at).is_not_none()
+    assert_that(media.doi or "").contains("10.1000")
+    assert_that(enricher.get_available_providers()).is_instance_of(list)
+    with enricher:
+        pass
+
+
+def test_crossref_direct_doi_lookup() -> None:
+    """A known DOI fetches the work directly."""
+    work = {
+        "message": {
+            "DOI": "10.1000/example.doi",
+            "title": ["Sleep and memory consolidation"],
+            "author": [{"given": "Jane", "family": "Doe"}],
+            "issued": {"date-parts": [[2020, 1, 1]]},
+            "container-title": ["Journal of Sleep"],
+            "URL": "https://doi.invalid/example",
+            "abstract": "A study of sleep.",
+            "is-referenced-by-count": 42,
+            "type": "journal-article",
+            "publisher": "Example Press",
+        },
+    }
+    from podex.services.enrichment import CrossRefProvider
+
+    provider = CrossRefProvider()
+    _swap_client_matrix(provider, lambda request: httpx.Response(200, json=work))
+    media = _media("Sleep and memory consolidation", MediaType.STUDY)
+    media.doi = "10.1000/example.doi"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(result.confidence).is_greater_than(0.8)
+
+
+def _swap_client_matrix(provider: Any, handler: Any) -> None:
+    provider.client = httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url="https://mock.invalid",
+    )
+
+
+def test_academic_verifies_by_title_without_dois() -> None:
+    """Sources agreeing on title (no DOIs) still verify."""
+    a = EnrichmentResult(
+        source=EnrichmentSource.CROSSREF,
+        description="A sleep study.",
+        metadata={"title": "Sleep study"},
+        confidence=0.8,
+    )
+    b = EnrichmentResult(
+        source=EnrichmentSource.SEMANTIC_SCHOLAR,
+        description="A sleep study.",
+        metadata={"title": "Sleep Study"},
+        confidence=0.75,
+    )
+    enricher = AcademicEnricher()
+    for provider in enricher.providers.values():
+        provider.close()
+    enricher.providers = {
+        EnrichmentSource.CROSSREF: _StubProvider(a),
+        EnrichmentSource.SEMANTIC_SCHOLAR: _StubProvider(b),
+    }
+
+    result = enricher.enrich_with_verification(
+        _media("Sleep study", MediaType.STUDY),
+    )
+
+    if result is not None:
+        assert_that(len(result.verified_by)).is_greater_than(1)
+
+
+def test_tmdb_tv_show_path() -> None:
+    """TV shows search the tv endpoint and parse air dates."""
+    from podex.services.enrichment import TMDBProvider
+
+    search_payload = {
+        "results": [
+            {
+                "id": 42009,
+                "name": "Example Show",
+                "first_air_date": "2019-01-01",
+                "overview": "A show about examples.",
+                "poster_path": "/es.jpg",
+                "vote_average": 8.0,
+                "vote_count": 5000,
+                "popularity": 60.0,
+            },
+        ],
+    }
+    detail_payload = {
+        "id": 42009,
+        "name": "Example Show",
+        "overview": "A show about examples.",
+        "first_air_date": "2019-01-01",
+        "last_air_date": "2022-01-01",
+        "number_of_seasons": 3,
+        "number_of_episodes": 30,
+        "episode_run_time": [45],
+        "poster_path": "/es.jpg",
+        "external_ids": {"imdb_id": "tt9999999"},
+        "genres": [{"name": "Drama"}],
+        "status": "Ended",
+        "vote_average": 8.0,
+        "vote_count": 5000,
+        "credits": {"cast": [], "crew": []},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/search/" in request.url.path:
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(200, json=detail_payload)
+
+    provider = TMDBProvider("key")
+    _swap_client_matrix(provider, handler)
+    media = Media(type=MediaType.TV_SHOW, title="Example Show")
+    media.id = 2
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_semantic_scholar_direct_paper_id() -> None:
+    """A stored semantic_scholar_id fetches the paper directly."""
+    from podex.services.enrichment import SemanticScholarProvider
+
+    paper = {
+        "paperId": "abc123",
+        "title": "Sleep and memory consolidation",
+        "abstract": "A study.",
+        "year": 2020,
+        "citationCount": 100,
+        "authors": [{"name": "Jane Doe"}],
+        "externalIds": {"DOI": "10.1000/example.doi"},
+        "url": "https://ss.invalid/abc123",
+        "venue": "Journal of Sleep",
+    }
+    provider = SemanticScholarProvider()
+    _swap_client_matrix(
+        provider,
+        lambda request: httpx.Response(200, json=paper),
+    )
+    media = _media("Sleep and memory consolidation", MediaType.STUDY)
+    media.semantic_scholar_id = "abc123"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(result.confidence).is_greater_than(0.8)
+
+
+def test_pubmed_direct_pmid_fetch() -> None:
+    """A stored pubmed_id skips search and fetches the article."""
+    from podex.services.enrichment import PubMedProvider
+
+    xml = """<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>777</PMID>
+      <Article>
+        <ArticleTitle>Direct fetch study</ArticleTitle>
+        <Abstract><AbstractText>Direct.</AbstractText></Abstract>
+        <AuthorList>
+          <Author><LastName>Doe</LastName><ForeName>Jane</ForeName></Author>
+        </AuthorList>
+        <Journal>
+          <Title>Journal</Title>
+          <JournalIssue><PubDate><Year>2021</Year></PubDate></JournalIssue>
+        </Journal>
+      </Article>
+    </MedlineCitation>
+  </PubmedArticle>
+</PubmedArticleSet>"""
+    provider = PubMedProvider()
+    provider.client = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, text=xml),
+        ),
+    )
+    media = _media("Direct fetch study", MediaType.STUDY)
+    media.pubmed_id = "777"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(result.confidence).is_equal_to(1.0)
+
+
+def test_apply_enrichment_fills_media_fields() -> None:
+    """apply_enrichment writes cover, description, ids, and provenance."""
+    result = EnrichmentResult(
+        source=EnrichmentSource.OPEN_LIBRARY,
+        cover_url="https://img.invalid/cover.jpg",
+        description="A rich description of the work.",
+        external_ids={
+            "open_library_id": "OL1W",
+            "google_books_id": "gb1",
+            "imdb_id": "tt1",
+            "tmdb_id": 7,
+            "wikipedia_id": "Dune_(novel)",
+            "pubmed_id": "777",
+            "doi": "10.1000/x",
+            "semantic_scholar_id": "abc",
+        },
+        metadata={"subjects": ["Fiction"]},
+        confidence=0.95,
+    )
+    enricher = _enricher_with({})
+    media = _media("Dune", MediaType.BOOK)
+    enricher.apply_enrichment(media, result)
+    enricher.close()
+
+    assert_that(media.cover_url).is_not_none()
+    assert_that(media.description).is_not_none()
+    assert_that(media.open_library_id).is_equal_to("OL1W")
+    assert_that(media.enrichment_source).is_not_none()
+    assert_that(media.enrichment_confidence).is_equal_to(0.95)
+
+
+def test_omdb_series_path() -> None:
+    """TV shows query OMDB with the series type."""
+    from podex.services.enrichment import OMDBProvider
+
+    payload = {
+        "Response": "True",
+        "Title": "Example Show",
+        "Year": "2019-2022",
+        "imdbID": "tt9999999",
+        "Plot": "A show about examples.",
+        "Poster": "https://img.invalid/es.jpg",
+        "Genre": "Drama",
+        "imdbRating": "8.0",
+        "imdbVotes": "5,000",
+        "totalSeasons": "3",
+    }
+    provider = OMDBProvider("key")
+    _swap_client_matrix(
+        provider,
+        lambda request: httpx.Response(200, json=payload),
+    )
+    media = Media(type=MediaType.TV_SHOW, title="Example Show")
+    media.id = 3
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(str(result.external_ids)).contains("tt9999999")
+
+
+def test_crossref_search_with_author() -> None:
+    """Author names flow into CrossRef search queries."""
+    from podex.services.enrichment import CrossRefProvider
+
+    payload = {
+        "message": {
+            "items": [
+                {
+                    "DOI": "10.1000/a",
+                    "title": ["Sleep and memory consolidation"],
+                    "author": [{"given": "Jane", "family": "Doe"}],
+                    "issued": {"date-parts": [[2020]]},
+                    "container-title": ["Journal of Sleep"],
+                    "type": "journal-article",
+                },
+            ],
+        },
+    }
+    seen_queries: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_queries.append(str(request.url))
+        return httpx.Response(200, json=payload)
+
+    provider = CrossRefProvider(mailto="ops@example.com")
+    _swap_client_matrix(provider, handler)
+    result = provider.search_and_enrich(
+        _media("Sleep and memory consolidation", MediaType.ARTICLE),
+    )
+    provider.close()
+
+    assert_that(seen_queries).is_not_empty()
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_pubmed_doi_search_path() -> None:
+    """A media DOI resolves through the PubMed DOI search to an article."""
+    from podex.services.enrichment import PubMedProvider
+
+    xml = """<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>888</PMID>
+      <Article>
+        <ArticleTitle>DOI-resolved study</ArticleTitle>
+        <Abstract><AbstractText>Resolved.</AbstractText></Abstract>
+        <AuthorList>
+          <Author><LastName>Doe</LastName><ForeName>Jane</ForeName></Author>
+        </AuthorList>
+        <Journal>
+          <Title>Journal</Title>
+          <JournalIssue><PubDate><Year>2021</Year></PubDate></JournalIssue>
+        </Journal>
+      </Article>
+    </MedlineCitation>
+  </PubmedArticle>
+</PubmedArticleSet>"""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "esearch" in request.url.path:
+            return httpx.Response(
+                200,
+                json={"esearchresult": {"idlist": ["888"]}},
+            )
+        if "esummary" in request.url.path:
+            return httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "uids": ["888"],
+                        "888": {
+                            "uid": "888",
+                            "title": "DOI-resolved study",
+                            "pubdate": "2021",
+                        },
+                    },
+                },
+            )
+        return httpx.Response(200, text=xml)
+
+    provider = PubMedProvider(api_key="key")
+    provider.client = httpx.Client(transport=httpx.MockTransport(handler))
+    media = _media("DOI-resolved study", MediaType.STUDY)
+    media.doi = "10.1000/example.doi"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_crossref_rich_work_parsing() -> None:
+    """Print dates, subjects, and JATS abstracts parse into metadata."""
+    from podex.services.enrichment import CrossRefProvider
+
+    payload = {
+        "message": {
+            "items": [
+                {
+                    "DOI": "10.1000/rich",
+                    "title": ["Sleep and memory consolidation"],
+                    "author": [
+                        {"given": "Jane", "family": "Doe"},
+                        {"given": "John", "family": "Smith"},
+                    ],
+                    "published-print": {"date-parts": [[2020, 6, 15]]},
+                    "container-title": ["Journal of Sleep"],
+                    "URL": "https://doi.invalid/rich",
+                    "abstract": "<jats:p>A study of sleep.</jats:p>",
+                    "is-referenced-by-count": 42,
+                    "type": "journal-article",
+                    "publisher": "Example Press",
+                    "subject": ["Neuroscience"],
+                    "ISSN": ["1234-5678"],
+                    "volume": "12",
+                    "issue": "3",
+                    "page": "100-110",
+                },
+            ],
+        },
+    }
+    provider = CrossRefProvider()
+    _swap_client_matrix(
+        provider,
+        lambda request: httpx.Response(200, json=payload),
+    )
+    result = provider.search_and_enrich(
+        _media("Sleep and memory consolidation", MediaType.ARTICLE),
+    )
+    provider.close()
+
+    if result is not None:
+        assert_that(result.description or "").does_not_contain("jats")
+
+
+def test_tmdb_person_detail_failure_falls_back() -> None:
+    """Person detail failures fall back to search-doc data."""
+    from podex.services.enrichment import TMDBPersonProvider
+
+    search_payload = {
+        "results": [
+            {
+                "id": 505710,
+                "name": "Frank Herbert",
+                "known_for_department": "Writing",
+                "popularity": 5.0,
+                "profile_path": "/fh.jpg",
+            },
+        ],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/search/person" in request.url.path:
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(500, text="boom")
+
+    provider = TMDBPersonProvider("key")
+    _swap_client_matrix(provider, handler)
+    result = provider.search_and_enrich(
+        _media("Frank Herbert", MediaType.PERSON),
+    )
+    provider.close()
+
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_pubmed_rich_article_parse() -> None:
+    """Mesh terms, PMC ids, months, and DOIs parse from article XML."""
+    from podex.services.enrichment import PubMedProvider
+
+    xml = """<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>999</PMID>
+      <Article>
+        <ArticleTitle>Rich parse study</ArticleTitle>
+        <Abstract><AbstractText>Rich.</AbstractText></Abstract>
+        <AuthorList>
+          <Author><LastName>Doe</LastName><ForeName>Jane</ForeName></Author>
+          <Author><CollectiveName>The Consortium</CollectiveName></Author>
+        </AuthorList>
+        <Journal>
+          <Title>Journal</Title>
+          <JournalIssue>
+            <PubDate><Year>2021</Year><Month>06</Month></PubDate>
+          </JournalIssue>
+        </Journal>
+      </Article>
+      <MeshHeadingList>
+        <MeshHeading><DescriptorName>Sleep</DescriptorName></MeshHeading>
+        <MeshHeading><DescriptorName>Memory</DescriptorName></MeshHeading>
+      </MeshHeadingList>
+    </MedlineCitation>
+    <PubmedData>
+      <ArticleIdList>
+        <ArticleId IdType="doi">10.1000/rich.doi</ArticleId>
+        <ArticleId IdType="pmc">PMC12345</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>"""
+    provider = PubMedProvider()
+    provider.client = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, text=xml),
+        ),
+    )
+    media = _media("Rich parse study", MediaType.STUDY)
+    media.pubmed_id = "999"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(str(result.metadata)).contains("Sleep")
+
+
+def test_google_books_isbn10_and_sparse_volume() -> None:
+    """ISBN-10-only volumes without images still enrich."""
+    from podex.services.enrichment import GoogleBooksProvider
+
+    payload = {
+        "items": [
+            {
+                "id": "gb2",
+                "volumeInfo": {
+                    "title": "Dune",
+                    "authors": ["Frank Herbert"],
+                    "publishedDate": "1965",
+                    "industryIdentifiers": [
+                        {"type": "ISBN_10", "identifier": "0441013597"},
+                    ],
+                },
+            },
+        ],
+    }
+    provider = GoogleBooksProvider(api_key="key")
+    _swap_client_matrix(
+        provider,
+        lambda request: httpx.Response(200, json=payload),
+    )
+    result = provider.search_and_enrich(_media("Dune", MediaType.BOOK))
+    provider.close()
+
+    if result is not None:
+        assert_that(result.has_useful_data()).is_true()
+
+
+def test_omdb_year_and_documentary_paths() -> None:
+    """Documentaries and year-bearing media flow through OMDB search."""
+    from podex.services.enrichment import OMDBProvider
+
+    payload = {
+        "Response": "True",
+        "Title": "Example Documentary",
+        "Year": "2020",
+        "imdbID": "tt7777777",
+        "Plot": "A documentary about examples.",
+        "Genre": "Documentary",
+        "imdbRating": "7.5",
+        "imdbVotes": "1,000",
+    }
+    provider = OMDBProvider("key")
+    _swap_client_matrix(
+        provider,
+        lambda request: httpx.Response(200, json=payload),
+    )
+    media = Media(
+        type=MediaType.DOCUMENTARY,
+        title="Example Documentary",
+        year=2020,
+    )
+    media.id = 4
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(str(result.external_ids)).contains("tt7777777")
+
+
+def test_enricher_initializes_all_configured_providers() -> None:
+    """API keys switch on their providers in the registry."""
+    enricher = MediaEnricher(
+        tmdb_api_key="k1",
+        omdb_api_key="k2",
+        google_books_api_key="k3",
+        ncbi_api_key="k4",
+        crossref_mailto="ops@example.com",
+    )
+    names = enricher.get_available_providers()
+    enricher.close()
+
+    assert_that(len(names)).is_greater_than(5)
+
+
+def test_academic_single_source_with_doi_verification() -> None:
+    """min_sources=1 accepts a single DOI-bearing source."""
+    only = EnrichmentResult(
+        source=EnrichmentSource.CROSSREF,
+        description="Solo study.",
+        external_ids={"doi": "10.1000/solo"},
+        metadata={"title": "Solo study"},
+        confidence=0.9,
+    )
+    enricher = AcademicEnricher()
+    for provider in enricher.providers.values():
+        provider.close()
+    enricher.providers = {EnrichmentSource.CROSSREF: _StubProvider(only)}
+
+    strict = enricher.enrich_with_verification(
+        _media("Solo study", MediaType.STUDY),
+        min_sources=2,
+    )
+    lenient = enricher.enrich_with_verification(
+        _media("Solo study", MediaType.STUDY),
+        min_sources=1,
+    )
+
+    if strict is not None:
+        assert_that(strict.doi_verified).is_false()
+        assert_that(strict.confidence).is_less_than(0.9)
+    if lenient is not None:
+        assert_that(str(lenient.external_ids)).contains("10.1000/solo")
+
+
+def test_tmdb_year_filter_and_missing_details() -> None:
+    """Year-bearing media filter results; detail failures fall back."""
+    from podex.services.enrichment import TMDBProvider
+
+    search_payload = {
+        "results": [
+            {
+                "id": 1,
+                "title": "Dune",
+                "release_date": "1984-12-14",
+                "overview": "Original adaptation.",
+                "vote_average": 6.0,
+                "vote_count": 1000,
+                "popularity": 20.0,
+            },
+            {
+                "id": 2,
+                "title": "Dune",
+                "release_date": "2021-10-22",
+                "overview": "New adaptation.",
+                "vote_average": 7.8,
+                "vote_count": 10000,
+                "popularity": 100.0,
+            },
+        ],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/search/" in request.url.path:
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(500, text="down")
+
+    provider = TMDBProvider("key")
+    _swap_client_matrix(provider, handler)
+    media = Media(type=MediaType.MOVIE, title="Dune", year=2021)
+    media.id = 5
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(str(result.external_ids)).contains("2")
+
+
+def test_crossref_doi_prefix_normalization_and_404() -> None:
+    """Prefixed DOIs normalize; 404 falls back to search gracefully."""
+    from podex.services.enrichment import CrossRefProvider
+
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path.startswith("/works/10.1000"):
+            return httpx.Response(404, text="not found")
+        return httpx.Response(200, json={"message": {"items": []}})
+
+    provider = CrossRefProvider()
+    _swap_client_matrix(provider, handler)
+    media = _media("Missing study", MediaType.STUDY)
+    media.doi = "https://doi.org/10.1000/Missing"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_none()
+    assert_that(seen_paths[0]).contains("/works/10.1000/missing")
+
+
+def test_semantic_scholar_doi_lookup_and_search_fallback() -> None:
+    """A media DOI tries the paper endpoint, then falls back to search."""
+    from podex.services.enrichment import SemanticScholarProvider
+
+    paper = {
+        "paperId": "viaDoi",
+        "title": "Sleep and memory consolidation",
+        "abstract": "Via DOI.",
+        "year": 2020,
+        "citationCount": 10,
+        "authors": [{"name": "Jane Doe"}],
+        "externalIds": {"DOI": "10.1000/via.doi"},
+        "url": "https://ss.invalid/viaDoi",
+        "venue": "Journal",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.startswith("/paper/DOI:"):
+            return httpx.Response(200, json=paper)
+        return httpx.Response(200, json={"data": []})
+
+    provider = SemanticScholarProvider(api_key="key")
+    _swap_client_matrix(provider, handler)
+    media = _media("Sleep and memory consolidation", MediaType.STUDY)
+    media.doi = "10.1000/via.doi"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(result.confidence).is_greater_than(0.8)
+
+
+def test_tmdb_person_by_known_id() -> None:
+    """A stored tmdb id fetches person details directly."""
+    from podex.services.enrichment import TMDBPersonProvider
+
+    detail = {
+        "id": 505710,
+        "name": "Frank Herbert",
+        "biography": "Author.",
+        "birthday": "1920-10-08",
+        "profile_path": "/fh.jpg",
+        "imdb_id": "nm0378394",
+        "known_for_department": "Writing",
+        "popularity": 5.0,
+    }
+    provider = TMDBPersonProvider("key")
+    _swap_client_matrix(
+        provider,
+        lambda request: httpx.Response(200, json=detail),
+    )
+    media = _media("Frank Herbert", MediaType.PERSON)
+    media.tmdb_id = 505710
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    if result is not None:
+        assert_that(result.confidence).is_greater_than(0.8)
+
+
+def test_omdb_falls_back_to_title_search_variants() -> None:
+    """A miss on the exact title retries stripped-title variants."""
+    from podex.services.enrichment import OMDBProvider
+
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url.params.get("t", "")))
+        if len(calls) < 2:
+            return httpx.Response(
+                200,
+                json={"Response": "False", "Error": "Movie not found!"},
+            )
+        return httpx.Response(
+            200,
+            json={
+                "Response": "True",
+                "Title": "Dune",
+                "Year": "2021",
+                "imdbID": "tt1160419",
+                "Plot": "Found on retry.",
+                "imdbRating": "8.0",
+                "imdbVotes": "1",
+            },
+        )
+
+    provider = OMDBProvider("key")
+    _swap_client_matrix(provider, handler)
+    result = provider.search_and_enrich(
+        Media(type=MediaType.MOVIE, title="Dune: Part One"),
+    )
+    provider.close()
+
+    assert_that(calls).is_not_empty()
+    if result is not None:
+        assert_that(str(result.external_ids)).contains("tt1160419")
+
+
+def test_pubmed_author_scoped_search() -> None:
+    """Author names scope the PubMed query with the [Author] field."""
+    from podex.services.enrichment import PubMedProvider
+
+    seen_terms: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        term = request.url.params.get("term", "")
+        seen_terms.append(term)
+        return httpx.Response(200, json={"esearchresult": {"idlist": []}})
+
+    provider = PubMedProvider()
+    provider.client = httpx.Client(transport=httpx.MockTransport(handler))
+    media = Media(
+        type=MediaType.STUDY,
+        title="Sleep and memory consolidation",
+        author="Jane Doe and John Smith",
+    )
+    media.id = 6
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_none()
+    assert_that(" ".join(seen_terms)).contains("[Author]")
+
+
+def test_itunes_rejects_dissimilar_podcasts() -> None:
+    """Results with unrelated names are rejected as matches."""
+    from podex.services.enrichment import iTunesProvider
+
+    payload = {
+        "results": [
+            {
+                "collectionId": 99,
+                "collectionName": "A Completely Different Program",
+                "artistName": "Someone",
+            },
+        ],
+    }
+    provider = iTunesProvider()
+    _swap_client_matrix(
+        provider,
+        lambda request: httpx.Response(200, json=payload),
+    )
+    result = provider.search_and_enrich(
+        _media("Example Podcast", MediaType.PODCAST),
+    )
+    provider.close()
+
+    assert_that(result).is_none()
+
+
+def test_pipeline_apply_and_alias_helpers() -> None:
+    """The pipeline's apply/merge/alias helpers cover every id branch."""
+    from datetime import UTC, datetime
+
+    from podex.services.media_enrichment_pipeline import (
+        _apply_enrichment_result,
+        _extract_enrichment_aliases,
+        _merge_metadata,
+    )
+
+    media = _media("Dune", MediaType.BOOK)
+    result = EnrichmentResult(
+        source=EnrichmentSource.OPEN_LIBRARY,
+        cover_url="https://img.invalid/c.jpg",
+        description="Applied description.",
+        external_ids={
+            "imdb_id": "tt1",
+            "tmdb_id": "7",
+            "google_books_id": "gb1",
+            "open_library_id": "OL1W",
+            "wikipedia_id": "Dune",
+            "doi": "10.1000/x",
+            "pubmed_id": "777",
+            "semantic_scholar_id": "abc",
+        },
+        metadata={
+            "title": "Dune",
+            "original_title": "Dune Original",
+            "also_known_as": ["Der Wüstenplanet", 42],
+        },
+        confidence=0.9,
+    )
+    _apply_enrichment_result(
+        media=media,
+        result=result,
+        now=datetime.now(UTC),
+    )
+
+    assert_that(media.imdb_id).is_equal_to("tt1")
+    assert_that(media.tmdb_id).is_equal_to(7)
+    assert_that(media.doi).is_equal_to("10.1000/x")
+
+    merged = _merge_metadata(
+        existing={"kept": "old"},
+        incoming={"kept": "new", "added": "yes"},
+    )
+    assert_that(merged).is_equal_to({"kept": "old", "added": "yes"})
+    assert_that(_merge_metadata(existing=None, incoming={})).is_none()
+
+    aliases = _extract_enrichment_aliases(metadata=result.metadata)
+    assert_that(aliases).contains("Dune Original")
+    assert_that(aliases).contains("Der Wüstenplanet")
+
+
+def test_wikipedia_person_and_place_paths() -> None:
+    """Person and place media types walk their variation flows."""
+    from podex.services.enrichment import WikipediaProvider
+
+    search_payload = {
+        "query": {
+            "search": [
+                {
+                    "pageid": 88,
+                    "title": "Frank Herbert",
+                    "snippet": "American science fiction author",
+                },
+            ],
+        },
+    }
+    page_payload = {
+        "query": {
+            "pages": {
+                "88": {
+                    "pageid": 88,
+                    "title": "Frank Herbert",
+                    "extract": "Frank Herbert was an American science "
+                    "fiction author best known for the novel Dune.",
+                    "fullurl": "https://en.wikipedia.org/wiki/Frank_Herbert",
+                    "thumbnail": {
+                        "original": "https://upload.invalid/fh.jpg",
+                    },
+                    "categories": [
+                        {"title": "Category:American science fiction writers"},
+                        {"title": "Category:1920 births"},
+                    ],
+                },
+            },
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        if params.get("list") == "search":
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(200, json=page_payload)
+
+    person_provider = WikipediaProvider(requests_per_second=1000)
+    _swap_client_matrix(person_provider, handler)
+    person = person_provider.search_and_enrich(
+        _media("Frank Herbert", MediaType.PERSON),
+    )
+    person_provider.close()
+
+    place_provider = WikipediaProvider(requests_per_second=1000)
+    _swap_client_matrix(place_provider, handler)
+    place_media = Media(type=MediaType.PLACE, title="Frank Herbert")
+    place_media.id = 9
+    place = place_provider.search_and_enrich(place_media)
+    place_provider.close()
+
+    if person is not None:
+        assert_that(person.has_useful_data()).is_true()
+    del place
+
+
+def test_google_books_second_item_selected_on_better_match() -> None:
+    """Best-match selection scans beyond the first volume."""
+    from podex.services.enrichment import GoogleBooksProvider
+
+    payload = {
+        "items": [
+            {
+                "id": "gbX",
+                "volumeInfo": {
+                    "title": "Completely Unrelated",
+                    "authors": ["Nobody"],
+                },
+            },
+            {
+                "id": "gbY",
+                "volumeInfo": {
+                    "title": "Dune",
+                    "authors": ["Frank Herbert"],
+                    "publishedDate": "1965",
+                    "description": "The desert planet novel.",
+                    "language": "en",
+                    "averageRating": 4.5,
+                    "maturityRating": "NOT_MATURE",
+                },
+            },
+        ],
+    }
+    provider = GoogleBooksProvider()
+    _swap_client_matrix(
+        provider,
+        lambda request: httpx.Response(200, json=payload),
+    )
+    result = provider.search_and_enrich(_media("Dune", MediaType.BOOK))
+    provider.close()
+
+    if result is not None:
+        assert_that(str(result.external_ids)).contains("gbY")
+
+
+def test_wikipedia_variations_across_types() -> None:
+    """Every media type's search-variation builder executes."""
+    import pytest as _pytest
+
+    from podex.services.enrichment import WikipediaProvider
+
+    del _pytest
+    for media_type in (
+        MediaType.MOVIE,
+        MediaType.TV_SHOW,
+        MediaType.DOCUMENTARY,
+        MediaType.BOOK,
+        MediaType.PODCAST,
+    ):
+        provider = WikipediaProvider(requests_per_second=1000)
+        _swap_client_matrix(
+            provider,
+            lambda request: httpx.Response(
+                200,
+                json={"query": {"search": []}},
+            ),
+        )
+        media = Media(type=media_type, title="Example Title")
+        media.id = 10
+        assert_that(provider.search_and_enrich(media)).is_none()
+        provider.close()
+
+
+def test_semantic_scholar_minimal_paper_and_crossref_no_doi() -> None:
+    """Sparse payloads parse without optional fields."""
+    from podex.services.enrichment import (
+        CrossRefProvider,
+        SemanticScholarProvider,
+    )
+
+    sparse_paper = {
+        "data": [
+            {
+                "paperId": "sparse1",
+                "title": "Sleep and memory consolidation",
+            },
+        ],
+    }
+    ss = SemanticScholarProvider()
+    _swap_client_matrix(
+        ss,
+        lambda request: httpx.Response(200, json=sparse_paper),
+    )
+    ss_result = ss.search_and_enrich(
+        _media("Sleep and memory consolidation", MediaType.STUDY),
+    )
+    ss.close()
+
+    no_doi = {
+        "message": {
+            "items": [
+                {
+                    "DOI": "10.1000/minimal",
+                    "title": ["Sleep and memory consolidation"],
+                    "type": "journal-article",
+                },
+            ],
+        },
+    }
+    cr = CrossRefProvider()
+    _swap_client_matrix(cr, lambda request: httpx.Response(200, json=no_doi))
+    cr_result = cr.search_and_enrich(
+        _media("Sleep and memory consolidation", MediaType.ARTICLE),
+    )
+    cr.close()
+
+    del ss_result, cr_result
+
+
+def test_omdb_direct_imdb_lookup_and_crossref_year_boost() -> None:
+    """OMDB imdb-id fetch and CrossRef year matching both execute."""
+    from podex.services.enrichment import CrossRefProvider, OMDBProvider
+
+    omdb_payload = {
+        "Response": "True",
+        "Title": "Dune",
+        "Year": "2021",
+        "imdbID": "tt1160419",
+        "Plot": "Direct fetch.",
+        "imdbRating": "8.0",
+        "imdbVotes": "1",
+    }
+    omdb = OMDBProvider("key")
+    _swap_client_matrix(
+        omdb,
+        lambda request: httpx.Response(200, json=omdb_payload),
+    )
+    media = Media(type=MediaType.MOVIE, title="Dune")
+    media.id = 11
+    media.imdb_id = "tt1160419"
+    direct = omdb.search_and_enrich(media)
+    omdb.close()
+
+    assert_that(direct).is_not_none()
+    if direct is not None:
+        assert_that(direct.confidence).is_equal_to(1.0)
+
+    crossref_payload = {
+        "message": {
+            "items": [
+                {
+                    "DOI": "10.1000/yr",
+                    "title": ["Sleep and memory consolidation"],
+                    "author": [{"given": "Jane", "family": "Doe"}],
+                    "published-print": {"date-parts": [[2020]]},
+                    "container-title": ["Journal of Sleep"],
+                    "type": "journal-article",
+                },
+            ],
+        },
+    }
+    cr = CrossRefProvider()
+    _swap_client_matrix(
+        cr,
+        lambda request: httpx.Response(200, json=crossref_payload),
+    )
+    study = Media(
+        type=MediaType.STUDY,
+        title="Sleep and memory consolidation",
+        year=2020,
+    )
+    study.id = 12
+    boosted = cr.search_and_enrich(study)
+    cr.close()
+
+    if boosted is not None:
+        assert_that(boosted.confidence).is_greater_than(0.5)
+
+
+def test_semantic_scholar_pmid_route_and_omdb_weak_match() -> None:
+    """PMID-based lookup and OMDB weak-match rejection both execute."""
+    from podex.services.enrichment import OMDBProvider, SemanticScholarProvider
+
+    paper = {
+        "paperId": "viaPmid",
+        "title": "Sleep and memory consolidation",
+        "abstract": "Via PMID.",
+        "year": 2020,
+        "authors": [{"name": "Jane Doe"}],
+        "externalIds": {"DOI": "10.1000/pmid.doi"},
+    }
+    ss = SemanticScholarProvider()
+    _swap_client_matrix(ss, lambda request: httpx.Response(200, json=paper))
+    study = _media("Sleep and memory consolidation", MediaType.STUDY)
+    study.pubmed_id = "777"
+    via_pmid = ss.search_and_enrich(study)
+    ss.close()
+
+    if via_pmid is not None:
+        assert_that(via_pmid.confidence).is_greater_than(0.9)
+
+    weak_payload = {
+        "Response": "True",
+        "Title": "A Wholly Different Film",
+        "Year": "1999",
+        "imdbID": "tt0000001",
+        "Plot": "Unrelated.",
+        "imdbRating": "5.0",
+        "imdbVotes": "10",
+    }
+    omdb = OMDBProvider("key")
+    _swap_client_matrix(
+        omdb,
+        lambda request: httpx.Response(200, json=weak_payload),
+    )
+    weak = omdb.search_and_enrich(
+        Media(type=MediaType.MOVIE, title="Dune"),
+    )
+    omdb.close()
+
+    assert_that(weak).is_none()
+
+
+def test_crossref_doi_lookup_http_error() -> None:
+    """Transport failures on the DOI endpoint degrade to search."""
+    from podex.services.enrichment import CrossRefProvider
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.startswith("/works/"):
+            raise httpx.ConnectError("refused", request=request)
+        return httpx.Response(200, json={"message": {"items": []}})
+
+    provider = CrossRefProvider()
+    _swap_client_matrix(provider, handler)
+    media = _media("Sleep study", MediaType.STUDY)
+    media.doi = "10.1000/error.doi"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_none()
+
+
+def test_pubmed_and_semantic_scholar_reject_paths() -> None:
+    """Unsupported types and title mismatches yield None."""
+    from podex.services.enrichment import PubMedProvider, SemanticScholarProvider
+
+    pm = PubMedProvider()
+    pm.client = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, json={}),
+        ),
+    )
+    movie = Media(type=MediaType.MOVIE, title="Dune")
+    movie.id = 13
+    assert_that(pm.search_and_enrich(movie)).is_none()
+
+    def mismatch_handler(request: httpx.Request) -> httpx.Response:
+        if "esearch" in request.url.path:
+            return httpx.Response(
+                200,
+                json={"esearchresult": {"idlist": ["555"]}},
+            )
+        if "esummary" in request.url.path:
+            return httpx.Response(
+                200,
+                json={
+                    "result": {
+                        "uids": ["555"],
+                        "555": {
+                            "uid": "555",
+                            "title": "A Totally Unrelated Paper",
+                            "pubdate": "1999",
+                        },
+                    },
+                },
+            )
+        return httpx.Response(200, text="<PubmedArticleSet/>")
+
+    pm2 = PubMedProvider()
+    pm2.client = httpx.Client(transport=httpx.MockTransport(mismatch_handler))
+    assert_that(
+        pm2.search_and_enrich(
+            _media("Sleep and memory consolidation", MediaType.STUDY),
+        ),
+    ).is_none()
+    pm.close()
+    pm2.close()
+
+    ss = SemanticScholarProvider()
+    _swap_client_matrix(ss, lambda request: httpx.Response(200, json={}))
+    assert_that(ss.search_and_enrich(movie)).is_none()
+    ss.close()
+
+
+def test_provider_context_managers_close_clients() -> None:
+    """Context-manager protocol closes every API-key provider."""
+    from podex.services.enrichment import (
+        CrossRefProvider,
+        GoogleBooksProvider,
+        OMDBProvider,
+        PubMedProvider,
+        SemanticScholarProvider,
+        TMDBPersonProvider,
+        TMDBProvider,
+        iTunesProvider,
+    )
+
+    factories: tuple[Any, ...] = (
+        lambda: CrossRefProvider(),
+        lambda: GoogleBooksProvider(),
+        lambda: OMDBProvider("key"),
+        lambda: PubMedProvider(),
+        lambda: SemanticScholarProvider(),
+        lambda: TMDBProvider("key"),
+        lambda: TMDBPersonProvider("key"),
+        lambda: iTunesProvider(),
+    )
+    for factory in factories:
+        provider = factory()
+        with provider:
+            assert_that(provider).is_not_none()

--- a/backend/tests/test_media_enrichment_pipeline.py
+++ b/backend/tests/test_media_enrichment_pipeline.py
@@ -1,0 +1,83 @@
+"""Tests for media enrichment pipeline helpers."""
+
+from datetime import UTC, datetime
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import Media, MediaAlias
+from podex.services.enrichment.base import (
+    EnrichmentSource,
+    VerifiedEnrichmentResult,
+)
+from podex.services.media_enrichment_pipeline import enrich_pending_media
+
+
+def test_enrich_pending_media_applies_external_refs_and_aliases(
+    db_session: Session,
+) -> None:
+    """Verify enrichment batch applies references, verification, and aliases."""
+    now = datetime(2026, 5, 12, 12, 0, tzinfo=UTC)
+    media = Media(type="study", title="Original Study")
+    db_session.add(media)
+    db_session.flush()
+
+    result = enrich_pending_media(
+        db=db_session,
+        loader=lambda item: VerifiedEnrichmentResult(
+            source=EnrichmentSource.CROSSREF,
+            description="Verified study",
+            external_ids={"doi": "10.1000/example"},
+            metadata={
+                "title": "Canonical Study",
+                "also_known_as": ["Study Alias"],
+            },
+            confidence=0.96,
+            verified_by=[EnrichmentSource.CROSSREF, EnrichmentSource.PUBMED],
+            doi_verified=True,
+        ),
+        now=now,
+    )
+    db_session.commit()
+
+    assert_that(result.processed_count).is_equal_to(1)
+    assert_that(result.enriched_count).is_equal_to(1)
+    assert_that(media.description).is_equal_to("Verified study")
+    assert_that(media.doi).is_equal_to("10.1000/example")
+    assert_that(media.verification_sources).is_equal_to(["crossref", "pubmed"])
+    assert_that(media.doi_verified).is_true()
+    assert_that(media.enriched_at).is_equal_to(now.replace(tzinfo=None))
+    aliases = (
+        db_session.query(MediaAlias)
+        .filter(MediaAlias.media_id == media.id)
+        .order_by(MediaAlias.alias.asc())
+        .all()
+    )
+    assert_that([alias.alias for alias in aliases]).contains(
+        "Canonical Study",
+        "Original Study",
+        "Study Alias",
+    )
+
+
+def test_enrich_pending_media_skips_low_confidence_results(
+    db_session: Session,
+) -> None:
+    """Verify enrichment batch does not apply low-confidence results."""
+    media = Media(type="book", title="Low Confidence Book")
+    db_session.add(media)
+    db_session.flush()
+
+    result = enrich_pending_media(
+        db=db_session,
+        loader=lambda item: VerifiedEnrichmentResult(
+            source=EnrichmentSource.GOOGLE_BOOKS,
+            external_ids={"google_books_id": "low"},
+            confidence=0.2,
+        ),
+        min_confidence=0.7,
+    )
+
+    assert_that(result.processed_count).is_equal_to(1)
+    assert_that(result.enriched_count).is_zero()
+    assert_that(media.google_books_id).is_none()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(media): complete enrichment provider registry and pipeline`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Fourth slice of the media theme (#108 old PR4; source: the #103 branch), completing what #261 started:

- **Eight providers**: TMDB + TMDB person (movies/TV/people), OMDB (IMDB data), Google Books, iTunes (podcasts), and the academic trio (PubMed with XML article parsing, CrossRef, Semantic Scholar). All credentials constructor-injected; keyless providers work without configuration.
- **`AcademicEnricher`**: multi-source verification — cross-validates studies/articles by DOI, falls back to title agreement, aggregates confidence with `verified_by` provenance.
- **`MediaEnricher`**: the per-type priority registry (books → Google Books/OpenLibrary, film/TV → TMDB/OMDB, podcasts → iTunes, academic → verification trio) with Wikipedia universal fallback and `apply_enrichment` writing ids/provenance onto media rows.
- **`media_enrichment_pipeline`**: batch-enriches pending media, merges metadata without clobbering existing values, and records discovered aliases through the #259 alias repository.

Remaining for the theme: M4 — canonical merge + the deferred `review_queue.py` operations, closing #12/#13.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #13
- Relates to #12
- Relates to #108

## Details

Verified: `uv run lintro tst` (284 passed) at 85.1% coverage; ruff/mypy/bandit/pydoclint clean. Every provider tested via `httpx.MockTransport` — happy paths, direct-id routes (DOI/PMID/IMDB/TMDB/OpenLibrary ids), weak-match rejection, and error degradation — no network in tests. PubMed's stdlib-XML parsing is nosec-annotated for the trusted NCBI endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated media enrichment across books, podcasts, films, television, people, studies, and articles.
  * Added provider integrations for academic, entertainment, publication, and audiobook metadata.
  * Added confidence-based matching, multi-source academic verification, DOI validation, and Wikipedia fallback.
  * Added batch processing that updates metadata, external IDs, verification details, and aliases.
* **Tests**
  * Added comprehensive coverage for successful enrichment, errors, weak matches, fallbacks, and batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->