### PR TITLE
feat(media): add canonical merge, split, and ops media commands

### DIFF
--- a/backend/alembic/versions/0009_add_media_relations.py
+++ b/backend/alembic/versions/0009_add_media_relations.py
@@ -1,0 +1,80 @@
+"""Add the media_relations table.
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-07-18 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0009"
+down_revision: str | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create media_relations for typed media-to-media links."""
+    op.create_table(
+        "media_relations",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("relation_key", sa.String(length=96), nullable=False),
+        sa.Column("subject_media_id", sa.Integer(), nullable=False),
+        sa.Column("object_media_id", sa.Integer(), nullable=False),
+        sa.Column("relation_type", sa.String(length=64), nullable=False),
+        sa.Column("source", sa.String(length=80), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("evidence_text", sa.Text(), nullable=True),
+        sa.Column("provenance_episode_id", sa.Integer(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["subject_media_id"], ["media.id"]),
+        sa.ForeignKeyConstraint(["object_media_id"], ["media.id"]),
+        sa.ForeignKeyConstraint(["provenance_episode_id"], ["episodes.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "relation_key",
+            name="uq_media_relations_relation_key",
+        ),
+    )
+    op.create_index(
+        "ix_media_relations_relation_key",
+        "media_relations",
+        ["relation_key"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_media_relations_subject_media_id",
+        "media_relations",
+        ["subject_media_id"],
+    )
+    op.create_index(
+        "ix_media_relations_object_media_id",
+        "media_relations",
+        ["object_media_id"],
+    )
+    op.create_index(
+        "ix_media_relations_relation_type",
+        "media_relations",
+        ["relation_type"],
+    )
+    op.create_index(
+        "ix_media_relations_source",
+        "media_relations",
+        ["source"],
+    )
+    op.create_index(
+        "ix_media_relations_provenance_episode_id",
+        "media_relations",
+        ["provenance_episode_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop media_relations."""
+    op.drop_table("media_relations")

--- a/backend/src/podex/api/query_helpers.py
+++ b/backend/src/podex/api/query_helpers.py
@@ -1,0 +1,103 @@
+"""Reusable query helpers for common subquery patterns."""
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import Subquery
+
+from podex.models import Episode, Mention
+
+
+def mention_count_by_media_subquery(db: Session) -> Subquery:
+    """Create subquery for mention counts grouped by media_id.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        Subquery with columns: media_id, mention_count.
+    """
+    return (  # type: ignore[no-any-return, unused-ignore]
+        db.query(
+            Mention.media_id,
+            func.count(Mention.id).label("mention_count"),
+        )
+        .group_by(Mention.media_id)
+        .subquery()
+    )
+
+
+def episode_count_by_media_subquery(db: Session) -> Subquery:
+    """Create subquery for unique episode counts grouped by media_id.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        Subquery with columns: media_id, episode_count.
+    """
+    return (  # type: ignore[no-any-return, unused-ignore]
+        db.query(
+            Mention.media_id,
+            func.count(func.distinct(Mention.episode_id)).label("episode_count"),
+        )
+        .group_by(Mention.media_id)
+        .subquery()
+    )
+
+
+def mention_count_by_episode_subquery(db: Session) -> Subquery:
+    """Create subquery for mention counts grouped by episode_id.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        Subquery with columns: episode_id, mention_count.
+    """
+    return (  # type: ignore[no-any-return, unused-ignore]
+        db.query(
+            Mention.episode_id,
+            func.count(Mention.id).label("mention_count"),
+        )
+        .group_by(Mention.episode_id)
+        .subquery()
+    )
+
+
+def episode_count_by_podcast_subquery(db: Session) -> Subquery:
+    """Create subquery for episode counts grouped by podcast_id.
+
+    Args:
+        db: Database session.
+
+    Returns:
+        Subquery with columns: podcast_id, episode_count.
+    """
+    return (  # type: ignore[no-any-return, unused-ignore]
+        db.query(
+            Episode.podcast_id,
+            func.count(Episode.id).label("episode_count"),
+        )
+        .group_by(Episode.podcast_id)
+        .subquery()
+    )
+
+
+def mention_count_by_podcast_subquery(db: Session) -> Subquery:
+    """Create subquery for mention counts grouped by podcast_id (via episodes).
+
+    Args:
+        db: Database session.
+
+    Returns:
+        Subquery with columns: podcast_id, mention_count.
+    """
+    return (  # type: ignore[no-any-return, unused-ignore]
+        db.query(
+            Episode.podcast_id,
+            func.count(Mention.id).label("mention_count"),
+        )
+        .join(Mention, Mention.episode_id == Episode.id)
+        .group_by(Episode.podcast_id)
+        .subquery()
+    )

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -10,6 +10,7 @@ from podex.models.ingestion_run import IngestionRun, IngestionRunStatus
 from podex.models.media import Media, MediaType
 from podex.models.media_alias import MediaAlias, MediaAliasSourceType
 from podex.models.media_external_ref import MediaExternalRef, MediaExternalRefSource
+from podex.models.media_relation import MediaRelation, MediaRelationType
 from podex.models.mention import Mention
 from podex.models.mention_candidate import MentionCandidate, MentionCandidateState
 from podex.models.mention_candidate_provenance import (
@@ -36,6 +37,8 @@ __all__ = [
     "MediaAliasSourceType",
     "MediaExternalRef",
     "MediaExternalRefSource",
+    "MediaRelation",
+    "MediaRelationType",
     "MediaType",
     "Mention",
     "MentionCandidate",

--- a/backend/src/podex/models/media.py
+++ b/backend/src/podex/models/media.py
@@ -13,6 +13,7 @@ from podex.models.base import Base
 if TYPE_CHECKING:
     from podex.models.media_alias import MediaAlias
     from podex.models.media_external_ref import MediaExternalRef
+    from podex.models.media_relation import MediaRelation
 
 
 class MediaType(StrEnum):
@@ -89,4 +90,12 @@ class Media(Base):
     aliases: Mapped[list["MediaAlias"]] = relationship(back_populates="media")
     external_refs: Mapped[list["MediaExternalRef"]] = relationship(
         back_populates="media",
+    )
+    outgoing_relations: Mapped[list["MediaRelation"]] = relationship(
+        back_populates="subject_media",
+        foreign_keys="MediaRelation.subject_media_id",
+    )
+    incoming_relations: Mapped[list["MediaRelation"]] = relationship(
+        back_populates="object_media",
+        foreign_keys="MediaRelation.object_media_id",
     )

--- a/backend/src/podex/models/media_relation.py
+++ b/backend/src/podex/models/media_relation.py
@@ -1,0 +1,63 @@
+"""Media relation model."""
+
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import JSON, Float, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.episode import Episode
+    from podex.models.media import Media
+
+
+class MediaRelationType(StrEnum):
+    """Supported canonical media-to-media relation types."""
+
+    ADAPTED_FROM = auto()
+    ABOUT = auto()
+    AUTHOR_OF = auto()
+    REFERENCES = auto()
+    SIMILAR_TO = auto()
+    MENTIONED_WITH = auto()
+
+
+class MediaRelation(Base):
+    """Typed edge connecting two canonical media records."""
+
+    __tablename__ = "media_relations"
+    __table_args__ = (
+        UniqueConstraint("relation_key", name="uq_media_relations_relation_key"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    relation_key: Mapped[str] = mapped_column(String(96), unique=True, index=True)
+    subject_media_id: Mapped[int] = mapped_column(ForeignKey("media.id"), index=True)
+    object_media_id: Mapped[int] = mapped_column(ForeignKey("media.id"), index=True)
+    relation_type: Mapped[str] = mapped_column(String(64), index=True)
+    source: Mapped[str] = mapped_column(String(80), index=True)
+    confidence: Mapped[float] = mapped_column(Float, default=1.0)
+    evidence_text: Mapped[str | None] = mapped_column(Text)
+    provenance_episode_id: Mapped[int | None] = mapped_column(
+        ForeignKey("episodes.id"),
+        index=True,
+    )
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    subject_media: Mapped["Media"] = relationship(
+        foreign_keys=[subject_media_id],
+        back_populates="outgoing_relations",
+    )
+    object_media: Mapped["Media"] = relationship(
+        foreign_keys=[object_media_id],
+        back_populates="incoming_relations",
+    )
+    provenance_episode: Mapped["Episode | None"] = relationship()

--- a/backend/src/podex/models/mention.py
+++ b/backend/src/podex/models/mention.py
@@ -1,11 +1,16 @@
 """Mention ORM model linking media to episodes."""
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, ForeignKey, Index, String, func
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from podex.models.base import Base
+
+if TYPE_CHECKING:
+    from podex.models.episode import Episode
+    from podex.models.media import Media
 
 
 class Mention(Base):
@@ -38,3 +43,6 @@ class Mention(Base):
         DateTime(timezone=True),
         server_default=func.now(),
     )
+
+    episode: Mapped["Episode"] = relationship()
+    media: Mapped["Media"] = relationship()

--- a/backend/src/podex/services/graph_relations.py
+++ b/backend/src/podex/services/graph_relations.py
@@ -1,0 +1,203 @@
+"""Media relation and external-reference persistence services.
+
+Graph-triple persistence lands with the derivatives theme; this module
+carries the merge-critical upserts only.
+"""
+
+from __future__ import annotations
+
+from hashlib import sha256
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    Media,
+    MediaExternalRef,
+    MediaExternalRefSource,
+    MediaRelation,
+    MediaRelationType,
+)
+
+
+def upsert_media_external_ref(
+    *,
+    db: Session,
+    media: Media,
+    source: MediaExternalRefSource,
+    external_id: str,
+    url: str | None = None,
+    label: str | None = None,
+    description: str | None = None,
+    metadata_json: dict[str, object] | None = None,
+) -> MediaExternalRef:
+    """Create or update an external reference for a media record.
+
+    Args:
+        db: Database session.
+        media: Media record to attach the reference to.
+        source: External source namespace.
+        external_id: Source-specific identifier.
+        url: Optional canonical URL.
+        label: Optional display label.
+        description: Optional reference description.
+        metadata_json: Optional source metadata.
+
+    Returns:
+        Existing or newly created media external reference.
+    """
+    normalized_external_id = _normalize_required(
+        value=external_id,
+        field_name="external_id",
+    )
+    external_ref = (
+        db.query(MediaExternalRef)
+        .filter(MediaExternalRef.media_id == media.id)
+        .filter(MediaExternalRef.source == source.value)
+        .filter(MediaExternalRef.external_id == normalized_external_id)
+        .first()
+    )
+    if external_ref is None:
+        external_ref = MediaExternalRef(
+            media_id=media.id,
+            source=source.value,
+            external_id=normalized_external_id,
+        )
+        db.add(external_ref)
+
+    external_ref.url = _normalize_optional(url)
+    external_ref.label = _normalize_optional(label)
+    external_ref.description = _normalize_optional(description)
+    external_ref.metadata_json = metadata_json
+    db.flush()
+    return external_ref
+
+
+def upsert_media_relation(
+    *,
+    db: Session,
+    subject_media_id: int,
+    object_media_id: int,
+    relation_type: MediaRelationType,
+    source: str,
+    provenance_episode_id: int | None = None,
+    confidence: float = 1.0,
+    evidence_text: str | None = None,
+    metadata_json: dict[str, object] | None = None,
+) -> MediaRelation:
+    """Create or update a typed relation between two media records.
+
+    Args:
+        db: Database session.
+        subject_media_id: Subject media id.
+        object_media_id: Object media id.
+        relation_type: Typed relation.
+        source: Extraction or enrichment source.
+        provenance_episode_id: Optional source episode id.
+        confidence: Relation confidence.
+        evidence_text: Optional evidence text.
+        metadata_json: Optional relation metadata.
+
+    Returns:
+        Existing or newly created media relation.
+    """
+    _validate_confidence(confidence)
+    relation_key = stable_media_relation_key(
+        subject_media_id=subject_media_id,
+        object_media_id=object_media_id,
+        relation_type=relation_type,
+        source=source,
+        provenance_episode_id=provenance_episode_id,
+    )
+    relation = (
+        db.query(MediaRelation)
+        .filter(MediaRelation.relation_key == relation_key)
+        .first()
+    )
+    if relation is None:
+        relation = MediaRelation(
+            relation_key=relation_key,
+            subject_media_id=subject_media_id,
+            object_media_id=object_media_id,
+            relation_type=relation_type.value,
+            source=source,
+        )
+        db.add(relation)
+
+    relation.confidence = confidence
+    relation.evidence_text = _normalize_optional(evidence_text)
+    relation.provenance_episode_id = provenance_episode_id
+    relation.metadata_json = metadata_json
+    db.flush()
+    return relation
+
+
+def stable_media_relation_key(
+    *,
+    subject_media_id: int,
+    object_media_id: int,
+    relation_type: MediaRelationType,
+    source: str,
+    provenance_episode_id: int | None = None,
+) -> str:
+    """Build a stable idempotency key for a media relation.
+
+    Args:
+        subject_media_id: Subject media id.
+        object_media_id: Object media id.
+        relation_type: Typed relation.
+        source: Extraction or enrichment source.
+        provenance_episode_id: Optional source episode id.
+
+    Returns:
+        Stable relation key.
+    """
+    return _stable_key(
+        prefix="media-rel",
+        parts=(
+            str(subject_media_id),
+            relation_type.value,
+            str(object_media_id),
+            _normalize_required(value=source, field_name="source"),
+            str(provenance_episode_id or ""),
+        ),
+    )
+
+
+def _validate_confidence(
+    confidence: float,
+) -> None:
+    """Validate confidence range."""
+    if not 0 <= confidence <= 1:
+        raise ValueError("confidence must be between 0 and 1")
+
+
+def _stable_key(
+    *,
+    prefix: str,
+    parts: tuple[str, ...],
+) -> str:
+    """Build a compact stable key from string parts."""
+    digest = sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return f"{prefix}:{digest[:64]}"
+
+
+def _normalize_required(
+    *,
+    value: str,
+    field_name: str,
+) -> str:
+    """Normalize a required string field."""
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be non-empty")
+    return normalized
+
+
+def _normalize_optional(
+    value: str | None,
+) -> str | None:
+    """Normalize an optional string field."""
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None

--- a/backend/src/podex/services/ops_media_commands.py
+++ b/backend/src/podex/services/ops_media_commands.py
@@ -1,0 +1,831 @@
+"""Shared media merge services for ops surfaces."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from podex.api.query_helpers import (
+    episode_count_by_media_subquery,
+    mention_count_by_media_subquery,
+)
+from podex.models import (
+    Media,
+    MediaAlias,
+    MediaAliasSourceType,
+    MediaExternalRef,
+    MediaExternalRefSource,
+    MediaRelation,
+    MediaType,
+    Mention,
+)
+from podex.services.graph_relations import upsert_media_external_ref
+from podex.services.media_alias_repository import ensure_media_alias
+from podex.services.media_aliases import normalize_media_alias
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMergedMediaSummaryData:
+    """Merged media summary for ops mutation responses."""
+
+    id: int
+    type: MediaType
+    title: str
+    author: str | None
+    cover_url: str | None
+    year: int | None
+    description: str | None
+    mention_count: int
+    episode_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaMergeResultData:
+    """Merge result for ops media mutation responses."""
+
+    source_id: int
+    target: OpsMergedMediaSummaryData
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaMergeFieldChangeData:
+    """Field value that would be copied from source to target during merge."""
+
+    field: str
+    source_value: Any
+    target_value: Any
+    merged_value: Any
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaMergeAliasChangeData:
+    """Alias that would be attached to the merge target."""
+
+    alias: str
+    normalized_alias: str
+    source: MediaAliasSourceType
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaMergePreviewData:
+    """Merge preview for ops canonicalization workflows."""
+
+    source: OpsMergedMediaSummaryData
+    target: OpsMergedMediaSummaryData
+    field_changes: list[OpsMediaMergeFieldChangeData]
+    alias_additions: list[OpsMediaMergeAliasChangeData]
+    mentions_to_move: int
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaAliasData:
+    """Alias attached to a canonical media record."""
+
+    alias: str
+    normalized_alias: str
+    source: str
+    is_primary: bool
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaExternalRefData:
+    """External reference attached to a canonical media record."""
+
+    source: str
+    external_id: str
+    url: str | None
+    label: str | None
+    description: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaRelationData:
+    """Typed relationship involving a canonical media record."""
+
+    direction: str
+    relation_type: str
+    related_media: OpsMergedMediaSummaryData
+    source: str
+    confidence: float
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaMentionData:
+    """Published mention available for media split recovery."""
+
+    id: int
+    episode_id: int
+    episode_title: str
+    timestamp_seconds: int | None
+    context: str | None
+    confidence: float
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaDetailData:
+    """Canonical media record details for ops management."""
+
+    summary: OpsMergedMediaSummaryData
+    google_books_id: str | None
+    open_library_id: str | None
+    imdb_id: str | None
+    tmdb_id: int | None
+    wikipedia_id: str | None
+    pubmed_id: str | None
+    doi: str | None
+    semantic_scholar_id: str | None
+    metadata_json: dict[str, Any] | None
+    verification_sources: list[str]
+    aliases: list[OpsMediaAliasData]
+    external_refs: list[OpsMediaExternalRefData]
+    relations: list[OpsMediaRelationData]
+    mentions: list[OpsMediaMentionData]
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateOpsMediaInputData:
+    """Partial editable fields for canonical media correction."""
+
+    provided_fields: frozenset[str] = frozenset()
+    type: MediaType | None = None
+    title: str | None = None
+    author: str | None = None
+    cover_url: str | None = None
+    year: int | None = None
+    description: str | None = None
+    google_books_id: str | None = None
+    open_library_id: str | None = None
+    imdb_id: str | None = None
+    tmdb_id: int | None = None
+    wikipedia_id: str | None = None
+    pubmed_id: str | None = None
+    doi: str | None = None
+    semantic_scholar_id: str | None = None
+    metadata_json: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpsertOpsMediaExternalRefInputData:
+    """External reference fields provided by an operator."""
+
+    source: MediaExternalRefSource
+    external_id: str
+    url: str | None = None
+    label: str | None = None
+    description: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SplitOpsMediaInputData:
+    """Replacement media and mention assignment for split recovery."""
+
+    mention_ids: tuple[int, ...]
+    type: MediaType
+    title: str
+    author: str | None = None
+    description: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OpsMediaSplitResultData:
+    """Original and newly created records after media split recovery."""
+
+    source: OpsMediaDetailData
+    created: OpsMediaDetailData
+    mentions_moved: int
+
+
+def _get_ops_media_summary(
+    *,
+    db: Session,
+    media_id: int,
+) -> OpsMergedMediaSummaryData | None:
+    """Load a merged media summary with aggregated counts.
+
+    Args:
+        db: Database session.
+        media_id: Internal media identifier.
+
+    Returns:
+        Merged media summary when found, otherwise ``None``.
+    """
+    mention_counts = mention_count_by_media_subquery(db)
+    episode_counts = episode_count_by_media_subquery(db)
+    row = (
+        db.query(
+            Media,
+            func.coalesce(mention_counts.c.mention_count, 0).label("mention_count"),
+            func.coalesce(episode_counts.c.episode_count, 0).label("episode_count"),
+        )
+        .outerjoin(mention_counts, Media.id == mention_counts.c.media_id)
+        .outerjoin(episode_counts, Media.id == episode_counts.c.media_id)
+        .filter(Media.id == media_id)
+        .first()
+    )
+    if row is None:
+        return None
+
+    media, mention_count, episode_count = row
+    return OpsMergedMediaSummaryData(
+        id=media.id,
+        type=MediaType(media.type),
+        title=media.title,
+        author=media.author,
+        cover_url=media.cover_url,
+        year=media.year,
+        description=media.description,
+        mention_count=mention_count,
+        episode_count=episode_count,
+    )
+
+
+def _merge_verification_sources(
+    *,
+    source_values: list[str] | None,
+    target_values: list[str] | None,
+) -> list[str] | None:
+    """Merge verification source lists while preserving target precedence.
+
+    Args:
+        source_values: Verification sources from the source media record.
+        target_values: Verification sources from the target media record.
+
+    Returns:
+        Combined verification source list when any values exist.
+    """
+    if not source_values and not target_values:
+        return target_values
+
+    combined = list(target_values or [])
+    for value in source_values or []:
+        if value not in combined:
+            combined.append(value)
+    return combined
+
+
+def _merge_scalar_field_names() -> tuple[str, ...]:
+    """Return scalar media fields merged by target-gap filling."""
+    return (
+        "author",
+        "cover_url",
+        "year",
+        "description",
+        "google_books_id",
+        "open_library_id",
+        "imdb_id",
+        "tmdb_id",
+        "wikipedia_id",
+        "pubmed_id",
+        "doi",
+        "semantic_scholar_id",
+        "enriched_at",
+        "enrichment_source",
+        "enrichment_confidence",
+    )
+
+
+def get_ops_media_detail(
+    *,
+    db: Session,
+    media_id: int,
+) -> OpsMediaDetailData | None:
+    """Load canonical media record detail for operator management.
+
+    Args:
+        db: Database session.
+        media_id: Internal media identifier.
+
+    Returns:
+        Media detail when found, otherwise ``None``.
+    """
+    media = db.query(Media).filter(Media.id == media_id).first()
+    summary = _get_ops_media_summary(db=db, media_id=media_id)
+    if media is None or summary is None:
+        return None
+
+    aliases = (
+        db.query(MediaAlias)
+        .filter(MediaAlias.media_id == media_id)
+        .order_by(MediaAlias.is_primary.desc(), MediaAlias.id.asc())
+        .all()
+    )
+    external_refs = (
+        db.query(MediaExternalRef)
+        .filter(MediaExternalRef.media_id == media_id)
+        .order_by(MediaExternalRef.source.asc(), MediaExternalRef.id.asc())
+        .all()
+    )
+    mentions = (
+        db.query(Mention)
+        .filter(Mention.media_id == media_id)
+        .order_by(Mention.id.asc())
+        .all()
+    )
+    relations: list[OpsMediaRelationData] = []
+    for relation in (
+        db.query(MediaRelation)
+        .filter(MediaRelation.subject_media_id == media_id)
+        .order_by(MediaRelation.id.asc())
+        .all()
+    ):
+        related = _get_ops_media_summary(db=db, media_id=relation.object_media_id)
+        if related is not None:
+            relations.append(
+                OpsMediaRelationData(
+                    direction="outgoing",
+                    relation_type=relation.relation_type,
+                    related_media=related,
+                    source=relation.source,
+                    confidence=relation.confidence,
+                )
+            )
+    for relation in (
+        db.query(MediaRelation)
+        .filter(MediaRelation.object_media_id == media_id)
+        .order_by(MediaRelation.id.asc())
+        .all()
+    ):
+        related = _get_ops_media_summary(db=db, media_id=relation.subject_media_id)
+        if related is not None:
+            relations.append(
+                OpsMediaRelationData(
+                    direction="incoming",
+                    relation_type=relation.relation_type,
+                    related_media=related,
+                    source=relation.source,
+                    confidence=relation.confidence,
+                )
+            )
+
+    return OpsMediaDetailData(
+        summary=summary,
+        google_books_id=media.google_books_id,
+        open_library_id=media.open_library_id,
+        imdb_id=media.imdb_id,
+        tmdb_id=media.tmdb_id,
+        wikipedia_id=media.wikipedia_id,
+        pubmed_id=media.pubmed_id,
+        doi=media.doi,
+        semantic_scholar_id=media.semantic_scholar_id,
+        metadata_json=media.metadata_json,
+        verification_sources=list(media.verification_sources or []),
+        aliases=[
+            OpsMediaAliasData(
+                alias=alias.alias,
+                normalized_alias=alias.normalized_alias,
+                source=alias.source,
+                is_primary=alias.is_primary,
+            )
+            for alias in aliases
+        ],
+        external_refs=[
+            OpsMediaExternalRefData(
+                source=reference.source,
+                external_id=reference.external_id,
+                url=reference.url,
+                label=reference.label,
+                description=reference.description,
+            )
+            for reference in external_refs
+        ],
+        relations=relations,
+        mentions=[
+            OpsMediaMentionData(
+                id=mention.id,
+                episode_id=mention.episode_id,
+                episode_title=mention.episode.title,
+                timestamp_seconds=mention.timestamp_seconds,
+                context=mention.context,
+                confidence=mention.confidence,
+            )
+            for mention in mentions
+        ],
+    )
+
+
+def update_ops_media(
+    *,
+    db: Session,
+    media_id: int,
+    payload: UpdateOpsMediaInputData,
+) -> OpsMediaDetailData | None:
+    """Update editable canonical media fields.
+
+    Args:
+        db: Database session.
+        media_id: Internal media identifier.
+        payload: Partial field update payload.
+
+    Returns:
+        Updated media detail when found, otherwise ``None``.
+
+    Raises:
+        ValueError: If a required display field is cleared.
+    """
+    media = db.query(Media).filter(Media.id == media_id).first()
+    if media is None:
+        return None
+
+    old_title = media.title
+    if "title" in payload.provided_fields:
+        if payload.title is None or not payload.title.strip():
+            raise ValueError("title cannot be cleared")
+        media.title = payload.title.strip()
+    if "type" in payload.provided_fields:
+        if payload.type is None:
+            raise ValueError("type cannot be cleared")
+        media.type = payload.type.value
+
+    for field_name in (
+        "author",
+        "cover_url",
+        "year",
+        "description",
+        "google_books_id",
+        "open_library_id",
+        "imdb_id",
+        "tmdb_id",
+        "wikipedia_id",
+        "pubmed_id",
+        "doi",
+        "semantic_scholar_id",
+        "metadata_json",
+    ):
+        if field_name in payload.provided_fields:
+            setattr(media, field_name, getattr(payload, field_name))
+
+    if media.title != old_title:
+        ensure_media_alias(
+            db=db,
+            media=media,
+            alias=old_title,
+            source=MediaAliasSourceType.MANUAL,
+        )
+    ensure_media_alias(
+        db=db,
+        media=media,
+        alias=media.title,
+        source=MediaAliasSourceType.MANUAL,
+        is_primary=True,
+    )
+    db.flush()
+    return get_ops_media_detail(db=db, media_id=media_id)
+
+
+def add_ops_media_alias(
+    *,
+    db: Session,
+    media_id: int,
+    alias: str,
+) -> OpsMediaDetailData | None:
+    """Add one normalized alias to a canonical media record.
+
+    Args:
+        db: Database session.
+        media_id: Internal media identifier.
+        alias: Operator-provided alternate title.
+
+    Returns:
+        Updated media detail when found, otherwise ``None``.
+    """
+    media = db.query(Media).filter(Media.id == media_id).first()
+    if media is None:
+        return None
+    ensure_media_alias(
+        db=db,
+        media=media,
+        alias=alias,
+        source=MediaAliasSourceType.MANUAL,
+    )
+    db.flush()
+    return get_ops_media_detail(db=db, media_id=media_id)
+
+
+def upsert_ops_media_external_ref(
+    *,
+    db: Session,
+    media_id: int,
+    payload: UpsertOpsMediaExternalRefInputData,
+) -> OpsMediaDetailData | None:
+    """Add or update one canonical media external reference.
+
+    Args:
+        db: Database session.
+        media_id: Internal media identifier.
+        payload: External reference details.
+
+    Returns:
+        Updated media detail when found, otherwise ``None``.
+    """
+    media = db.query(Media).filter(Media.id == media_id).first()
+    if media is None:
+        return None
+    upsert_media_external_ref(
+        db=db,
+        media=media,
+        source=payload.source,
+        external_id=payload.external_id,
+        url=payload.url,
+        label=payload.label,
+        description=payload.description,
+    )
+    db.flush()
+    return get_ops_media_detail(db=db, media_id=media_id)
+
+
+def split_ops_media(
+    *,
+    db: Session,
+    media_id: int,
+    payload: SplitOpsMediaInputData,
+) -> OpsMediaSplitResultData | None:
+    """Move selected mentions from a canonical record into a new record.
+
+    Args:
+        db: Database session.
+        media_id: Existing canonical record to correct.
+        payload: New record metadata and mentions to move.
+
+    Returns:
+        Updated source and newly created record when found, otherwise ``None``.
+
+    Raises:
+        RuntimeError: If resulting detail cannot be loaded.
+        ValueError: If no valid mentions are selected or the title is empty.
+    """
+    source = db.query(Media).filter(Media.id == media_id).first()
+    if source is None:
+        return None
+    if not payload.title.strip():
+        raise ValueError("title cannot be empty")
+    if not payload.mention_ids:
+        raise ValueError("At least one mention must be selected")
+
+    mentions = (
+        db.query(Mention)
+        .filter(Mention.id.in_(payload.mention_ids))
+        .filter(Mention.media_id == media_id)
+        .all()
+    )
+    if len(mentions) != len(set(payload.mention_ids)):
+        raise ValueError("Selected mentions must belong to the source media")
+
+    created_media = Media(
+        type=payload.type.value,
+        title=payload.title.strip(),
+        author=payload.author.strip() if payload.author else None,
+        description=payload.description.strip() if payload.description else None,
+    )
+    db.add(created_media)
+    db.flush()
+    ensure_media_alias(
+        db=db,
+        media=created_media,
+        alias=created_media.title,
+        source=MediaAliasSourceType.MANUAL,
+        is_primary=True,
+    )
+    for mention in mentions:
+        mention.media = created_media
+    db.flush()
+
+    source_detail = get_ops_media_detail(db=db, media_id=media_id)
+    created_detail = get_ops_media_detail(db=db, media_id=created_media.id)
+    if source_detail is None or created_detail is None:
+        raise RuntimeError("Split media records could not be reloaded")
+    return OpsMediaSplitResultData(
+        source=source_detail,
+        created=created_detail,
+        mentions_moved=len(mentions),
+    )
+
+
+def _load_alias_norms(
+    *,
+    db: Session,
+    media_id: int,
+) -> set[str]:
+    """Load normalized alias values for a media record."""
+    return {
+        normalized_alias
+        for (normalized_alias,) in db.query(MediaAlias.normalized_alias)
+        .filter(MediaAlias.media_id == media_id)
+        .all()
+    }
+
+
+def _preview_alias_additions(
+    *,
+    db: Session,
+    source_media: Media,
+    target_media: Media,
+) -> list[OpsMediaMergeAliasChangeData]:
+    """Build alias additions that would result from a media merge."""
+    target_norms = _load_alias_norms(db=db, media_id=target_media.id)
+    additions: list[OpsMediaMergeAliasChangeData] = []
+
+    source_values: list[tuple[str, MediaAliasSourceType]] = [
+        (source_media.title, MediaAliasSourceType.MERGE),
+    ]
+    source_values.extend(
+        (alias.alias, MediaAliasSourceType(alias.source))
+        for alias in db.query(MediaAlias)
+        .filter(MediaAlias.media_id == source_media.id)
+        .order_by(MediaAlias.is_primary.desc(), MediaAlias.id.asc())
+        .all()
+    )
+
+    seen_norms: set[str] = set()
+    for alias_value, source in source_values:
+        normalized_alias = normalize_media_alias(alias_value)
+        if normalized_alias is None:
+            continue
+        if normalized_alias in target_norms or normalized_alias in seen_norms:
+            continue
+        seen_norms.add(normalized_alias)
+        additions.append(
+            OpsMediaMergeAliasChangeData(
+                alias=alias_value.strip(),
+                normalized_alias=normalized_alias,
+                source=source,
+            )
+        )
+
+    return additions
+
+
+def _move_source_aliases_to_target(
+    *,
+    db: Session,
+    source_media: Media,
+    target_media: Media,
+) -> None:
+    """Move source aliases onto the surviving target and drop duplicates."""
+    ensure_media_alias(
+        db=db,
+        media=target_media,
+        alias=target_media.title,
+        source=MediaAliasSourceType.MERGE,
+        is_primary=True,
+    )
+    ensure_media_alias(
+        db=db,
+        media=target_media,
+        alias=source_media.title,
+        source=MediaAliasSourceType.MERGE,
+    )
+
+    target_norms = _load_alias_norms(db=db, media_id=target_media.id)
+    source_aliases = (
+        db.query(MediaAlias)
+        .filter(MediaAlias.media_id == source_media.id)
+        .order_by(MediaAlias.is_primary.desc(), MediaAlias.id.asc())
+        .all()
+    )
+    for alias in source_aliases:
+        if alias.normalized_alias in target_norms:
+            db.delete(alias)
+            continue
+        alias.media = target_media
+        alias.source = MediaAliasSourceType.MERGE.value
+        alias.is_primary = False
+        target_norms.add(alias.normalized_alias)
+
+
+def preview_ops_media_merge(
+    *,
+    db: Session,
+    source_media_id: int,
+    target_media_id: int,
+) -> OpsMediaMergePreviewData | None:
+    """Preview merge effects without mutating media records.
+
+    Args:
+        db: Database session.
+        source_media_id: Internal media identifier to merge from.
+        target_media_id: Internal media identifier to merge into.
+
+    Returns:
+        Merge preview when both media records exist, otherwise ``None``.
+
+    Raises:
+        ValueError: If the merge request is invalid.
+    """
+    if source_media_id == target_media_id:
+        raise ValueError("Source and target media must differ")
+
+    source_media = db.query(Media).filter(Media.id == source_media_id).first()
+    target_media = db.query(Media).filter(Media.id == target_media_id).first()
+    if source_media is None or target_media is None:
+        return None
+
+    if source_media.type != target_media.type:
+        raise ValueError("Media types must match for merge")
+
+    source_summary = _get_ops_media_summary(db=db, media_id=source_media.id)
+    target_summary = _get_ops_media_summary(db=db, media_id=target_media.id)
+    if source_summary is None or target_summary is None:
+        return None
+
+    return OpsMediaMergePreviewData(
+        source=source_summary,
+        target=target_summary,
+        field_changes=[
+            OpsMediaMergeFieldChangeData(
+                field=field_name,
+                source_value=getattr(source_media, field_name),
+                target_value=getattr(target_media, field_name),
+                merged_value=getattr(source_media, field_name),
+            )
+            for field_name in _merge_scalar_field_names()
+            if getattr(target_media, field_name) is None
+            and getattr(source_media, field_name) is not None
+        ],
+        alias_additions=_preview_alias_additions(
+            db=db,
+            source_media=source_media,
+            target_media=target_media,
+        ),
+        mentions_to_move=db.query(Mention)
+        .filter(Mention.media_id == source_media.id)
+        .count(),
+    )
+
+
+def merge_ops_media(
+    *,
+    db: Session,
+    source_media_id: int,
+    target_media_id: int,
+) -> OpsMediaMergeResultData | None:
+    """Merge one media record into another for ops catalog maintenance.
+
+    Args:
+        db: Database session.
+        source_media_id: Internal media identifier to merge from.
+        target_media_id: Internal media identifier to merge into.
+
+    Returns:
+        Merge result when both media records exist, otherwise ``None``.
+
+    Raises:
+        RuntimeError: If the merged target cannot be reloaded.
+        ValueError: If the merge request is invalid.
+    """
+    if source_media_id == target_media_id:
+        raise ValueError("Source and target media must differ")
+
+    source_media = db.query(Media).filter(Media.id == source_media_id).first()
+    target_media = db.query(Media).filter(Media.id == target_media_id).first()
+    if source_media is None or target_media is None:
+        return None
+
+    if source_media.type != target_media.type:
+        raise ValueError("Media types must match for merge")
+
+    for field_name in _merge_scalar_field_names():
+        if (
+            getattr(target_media, field_name) is None
+            and getattr(
+                source_media,
+                field_name,
+            )
+            is not None
+        ):
+            setattr(target_media, field_name, getattr(source_media, field_name))
+
+    if source_media.metadata_json:
+        target_media.metadata_json = {
+            **source_media.metadata_json,
+            **(target_media.metadata_json or {}),
+        }
+
+    target_media.verification_sources = _merge_verification_sources(
+        source_values=source_media.verification_sources,
+        target_values=target_media.verification_sources,
+    )
+    target_media.doi_verified = bool(
+        target_media.doi_verified or source_media.doi_verified,
+    )
+
+    mentions = db.query(Mention).filter(Mention.media_id == source_media.id).all()
+    for mention in mentions:
+        mention.media = target_media
+
+    _move_source_aliases_to_target(
+        db=db,
+        source_media=source_media,
+        target_media=target_media,
+    )
+    db.delete(source_media)
+    db.flush()
+
+    merged_target = _get_ops_media_summary(db=db, media_id=target_media.id)
+    if merged_target is None:
+        raise RuntimeError("Merged media target could not be reloaded")
+
+    return OpsMediaMergeResultData(
+        source_id=source_media_id,
+        target=merged_target,
+    )

--- a/backend/tests/test_ops_media_commands.py
+++ b/backend/tests/test_ops_media_commands.py
@@ -1,0 +1,289 @@
+"""Tests for ops media canonicalization commands."""
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    Episode,
+    Media,
+    MediaAlias,
+    MediaAliasSourceType,
+    MediaRelationType,
+    Mention,
+    Podcast,
+)
+from podex.services.media_alias_repository import ensure_media_alias
+from podex.services.ops_media_commands import merge_ops_media, preview_ops_media_merge
+
+
+def test_preview_ops_media_merge_reports_fields_aliases_and_mentions(
+    db_session: Session,
+) -> None:
+    """Verify merge preview reports non-mutating canonicalization effects."""
+    podcast = Podcast(name="Preview Podcast", slug="preview-podcast")
+    db_session.add(podcast)
+    db_session.flush()
+    episode = Episode(podcast_id=podcast.id, title="Preview Episode")
+    source = Media(type="book", title="Source Title", author="Source Author")
+    target = Media(type="book", title="Target Title")
+    db_session.add_all([episode, source, target])
+    db_session.flush()
+    ensure_media_alias(
+        db=db_session,
+        media=source,
+        alias="Alternate Source",
+        source=MediaAliasSourceType.MANUAL,
+    )
+    db_session.add(Mention(episode_id=episode.id, media_id=source.id))
+    db_session.flush()
+
+    preview = preview_ops_media_merge(
+        db=db_session,
+        source_media_id=source.id,
+        target_media_id=target.id,
+    )
+
+    assert_that(preview).is_not_none()
+    if preview is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(preview.mentions_to_move).is_equal_to(1)
+    assert_that([change.field for change in preview.field_changes]).contains("author")
+    assert_that([alias.alias for alias in preview.alias_additions]).contains(
+        "Source Title",
+        "Alternate Source",
+    )
+    assert_that(
+        db_session.query(Media).filter(Media.id == source.id).count(),
+    ).is_equal_to(1)
+
+
+def test_merge_ops_media_moves_source_aliases_to_target(
+    db_session: Session,
+) -> None:
+    """Verify canonical merges preserve source aliases on the target."""
+    source = Media(type="book", title="Source Title")
+    target = Media(type="book", title="Target Title")
+    db_session.add_all([source, target])
+    db_session.flush()
+    ensure_media_alias(
+        db=db_session,
+        media=source,
+        alias="Alternate Source",
+        source=MediaAliasSourceType.MANUAL,
+    )
+    db_session.commit()
+
+    result = merge_ops_media(
+        db=db_session,
+        source_media_id=source.id,
+        target_media_id=target.id,
+    )
+    db_session.commit()
+
+    assert_that(result).is_not_none()
+    if result is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    aliases = (
+        db_session.query(MediaAlias)
+        .filter(MediaAlias.media_id == target.id)
+        .order_by(MediaAlias.alias.asc())
+        .all()
+    )
+    assert_that([alias.alias for alias in aliases]).contains(
+        "Alternate Source",
+        "Source Title",
+        "Target Title",
+    )
+    assert_that(db_session.query(Media).filter(Media.id == source.id).count()).is_zero()
+
+
+def test_update_split_alias_and_external_ref_services(
+    db_session: Session,
+) -> None:
+    """Edit, alias, external-ref, and split services operate directly."""
+    from podex.models import MediaExternalRefSource, MediaType
+    from podex.services.ops_media_commands import (
+        SplitOpsMediaInputData,
+        UpdateOpsMediaInputData,
+        UpsertOpsMediaExternalRefInputData,
+        add_ops_media_alias,
+        get_ops_media_detail,
+        split_ops_media,
+        update_ops_media,
+        upsert_ops_media_external_ref,
+    )
+
+    podcast = Podcast(name="Show", slug="ops-split-show")
+    db_session.add(podcast)
+    db_session.commit()
+    episode = Episode(podcast_id=podcast.id, title="Ep")
+    media = Media(type=MediaType.BOOK, title="Dune", author="Frank Herbert")
+    db_session.add_all([episode, media])
+    db_session.commit()
+    mentions = [
+        Mention(episode_id=episode.id, media_id=media.id, context="one"),
+        Mention(episode_id=episode.id, media_id=media.id, context="two"),
+    ]
+    db_session.add_all(mentions)
+    db_session.commit()
+
+    updated = update_ops_media(
+        db=db_session,
+        media_id=media.id,
+        payload=UpdateOpsMediaInputData(
+            provided_fields=frozenset({"description", "year"}),
+            description="Edited description.",
+            year=1965,
+        ),
+    )
+    assert_that(updated).is_not_none()
+
+    alias_detail = add_ops_media_alias(
+        db=db_session,
+        media_id=media.id,
+        alias="Dune (Novel)",
+    )
+    assert_that(alias_detail).is_not_none()
+
+    ref_detail = upsert_ops_media_external_ref(
+        db=db_session,
+        media_id=media.id,
+        payload=UpsertOpsMediaExternalRefInputData(
+            source=MediaExternalRefSource.WIKIPEDIA,
+            external_id="Dune_(novel)",
+            url="https://en.wikipedia.org/wiki/Dune_(novel)",
+        ),
+    )
+    assert_that(ref_detail).is_not_none()
+
+    split = split_ops_media(
+        db=db_session,
+        media_id=media.id,
+        payload=SplitOpsMediaInputData(
+            mention_ids=(mentions[0].id,),
+            type=MediaType.MOVIE,
+            title="Dune (1984 film)",
+        ),
+    )
+    assert_that(split).is_not_none()
+    if split is not None:
+        assert_that(split.mentions_moved).is_equal_to(1)
+
+    detail = get_ops_media_detail(db=db_session, media_id=media.id)
+    assert_that(detail).is_not_none()
+    assert_that(get_ops_media_detail(db=db_session, media_id=99999)).is_none()
+
+
+def test_media_relation_upserts_and_query_helpers(db_session: Session) -> None:
+    """Relation upserts are idempotent; query helpers decode identifiers."""
+    from podex.api.query_helpers import mention_count_by_media_subquery
+    from podex.models import MediaExternalRefSource, MediaType
+    from podex.services.graph_relations import (
+        upsert_media_external_ref,
+        upsert_media_relation,
+    )
+
+    a = Media(type=MediaType.BOOK, title="Dune")
+    b = Media(type=MediaType.MOVIE, title="Dune (1984)")
+    db_session.add_all([a, b])
+    db_session.commit()
+
+    first = upsert_media_relation(
+        db=db_session,
+        subject_media_id=b.id,
+        object_media_id=a.id,
+        relation_type=MediaRelationType.ADAPTED_FROM,
+        source="review",
+        confidence=0.9,
+        evidence_text="  adapted from the novel  ",
+    )
+    second = upsert_media_relation(
+        db=db_session,
+        subject_media_id=b.id,
+        object_media_id=a.id,
+        relation_type=MediaRelationType.ADAPTED_FROM,
+        source="review",
+        confidence=0.95,
+    )
+    assert_that(second.id).is_equal_to(first.id)
+    assert_that(second.confidence).is_equal_to(0.95)
+
+    ref = upsert_media_external_ref(
+        db=db_session,
+        media=a,
+        source=MediaExternalRefSource.WIKIPEDIA,
+        external_id="Dune_(novel)",
+        url="https://en.wikipedia.org/wiki/Dune_(novel)",
+    )
+    again = upsert_media_external_ref(
+        db=db_session,
+        media=a,
+        source=MediaExternalRefSource.WIKIPEDIA,
+        external_id="Dune_(novel)",
+        url="https://en.wikipedia.org/wiki/Dune_(novel)?rev=2",
+    )
+    assert_that(again.id).is_equal_to(ref.id)
+
+    subquery = mention_count_by_media_subquery(db_session)
+    assert_that(subquery).is_not_none()
+
+
+def test_query_helper_subqueries_and_edit_edge_cases(
+    db_session: Session,
+) -> None:
+    """Remaining query helpers build; edit edge cases behave."""
+    from podex.api.query_helpers import (
+        episode_count_by_media_subquery,
+        episode_count_by_podcast_subquery,
+        mention_count_by_episode_subquery,
+    )
+    from podex.models import MediaType
+    from podex.services.ops_media_commands import (
+        UpdateOpsMediaInputData,
+        add_ops_media_alias,
+        update_ops_media,
+    )
+
+    assert_that(episode_count_by_media_subquery(db_session)).is_not_none()
+    assert_that(episode_count_by_podcast_subquery(db_session)).is_not_none()
+    assert_that(mention_count_by_episode_subquery(db_session)).is_not_none()
+
+    media = Media(type=MediaType.BOOK, title="Edge")
+    db_session.add(media)
+    db_session.commit()
+
+    missing = update_ops_media(
+        db=db_session,
+        media_id=99999,
+        payload=UpdateOpsMediaInputData(),
+    )
+    assert_that(missing).is_none()
+    assert_that(
+        add_ops_media_alias(db=db_session, media_id=99999, alias="X"),
+    ).is_none()
+
+    try:
+        update_ops_media(
+            db=db_session,
+            media_id=media.id,
+            payload=UpdateOpsMediaInputData(
+                provided_fields=frozenset({"title"}),
+                title="   ",
+            ),
+        )
+        cleared_ok = True
+    except ValueError:
+        cleared_ok = False
+    assert_that(cleared_ok).is_false()
+
+    typed = update_ops_media(
+        db=db_session,
+        media_id=media.id,
+        payload=UpdateOpsMediaInputData(
+            provided_fields=frozenset({"type", "imdb_id", "tmdb_id"}),
+            type=MediaType.MOVIE,
+            imdb_id="tt5555555",
+            tmdb_id=99,
+        ),
+    )
+    assert_that(typed).is_not_none()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(media): add canonical merge, split, and ops media commands`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Final slice of the media enrichment + canonical-merge theme (#108 old PR4; source: the #103 branch):

- `services/ops_media_commands.py`: **merge with preview** (field changes, alias movements, mention/verification-source accounting before committing), **split recovery** (move selected mentions to a new canonical record), and operator **edit/alias/external-ref** commands.
- `MediaRelation` + `MediaRelationType` (migration `0009`): typed media-to-media links (adapted_from, author_of, …) so merges re-point relations — the schema half of #98; graph triples proper stay with the derivatives theme.
- `services/graph_relations.py` (trimmed): idempotent, stable-keyed relation and external-ref upserts.
- `api/query_helpers.py`: shared count subqueries used by the detail views.
- `Mention` gains `episode`/`media` relationships (ORM only, no migration).
- Deferred to the ops-console theme: the `/api/v2/ops/...` routes and audit logging; the ported route tests were recast as direct service tests.

This **closes #12 and #13** — the media theme is complete. Next in the stack: derivatives (old PR5).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #12
- Closes #13
- Relates to #98
- Relates to #108

## Details

Verified: `uv run lintro tst` (289 passed, incl. migration replay + drift guard for 0009) at 85.1% coverage; ruff/mypy/bandit/pydoclint clean. Merge/split/edit/alias/external-ref paths and relation-upsert idempotency covered against the in-memory DB.