### PR TITLE
feat(derivatives): add chunking, summaries, triples, and orchestration

### DIFF
--- a/backend/src/podex/services/derivative_coverage.py
+++ b/backend/src/podex/services/derivative_coverage.py
@@ -1,0 +1,148 @@
+"""Derivative coverage gates for raw transcript retention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum, auto
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    DerivativeSummaryStatus,
+    Episode,
+    EpisodeSummary,
+    GraphTriple,
+    MediaSummary,
+    Mention,
+    SemanticChunk,
+)
+
+
+class PublicDerivativeQueryClass(StrEnum):
+    """Public query classes that must survive raw transcript purge."""
+
+    EPISODE_DETAIL = auto()
+    EPISODE_SNIPPETS = auto()
+    GLOBAL_SEARCH = auto()
+    MEDIA_DETAIL = auto()
+    MEDIA_MENTIONS = auto()
+    RELATED_ENTITIES = auto()
+    TRENDS = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class DerivativeCoverageResultData:
+    """Derivative coverage result for a single episode."""
+
+    episode_id: int
+    purge_safe: bool
+    covered_query_classes: tuple[PublicDerivativeQueryClass, ...]
+    missing_query_classes: tuple[PublicDerivativeQueryClass, ...]
+    missing_reasons: dict[str, str]
+
+
+def evaluate_episode_derivative_coverage(
+    *,
+    db: Session,
+    episode: Episode,
+) -> DerivativeCoverageResultData:
+    """Evaluate whether derivatives cover public queries for an episode.
+
+    Args:
+        db: Database session.
+        episode: Episode whose raw transcript may become purge eligible.
+
+    Returns:
+        Coverage result used to gate raw transcript purge.
+    """
+    coverage = _coverage_state(db=db, episode=episode)
+    missing_reasons: dict[PublicDerivativeQueryClass, str] = {}
+    if not coverage["has_episode_summary"]:
+        missing_reasons[PublicDerivativeQueryClass.EPISODE_DETAIL] = (
+            "missing ready episode summary"
+        )
+    if not coverage["has_semantic_chunks"]:
+        missing_reasons[PublicDerivativeQueryClass.EPISODE_SNIPPETS] = (
+            "missing semantic chunks"
+        )
+    if not (
+        coverage["has_semantic_chunks"]
+        and coverage["has_episode_summary"]
+        and coverage["all_media_summarized"]
+    ):
+        missing_reasons[PublicDerivativeQueryClass.GLOBAL_SEARCH] = (
+            "missing summary or semantic chunk derivatives"
+        )
+    if not coverage["all_media_summarized"]:
+        missing_reasons[PublicDerivativeQueryClass.MEDIA_DETAIL] = (
+            "missing ready summaries for mentioned media"
+        )
+    if not coverage["has_mentions"]:
+        missing_reasons[PublicDerivativeQueryClass.MEDIA_MENTIONS] = (
+            "missing structured mentions"
+        )
+    if not coverage["has_graph_triples"]:
+        missing_reasons[PublicDerivativeQueryClass.RELATED_ENTITIES] = (
+            "missing graph triples"
+        )
+    if not coverage["has_mentions"]:
+        missing_reasons[PublicDerivativeQueryClass.TRENDS] = (
+            "missing structured mentions for trend counts"
+        )
+
+    missing = tuple(missing_reasons)
+    covered = tuple(
+        query_class
+        for query_class in PublicDerivativeQueryClass
+        if query_class not in missing_reasons
+    )
+    return DerivativeCoverageResultData(
+        episode_id=episode.id,
+        purge_safe=not missing,
+        covered_query_classes=covered,
+        missing_query_classes=missing,
+        missing_reasons={
+            query_class.value: reason for query_class, reason in missing_reasons.items()
+        },
+    )
+
+
+def _coverage_state(
+    *,
+    db: Session,
+    episode: Episode,
+) -> dict[str, bool]:
+    """Collect derivative coverage booleans for an episode."""
+    mentioned_media_ids = [
+        media_id
+        for (media_id,) in db.query(Mention.media_id)
+        .filter(Mention.episode_id == episode.id)
+        .distinct()
+        .all()
+    ]
+    summarized_media_ids = {
+        media_id
+        for (media_id,) in db.query(MediaSummary.media_id)
+        .filter(MediaSummary.media_id.in_(mentioned_media_ids or [-1]))
+        .filter(MediaSummary.status == DerivativeSummaryStatus.READY.value)
+        .distinct()
+        .all()
+    }
+    return {
+        "has_episode_summary": db.query(EpisodeSummary)
+        .filter(EpisodeSummary.episode_id == episode.id)
+        .filter(EpisodeSummary.status == DerivativeSummaryStatus.READY.value)
+        .first()
+        is not None,
+        "has_semantic_chunks": db.query(SemanticChunk)
+        .filter(SemanticChunk.episode_id == episode.id)
+        .first()
+        is not None,
+        "has_mentions": bool(mentioned_media_ids),
+        "all_media_summarized": bool(mentioned_media_ids)
+        and set(mentioned_media_ids).issubset(summarized_media_ids),
+        "has_graph_triples": db.query(GraphTriple)
+        .filter(GraphTriple.provenance_episode_id == episode.id)
+        .first()
+        is not None,
+    }

--- a/backend/src/podex/services/derivative_generation.py
+++ b/backend/src/podex/services/derivative_generation.py
@@ -1,0 +1,325 @@
+"""Replay-safe derivative generation orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    DerivativeGenerationRun,
+    DerivativeGenerationRunStatus,
+    Episode,
+    Media,
+    Mention,
+    Transcript,
+)
+from podex.services.derivative_summaries import (
+    SummaryProvider,
+    build_episode_summary_source,
+    generate_episode_summary,
+    generate_media_summary,
+    stable_source_text_hash,
+)
+from podex.services.graph_relations import GraphTripleInputData, upsert_graph_triple
+from podex.services.semantic_chunks import (
+    EmbeddingProvider,
+    SemanticChunkingPolicy,
+    sync_semantic_chunks_for_transcript,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DerivativeGenerationConfig:
+    """Versioned configuration for derivative generation."""
+
+    pipeline_version: str = "derivative-generation-v1"
+    chunk_pipeline_version: str = "semantic-chunk-v1"
+    summary_prompt_version: str = "summary-prompt-v1"
+
+
+def generate_episode_derivatives(
+    *,
+    db: Session,
+    episode: Episode,
+    config: DerivativeGenerationConfig | None = None,
+    transcript: Transcript | None = None,
+    embedding_provider: EmbeddingProvider | None = None,
+    summary_provider: SummaryProvider | None = None,
+    chunking_policy: SemanticChunkingPolicy | None = None,
+    graph_triples: list[GraphTripleInputData] | None = None,
+    now: datetime | None = None,
+) -> DerivativeGenerationRun:
+    """Generate durable derivatives for a single episode.
+
+    Args:
+        db: Database session.
+        episode: Episode to process.
+        config: Versioned derivative generation configuration.
+        transcript: Optional transcript source; latest episode transcript is used
+            when omitted.
+        embedding_provider: Optional embedding provider for semantic chunks.
+        summary_provider: Optional summary provider for episode and media summaries.
+        chunking_policy: Optional semantic chunking policy.
+        graph_triples: Optional graph triples to upsert with this run.
+        now: Optional timestamp for deterministic tests.
+
+    Returns:
+        Persisted derivative generation run summary.
+    """
+    effective_config = config or DerivativeGenerationConfig()
+    effective_now = now or datetime.now(UTC)
+    effective_transcript = transcript or _latest_transcript(db=db, episode=episode)
+    source_text_hash = _run_source_hash(
+        db=db,
+        episode=episode,
+        transcript=effective_transcript,
+    )
+    effective_policy = chunking_policy or SemanticChunkingPolicy(
+        pipeline_version=effective_config.chunk_pipeline_version,
+    )
+    run = _upsert_generation_run(
+        db=db,
+        episode=episode,
+        transcript=effective_transcript,
+        config=effective_config,
+        summary_model=summary_provider.model_name if summary_provider else None,
+        source_text_hash=source_text_hash,
+        started_at=effective_now,
+    )
+
+    semantic_result = None
+    if effective_transcript is not None:
+        semantic_result = sync_semantic_chunks_for_transcript(
+            db=db,
+            transcript=effective_transcript,
+            embedding_provider=embedding_provider,
+            policy=effective_policy,
+            now=effective_now,
+        )
+
+    episode_summary = None
+    media_summary_count = 0
+    if summary_provider is not None:
+        episode_summary = generate_episode_summary(
+            db=db,
+            episode=episode,
+            provider=summary_provider,
+            pipeline_version=effective_config.pipeline_version,
+            prompt_version=effective_config.summary_prompt_version,
+            generated_at=effective_now,
+        )
+        for media in _episode_media(db=db, episode=episode):
+            generate_media_summary(
+                db=db,
+                media=media,
+                provider=summary_provider,
+                pipeline_version=effective_config.pipeline_version,
+                prompt_version=effective_config.summary_prompt_version,
+                generated_at=effective_now,
+            )
+            media_summary_count += 1
+
+    graph_triple_count = 0
+    for graph_triple in graph_triples or []:
+        upsert_graph_triple(db=db, payload=graph_triple)
+        graph_triple_count += 1
+
+    run.status = DerivativeGenerationRunStatus.COMPLETED.value
+    run.episode_summary_id = episode_summary.id if episode_summary else None
+    run.semantic_chunks_created = (
+        semantic_result.created_count if semantic_result is not None else 0
+    )
+    run.semantic_chunks_updated = (
+        semantic_result.updated_count if semantic_result is not None else 0
+    )
+    run.semantic_chunks_deleted = (
+        semantic_result.deleted_count if semantic_result is not None else 0
+    )
+    run.semantic_chunks_embedded = (
+        semantic_result.embedded_count if semantic_result is not None else 0
+    )
+    run.semantic_chunks_failed = (
+        semantic_result.failed_count if semantic_result is not None else 0
+    )
+    run.media_summaries_generated = media_summary_count
+    run.graph_triples_upserted = graph_triple_count
+    run.completed_at = effective_now
+    run.error_message = None
+    run.metadata_json = {
+        "semantic_chunk_keys": (
+            list(semantic_result.chunk_keys) if semantic_result is not None else []
+        ),
+    }
+    db.flush()
+    return run
+
+
+def stable_derivative_generation_run_key(
+    *,
+    episode_id: int,
+    transcript_id: int | None,
+    pipeline_version: str,
+    chunk_pipeline_version: str,
+    summary_prompt_version: str,
+    summary_model: str | None,
+    source_text_hash: str,
+) -> str:
+    """Build a stable idempotency key for a derivative generation run.
+
+    Args:
+        episode_id: Episode id.
+        transcript_id: Optional transcript id.
+        pipeline_version: Derivative orchestration version.
+        chunk_pipeline_version: Semantic chunk pipeline version.
+        summary_prompt_version: Summary prompt version.
+        summary_model: Optional summary model version.
+        source_text_hash: Hash of summarized source text.
+
+    Returns:
+        Stable derivative run key.
+    """
+    digest = sha256(
+        "|".join(
+            (
+                str(episode_id),
+                str(transcript_id or ""),
+                _normalize_required(
+                    value=pipeline_version,
+                    field_name="pipeline_version",
+                ),
+                _normalize_required(
+                    value=chunk_pipeline_version,
+                    field_name="chunk_pipeline_version",
+                ),
+                _normalize_required(
+                    value=summary_prompt_version,
+                    field_name="summary_prompt_version",
+                ),
+                summary_model or "",
+                _normalize_source_hash(source_text_hash),
+            ),
+        ).encode("utf-8"),
+    ).hexdigest()
+    return f"derivative-run:{digest[:64]}"
+
+
+def _upsert_generation_run(
+    *,
+    db: Session,
+    episode: Episode,
+    transcript: Transcript | None,
+    config: DerivativeGenerationConfig,
+    summary_model: str | None,
+    source_text_hash: str,
+    started_at: datetime,
+) -> DerivativeGenerationRun:
+    """Create or reset a derivative generation run record."""
+    run_key = stable_derivative_generation_run_key(
+        episode_id=episode.id,
+        transcript_id=transcript.id if transcript is not None else None,
+        pipeline_version=config.pipeline_version,
+        chunk_pipeline_version=config.chunk_pipeline_version,
+        summary_prompt_version=config.summary_prompt_version,
+        summary_model=summary_model,
+        source_text_hash=source_text_hash,
+    )
+    run = (
+        db.query(DerivativeGenerationRun)
+        .filter(DerivativeGenerationRun.run_key == run_key)
+        .first()
+    )
+    if run is None:
+        run = DerivativeGenerationRun(
+            run_key=run_key,
+            episode_id=episode.id,
+            transcript_id=transcript.id if transcript is not None else None,
+            pipeline_version=config.pipeline_version,
+            chunk_pipeline_version=config.chunk_pipeline_version,
+            summary_prompt_version=config.summary_prompt_version,
+            summary_model=summary_model,
+            source_text_hash=source_text_hash,
+            started_at=started_at,
+        )
+        db.add(run)
+
+    run.status = DerivativeGenerationRunStatus.RUNNING.value
+    run.started_at = started_at
+    run.completed_at = None
+    run.error_message = None
+    db.flush()
+    return run
+
+
+def _run_source_hash(
+    *,
+    db: Session,
+    episode: Episode,
+    transcript: Transcript | None,
+) -> str:
+    """Build a source hash for the orchestration run."""
+    if transcript is not None:
+        return str(
+            stable_source_text_hash(
+                transcript.cleaned_text or transcript.raw_text or "",
+            ),
+        )
+    source = build_episode_summary_source(db=db, episode=episode)
+    return str(source.source_text_hash)
+
+
+def _latest_transcript(
+    *,
+    db: Session,
+    episode: Episode,
+) -> Transcript | None:
+    """Return the newest transcript for an episode."""
+    return (
+        db.query(Transcript)
+        .filter(Transcript.episode_id == episode.id)
+        .order_by(Transcript.id.desc())
+        .first()
+    )
+
+
+def _episode_media(
+    *,
+    db: Session,
+    episode: Episode,
+) -> list[Media]:
+    """Return media mentioned in an episode exactly once."""
+    return list(
+        db.query(Media)
+        .join(Mention, Mention.media_id == Media.id)
+        .filter(Mention.episode_id == episode.id)
+        .order_by(Media.id)
+        .distinct()
+        .all(),
+    )
+
+
+def _normalize_source_hash(
+    source_text_hash: str,
+) -> str:
+    """Validate and normalize a source text hash."""
+    normalized = _normalize_required(
+        value=source_text_hash,
+        field_name="source_text_hash",
+    )
+    if len(normalized) != 64:
+        raise ValueError("source_text_hash must be a SHA-256 hex digest")
+    return normalized
+
+
+def _normalize_required(
+    *,
+    value: str,
+    field_name: str,
+) -> str:
+    """Normalize a required string field."""
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be non-empty")
+    return normalized

--- a/backend/src/podex/services/derivative_summaries.py
+++ b/backend/src/podex/services/derivative_summaries.py
@@ -1,0 +1,592 @@
+"""Derivative summary generation and persistence services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import Protocol
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    DerivativeSummaryKind,
+    DerivativeSummaryStatus,
+    Episode,
+    EpisodeSummary,
+    Media,
+    MediaSummary,
+    Mention,
+    SemanticChunk,
+    Transcript,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SummarySourceData:
+    """Source material used to generate a derivative summary."""
+
+    resource_kind: str
+    resource_id: int
+    source_text: str
+    source_text_hash: str
+    metadata_json: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratedSummaryData:
+    """Generated narrative summary payload."""
+
+    summary_text: str
+    short_summary: str | None = None
+    highlights: list[str] | None = None
+    citations: list[dict[str, object]] | None = None
+    metadata_json: dict[str, object] | None = None
+
+
+class SummaryProvider(Protocol):
+    """Port implemented by LLM or deterministic summary generators."""
+
+    model_name: str
+
+    def summarize(
+        self,
+        source: SummarySourceData,
+    ) -> GeneratedSummaryData:
+        """Generate a summary from source material.
+
+        Args:
+            source: Source material and provenance metadata.
+
+        Returns:
+            Generated summary payload.
+        """
+
+
+def generate_episode_summary(
+    *,
+    db: Session,
+    episode: Episode,
+    provider: SummaryProvider,
+    summary_kind: DerivativeSummaryKind = DerivativeSummaryKind.OVERVIEW,
+    pipeline_version: str,
+    prompt_version: str,
+    generated_at: datetime | None = None,
+) -> EpisodeSummary:
+    """Generate and persist an episode summary.
+
+    Args:
+        db: Database session.
+        episode: Episode to summarize.
+        provider: Summary generation provider.
+        summary_kind: Narrative summary kind.
+        pipeline_version: Derivative pipeline version.
+        prompt_version: Summary prompt version.
+        generated_at: Optional generation timestamp.
+
+    Returns:
+        Persisted episode summary.
+    """
+    source = build_episode_summary_source(db=db, episode=episode)
+    generated = provider.summarize(source)
+    return upsert_episode_summary(
+        db=db,
+        episode=episode,
+        summary_kind=summary_kind,
+        pipeline_version=pipeline_version,
+        prompt_version=prompt_version,
+        source_model=provider.model_name,
+        source_text_hash=source.source_text_hash,
+        summary_text=generated.summary_text,
+        short_summary=generated.short_summary,
+        highlights_json=generated.highlights,
+        citations_json=generated.citations,
+        metadata_json={
+            **source.metadata_json,
+            **(generated.metadata_json or {}),
+        },
+        generated_at=generated_at,
+    )
+
+
+def generate_media_summary(
+    *,
+    db: Session,
+    media: Media,
+    provider: SummaryProvider,
+    summary_kind: DerivativeSummaryKind = DerivativeSummaryKind.OVERVIEW,
+    pipeline_version: str,
+    prompt_version: str,
+    generated_at: datetime | None = None,
+) -> MediaSummary:
+    """Generate and persist a media summary.
+
+    Args:
+        db: Database session.
+        media: Media entity to summarize.
+        provider: Summary generation provider.
+        summary_kind: Narrative summary kind.
+        pipeline_version: Derivative pipeline version.
+        prompt_version: Summary prompt version.
+        generated_at: Optional generation timestamp.
+
+    Returns:
+        Persisted media summary.
+    """
+    source = build_media_summary_source(db=db, media=media)
+    generated = provider.summarize(source)
+    return upsert_media_summary(
+        db=db,
+        media=media,
+        summary_kind=summary_kind,
+        pipeline_version=pipeline_version,
+        prompt_version=prompt_version,
+        source_model=provider.model_name,
+        source_text_hash=source.source_text_hash,
+        summary_text=generated.summary_text,
+        short_summary=generated.short_summary,
+        highlights_json=generated.highlights,
+        citations_json=generated.citations,
+        metadata_json={
+            **source.metadata_json,
+            **(generated.metadata_json or {}),
+        },
+        generated_at=generated_at,
+    )
+
+
+def upsert_episode_summary(
+    *,
+    db: Session,
+    episode: Episode,
+    summary_kind: DerivativeSummaryKind,
+    pipeline_version: str,
+    prompt_version: str,
+    source_model: str,
+    source_text_hash: str,
+    summary_text: str,
+    short_summary: str | None = None,
+    highlights_json: list[str] | None = None,
+    citations_json: list[dict[str, object]] | None = None,
+    metadata_json: dict[str, object] | None = None,
+    status: DerivativeSummaryStatus = DerivativeSummaryStatus.READY,
+    error_message: str | None = None,
+    generated_at: datetime | None = None,
+) -> EpisodeSummary:
+    """Create or update an idempotent episode summary record.
+
+    Args:
+        db: Database session.
+        episode: Episode being summarized.
+        summary_kind: Narrative summary kind.
+        pipeline_version: Derivative pipeline version.
+        prompt_version: Summary prompt version.
+        source_model: Model or generator version.
+        source_text_hash: Hash of the summarized source material.
+        summary_text: Long-form generated summary text.
+        short_summary: Optional display-length summary.
+        highlights_json: Optional highlighted facts.
+        citations_json: Optional provenance citations.
+        metadata_json: Optional summary metadata.
+        status: Summary lifecycle status.
+        error_message: Optional generation failure details.
+        generated_at: Optional generation timestamp.
+
+    Returns:
+        Existing or newly created episode summary.
+    """
+    summary_key = stable_episode_summary_key(
+        episode_id=episode.id,
+        summary_kind=summary_kind,
+        pipeline_version=pipeline_version,
+        prompt_version=prompt_version,
+        source_model=source_model,
+        source_text_hash=source_text_hash,
+    )
+    summary = (
+        db.query(EpisodeSummary)
+        .filter(EpisodeSummary.summary_key == summary_key)
+        .first()
+    )
+    if summary is None:
+        summary = EpisodeSummary(
+            episode_id=episode.id,
+            summary_key=summary_key,
+            summary_kind=summary_kind.value,
+            pipeline_version=_normalize_required(
+                value=pipeline_version,
+                field_name="pipeline_version",
+            ),
+            prompt_version=_normalize_required(
+                value=prompt_version,
+                field_name="prompt_version",
+            ),
+            source_model=_normalize_required(
+                value=source_model,
+                field_name="source_model",
+            ),
+            source_text_hash=_normalize_source_hash(source_text_hash),
+            generated_at=generated_at or datetime.now(UTC),
+        )
+        db.add(summary)
+
+    _apply_summary_fields(
+        summary=summary,
+        summary_text=summary_text,
+        short_summary=short_summary,
+        highlights_json=highlights_json,
+        citations_json=citations_json,
+        metadata_json=metadata_json,
+        status=status,
+        error_message=error_message,
+        generated_at=generated_at,
+    )
+    db.flush()
+    return summary
+
+
+def upsert_media_summary(
+    *,
+    db: Session,
+    media: Media,
+    summary_kind: DerivativeSummaryKind,
+    pipeline_version: str,
+    prompt_version: str,
+    source_model: str,
+    source_text_hash: str,
+    summary_text: str,
+    short_summary: str | None = None,
+    highlights_json: list[str] | None = None,
+    citations_json: list[dict[str, object]] | None = None,
+    metadata_json: dict[str, object] | None = None,
+    status: DerivativeSummaryStatus = DerivativeSummaryStatus.READY,
+    error_message: str | None = None,
+    generated_at: datetime | None = None,
+) -> MediaSummary:
+    """Create or update an idempotent media summary record.
+
+    Args:
+        db: Database session.
+        media: Media entity being summarized.
+        summary_kind: Narrative summary kind.
+        pipeline_version: Derivative pipeline version.
+        prompt_version: Summary prompt version.
+        source_model: Model or generator version.
+        source_text_hash: Hash of the summarized source material.
+        summary_text: Long-form generated summary text.
+        short_summary: Optional display-length summary.
+        highlights_json: Optional highlighted facts.
+        citations_json: Optional provenance citations.
+        metadata_json: Optional summary metadata.
+        status: Summary lifecycle status.
+        error_message: Optional generation failure details.
+        generated_at: Optional generation timestamp.
+
+    Returns:
+        Existing or newly created media summary.
+    """
+    summary_key = stable_media_summary_key(
+        media_id=media.id,
+        summary_kind=summary_kind,
+        pipeline_version=pipeline_version,
+        prompt_version=prompt_version,
+        source_model=source_model,
+        source_text_hash=source_text_hash,
+    )
+    summary = (
+        db.query(MediaSummary).filter(MediaSummary.summary_key == summary_key).first()
+    )
+    if summary is None:
+        summary = MediaSummary(
+            media_id=media.id,
+            summary_key=summary_key,
+            summary_kind=summary_kind.value,
+            pipeline_version=_normalize_required(
+                value=pipeline_version,
+                field_name="pipeline_version",
+            ),
+            prompt_version=_normalize_required(
+                value=prompt_version,
+                field_name="prompt_version",
+            ),
+            source_model=_normalize_required(
+                value=source_model,
+                field_name="source_model",
+            ),
+            source_text_hash=_normalize_source_hash(source_text_hash),
+            generated_at=generated_at or datetime.now(UTC),
+        )
+        db.add(summary)
+
+    _apply_summary_fields(
+        summary=summary,
+        summary_text=summary_text,
+        short_summary=short_summary,
+        highlights_json=highlights_json,
+        citations_json=citations_json,
+        metadata_json=metadata_json,
+        status=status,
+        error_message=error_message,
+        generated_at=generated_at,
+    )
+    db.flush()
+    return summary
+
+
+def build_episode_summary_source(
+    *,
+    db: Session,
+    episode: Episode,
+) -> SummarySourceData:
+    """Build deterministic source material for an episode summary.
+
+    Args:
+        db: Database session.
+        episode: Episode to summarize.
+
+    Returns:
+        Source text and provenance metadata.
+    """
+    chunks = (
+        db.query(SemanticChunk)
+        .filter(SemanticChunk.episode_id == episode.id)
+        .order_by(SemanticChunk.chunk_index)
+        .all()
+    )
+    if chunks:
+        source_text = "\n\n".join(chunk.text for chunk in chunks)
+        metadata_json: dict[str, object] = {
+            "source": "semantic_chunks",
+            "chunk_count": len(chunks),
+        }
+    else:
+        transcripts = (
+            db.query(Transcript)
+            .filter(Transcript.episode_id == episode.id)
+            .order_by(Transcript.id.desc())
+            .all()
+        )
+        transcript_texts: list[str] = []
+        for transcript in transcripts:
+            transcript_text = transcript.cleaned_text or transcript.raw_text
+            if transcript_text:
+                transcript_texts.append(transcript_text)
+        source_text = "\n\n".join(transcript_texts) or episode.title
+        metadata_json = {
+            "source": "transcripts" if transcript_texts else "episode_metadata",
+            "transcript_count": len(transcript_texts),
+        }
+    return SummarySourceData(
+        resource_kind="episode",
+        resource_id=episode.id,
+        source_text=source_text,
+        source_text_hash=stable_source_text_hash(source_text),
+        metadata_json=metadata_json,
+    )
+
+
+def build_media_summary_source(
+    *,
+    db: Session,
+    media: Media,
+) -> SummarySourceData:
+    """Build deterministic source material for a media summary.
+
+    Args:
+        db: Database session.
+        media: Media entity to summarize.
+
+    Returns:
+        Source text and provenance metadata.
+    """
+    identity_parts = [
+        f"Title: {media.title}",
+        f"Type: {media.type}",
+    ]
+    if media.author:
+        identity_parts.append(f"Author: {media.author}")
+    if media.year is not None:
+        identity_parts.append(f"Year: {media.year}")
+    if media.description:
+        identity_parts.append(f"Description: {media.description}")
+
+    mentions = (
+        db.query(Mention)
+        .filter(Mention.media_id == media.id)
+        .order_by(Mention.episode_id, Mention.timestamp_seconds)
+        .all()
+    )
+    mention_contexts = [
+        mention.context.strip()
+        for mention in mentions
+        if mention.context and mention.context.strip()
+    ]
+    source_text = "\n".join(identity_parts + mention_contexts)
+    return SummarySourceData(
+        resource_kind="media",
+        resource_id=media.id,
+        source_text=source_text,
+        source_text_hash=stable_source_text_hash(source_text),
+        metadata_json={
+            "source": "media_metadata_mentions",
+            "mention_count": len(mentions),
+            "mention_context_count": len(mention_contexts),
+        },
+    )
+
+
+def stable_episode_summary_key(
+    *,
+    episode_id: int,
+    summary_kind: DerivativeSummaryKind,
+    pipeline_version: str,
+    prompt_version: str,
+    source_model: str,
+    source_text_hash: str,
+) -> str:
+    """Build a stable key for an episode summary derivative.
+
+    Args:
+        episode_id: Episode id.
+        summary_kind: Narrative summary kind.
+        pipeline_version: Derivative pipeline version.
+        prompt_version: Summary prompt version.
+        source_model: Model or generator version.
+        source_text_hash: Hash of summarized source material.
+
+    Returns:
+        Stable summary key.
+    """
+    return _stable_key(
+        prefix="episode-summary",
+        parts=(
+            str(episode_id),
+            summary_kind.value,
+            _normalize_required(value=pipeline_version, field_name="pipeline_version"),
+            _normalize_required(value=prompt_version, field_name="prompt_version"),
+            _normalize_required(value=source_model, field_name="source_model"),
+            _normalize_source_hash(source_text_hash),
+        ),
+    )
+
+
+def stable_media_summary_key(
+    *,
+    media_id: int,
+    summary_kind: DerivativeSummaryKind,
+    pipeline_version: str,
+    prompt_version: str,
+    source_model: str,
+    source_text_hash: str,
+) -> str:
+    """Build a stable key for a media summary derivative.
+
+    Args:
+        media_id: Media id.
+        summary_kind: Narrative summary kind.
+        pipeline_version: Derivative pipeline version.
+        prompt_version: Summary prompt version.
+        source_model: Model or generator version.
+        source_text_hash: Hash of summarized source material.
+
+    Returns:
+        Stable summary key.
+    """
+    return _stable_key(
+        prefix="media-summary",
+        parts=(
+            str(media_id),
+            summary_kind.value,
+            _normalize_required(value=pipeline_version, field_name="pipeline_version"),
+            _normalize_required(value=prompt_version, field_name="prompt_version"),
+            _normalize_required(value=source_model, field_name="source_model"),
+            _normalize_source_hash(source_text_hash),
+        ),
+    )
+
+
+def stable_source_text_hash(
+    source_text: str,
+) -> str:
+    """Hash normalized summary source material.
+
+    Args:
+        source_text: Source material to hash.
+
+    Returns:
+        SHA-256 source text hash.
+    """
+    normalized = " ".join(source_text.split())
+    return sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _apply_summary_fields(
+    *,
+    summary: EpisodeSummary | MediaSummary,
+    summary_text: str,
+    short_summary: str | None,
+    highlights_json: list[str] | None,
+    citations_json: list[dict[str, object]] | None,
+    metadata_json: dict[str, object] | None,
+    status: DerivativeSummaryStatus,
+    error_message: str | None,
+    generated_at: datetime | None,
+) -> None:
+    """Apply mutable summary fields to an existing summary model."""
+    summary.summary_text = _normalize_required(
+        value=summary_text,
+        field_name="summary_text",
+    )
+    summary.short_summary = _normalize_optional(short_summary)
+    summary.highlights_json = highlights_json
+    summary.citations_json = citations_json
+    summary.metadata_json = metadata_json
+    summary.status = status.value
+    summary.error_message = _normalize_optional(error_message)
+    if generated_at is not None:
+        summary.generated_at = generated_at
+
+
+def _stable_key(
+    *,
+    prefix: str,
+    parts: tuple[str, ...],
+) -> str:
+    """Build a compact stable key from string parts."""
+    digest = sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return f"{prefix}:{digest[:64]}"
+
+
+def _normalize_source_hash(
+    source_text_hash: str,
+) -> str:
+    """Validate and normalize a source text hash."""
+    normalized = _normalize_required(
+        value=source_text_hash,
+        field_name="source_text_hash",
+    )
+    if len(normalized) != 64:
+        raise ValueError("source_text_hash must be a SHA-256 hex digest")
+    return normalized
+
+
+def _normalize_required(
+    *,
+    value: str,
+    field_name: str,
+) -> str:
+    """Normalize a required string field."""
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be non-empty")
+    return normalized
+
+
+def _normalize_optional(
+    value: str | None,
+) -> str | None:
+    """Normalize an optional string field."""
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None

--- a/backend/src/podex/services/graph_relations.py
+++ b/backend/src/podex/services/graph_relations.py
@@ -1,16 +1,19 @@
 """Media relation and external-reference persistence services.
 
-Graph-triple persistence lands with the derivatives theme; this module
-carries the merge-critical upserts only.
+Carries the idempotent upserts for external refs, typed media relations,
+and graph triples used by enrichment, merges, and the derivatives layer.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from hashlib import sha256
 
 from sqlalchemy.orm import Session
 
 from podex.models import (
+    GraphTriple,
+    GraphTripleObjectKind,
     Media,
     MediaExternalRef,
     MediaExternalRefSource,
@@ -201,3 +204,126 @@ def _normalize_optional(
         return None
     normalized = value.strip()
     return normalized or None
+
+
+@dataclass(frozen=True, slots=True)
+class GraphTripleInputData:
+    """Input for an idempotent graph triple upsert."""
+
+    subject_media_id: int
+    predicate: str
+    source: str
+    object_media_id: int | None = None
+    object_value: str | None = None
+    provenance_episode_id: int | None = None
+    provenance_mention_id: int | None = None
+    confidence: float = 1.0
+    evidence_text: str | None = None
+    metadata_json: dict[str, object] | None = None
+
+
+def upsert_graph_triple(
+    *,
+    db: Session,
+    payload: GraphTripleInputData,
+) -> GraphTriple:
+    """Create or update a graph triple with source provenance.
+
+    Args:
+        db: Database session.
+        payload: Graph triple input.
+
+    Returns:
+        Existing or newly created graph triple.
+    """
+    _validate_graph_triple_payload(payload)
+    triple_key = stable_graph_triple_key(payload)
+    triple = db.query(GraphTriple).filter(GraphTriple.triple_key == triple_key).first()
+    if triple is None:
+        triple = GraphTriple(
+            triple_key=triple_key,
+            subject_media_id=payload.subject_media_id,
+            predicate=_normalize_required(
+                value=payload.predicate,
+                field_name="predicate",
+            ),
+            source=_normalize_required(value=payload.source, field_name="source"),
+        )
+        db.add(triple)
+
+    triple.object_media_id = payload.object_media_id
+    triple.object_value = _normalize_optional(payload.object_value)
+    triple.object_kind = _object_kind(payload).value
+    triple.provenance_episode_id = payload.provenance_episode_id
+    triple.provenance_mention_id = payload.provenance_mention_id
+    triple.confidence = payload.confidence
+    triple.evidence_text = _normalize_optional(payload.evidence_text)
+    triple.metadata_json = payload.metadata_json
+    if payload.object_media_id is not None:
+        relation = upsert_media_relation(
+            db=db,
+            subject_media_id=payload.subject_media_id,
+            object_media_id=payload.object_media_id,
+            relation_type=MediaRelationType(payload.predicate),
+            source=payload.source,
+            provenance_episode_id=payload.provenance_episode_id,
+            confidence=payload.confidence,
+            evidence_text=payload.evidence_text,
+            metadata_json=payload.metadata_json,
+        )
+        triple.media_relation_id = relation.id
+    else:
+        triple.media_relation_id = None
+    db.flush()
+    return triple
+
+
+def stable_graph_triple_key(
+    payload: GraphTripleInputData,
+) -> str:
+    """Build a stable idempotency key for a graph triple.
+
+    Args:
+        payload: Graph triple input.
+
+    Returns:
+        Stable graph triple key.
+    """
+    object_part = (
+        f"media:{payload.object_media_id}"
+        if payload.object_media_id is not None
+        else f"literal:{_normalize_optional(payload.object_value) or ''}"
+    )
+    return _stable_key(
+        prefix="graph-triple",
+        parts=(
+            str(payload.subject_media_id),
+            _normalize_required(value=payload.predicate, field_name="predicate"),
+            object_part,
+            _normalize_required(value=payload.source, field_name="source"),
+            str(payload.provenance_episode_id or ""),
+            str(payload.provenance_mention_id or ""),
+        ),
+    )
+
+
+def _validate_graph_triple_payload(
+    payload: GraphTripleInputData,
+) -> None:
+    """Validate graph triple object and confidence constraints."""
+    _validate_confidence(payload.confidence)
+    has_media_object = payload.object_media_id is not None
+    has_literal_object = bool(_normalize_optional(payload.object_value))
+    if has_media_object == has_literal_object:
+        raise ValueError("graph triple must have exactly one object")
+    if has_media_object:
+        MediaRelationType(payload.predicate)
+
+
+def _object_kind(
+    payload: GraphTripleInputData,
+) -> GraphTripleObjectKind:
+    """Determine graph triple object storage kind."""
+    if payload.object_media_id is not None:
+        return GraphTripleObjectKind.MEDIA
+    return GraphTripleObjectKind.LITERAL

--- a/backend/src/podex/services/semantic_chunks.py
+++ b/backend/src/podex/services/semantic_chunks.py
@@ -1,0 +1,507 @@
+"""Semantic chunk generation and persistence services."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import Protocol
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    SemanticChunk,
+    SemanticChunkEmbeddingStatus,
+    Transcript,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticChunkingPolicy:
+    """Policy controlling transcript semantic windows."""
+
+    max_words: int = 220
+    overlap_words: int = 40
+    min_words: int = 20
+    context_words: int = 24
+    pipeline_version: str = "semantic-chunk-v1"
+
+    def __post_init__(self) -> None:
+        """Validate chunking thresholds."""
+        if self.max_words <= 0:
+            raise ValueError("max_words must be positive")
+        if self.overlap_words < 0:
+            raise ValueError("overlap_words must be non-negative")
+        if self.overlap_words >= self.max_words:
+            raise ValueError("overlap_words must be less than max_words")
+        if self.min_words <= 0:
+            raise ValueError("min_words must be positive")
+        if self.context_words < 0:
+            raise ValueError("context_words must be non-negative")
+        if not self.pipeline_version:
+            raise ValueError("pipeline_version must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticChunkCandidateData:
+    """Candidate semantic chunk derived from transcript text."""
+
+    chunk_index: int
+    chunk_key: str
+    source_text_hash: str
+    text: str
+    context_snippet: str
+    token_count: int
+    start_seconds: int | None
+    end_seconds: int | None
+    pipeline_version: str
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticChunkSyncResultData:
+    """Summary of persisted semantic chunk sync work."""
+
+    created_count: int
+    updated_count: int
+    deleted_count: int
+    embedded_count: int
+    failed_count: int
+    chunk_keys: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptSegmentData:
+    """Normalized transcript segment used for timestamped chunking."""
+
+    text: str
+    start_seconds: int | None = None
+    end_seconds: int | None = None
+
+
+class EmbeddingProvider(Protocol):
+    """Protocol for model-backed embedding providers."""
+
+    model_name: str
+    dimensions: int
+
+    def embed_texts(
+        self,
+        texts: list[str],
+    ) -> list[list[float]]:
+        """Embed transcript chunk text.
+
+        Args:
+            texts: Chunk text values in request order.
+
+        Returns:
+            Embedding vectors in the same order as ``texts``.
+        """
+
+
+def build_semantic_chunk_candidates(
+    *,
+    transcript: Transcript,
+    policy: SemanticChunkingPolicy | None = None,
+) -> list[SemanticChunkCandidateData]:
+    """Build semantic chunk candidates from a transcript.
+
+    Args:
+        transcript: Transcript source row.
+        policy: Chunking policy.
+
+    Returns:
+        Deterministic chunk candidates with stable idempotency keys.
+    """
+    effective_policy = policy or SemanticChunkingPolicy()
+    source_segments = _segments_from_transcript(transcript)
+    if source_segments:
+        return _candidates_from_segments(
+            transcript=transcript,
+            segments=source_segments,
+            policy=effective_policy,
+        )
+
+    source_text = _transcript_text(transcript)
+    if not source_text:
+        return []
+    return _candidates_from_words(
+        transcript=transcript,
+        words=source_text.split(),
+        policy=effective_policy,
+    )
+
+
+def sync_semantic_chunks_for_transcript(
+    *,
+    db: Session,
+    transcript: Transcript,
+    embedding_provider: EmbeddingProvider | None = None,
+    policy: SemanticChunkingPolicy | None = None,
+    now: datetime | None = None,
+) -> SemanticChunkSyncResultData:
+    """Persist semantic chunks and optional embeddings for a transcript.
+
+    Args:
+        db: Database session.
+        transcript: Transcript source row.
+        embedding_provider: Optional provider used to generate embeddings.
+        policy: Chunking policy.
+        now: Timestamp used for deterministic embedded timestamps.
+
+    Returns:
+        Summary of created, updated, deleted, and embedded chunks.
+    """
+    effective_now = now or datetime.now(UTC)
+    effective_policy = policy or SemanticChunkingPolicy()
+    candidates = build_semantic_chunk_candidates(
+        transcript=transcript,
+        policy=effective_policy,
+    )
+    existing_chunks = {
+        chunk.chunk_key: chunk
+        for chunk in db.query(SemanticChunk)
+        .filter(SemanticChunk.transcript_id == transcript.id)
+        .filter(SemanticChunk.pipeline_version == effective_policy.pipeline_version)
+        .all()
+    }
+    candidate_keys = {candidate.chunk_key for candidate in candidates}
+
+    created_count = 0
+    updated_count = 0
+    deleted_count = 0
+    embedded_count = 0
+    failed_count = 0
+
+    for stale_key, stale_chunk in existing_chunks.items():
+        if stale_key not in candidate_keys:
+            db.delete(stale_chunk)
+            deleted_count += 1
+
+    chunks_to_embed: list[SemanticChunk] = []
+    for candidate in candidates:
+        chunk = existing_chunks.get(candidate.chunk_key)
+        if chunk is None:
+            chunk = SemanticChunk(
+                episode_id=transcript.episode_id,
+                transcript_id=transcript.id,
+                chunk_key=candidate.chunk_key,
+            )
+            db.add(chunk)
+            created_count += 1
+        else:
+            updated_count += int(_semantic_chunk_needs_update(chunk, candidate))
+
+        _apply_candidate(chunk=chunk, candidate=candidate)
+        if embedding_provider is None:
+            chunk.embedding_status = SemanticChunkEmbeddingStatus.PENDING.value
+            chunk.embedding_error = None
+            continue
+        chunks_to_embed.append(chunk)
+
+    if embedding_provider is not None and chunks_to_embed:
+        try:
+            vectors = embedding_provider.embed_texts(
+                texts=[chunk.text for chunk in chunks_to_embed],
+            )
+            _validate_embeddings(
+                vectors=vectors,
+                expected_count=len(chunks_to_embed),
+                expected_dimensions=embedding_provider.dimensions,
+            )
+        except (RuntimeError, ValueError, TypeError) as exc:
+            failed_count = len(chunks_to_embed)
+            for chunk in chunks_to_embed:
+                chunk.embedding_status = SemanticChunkEmbeddingStatus.FAILED.value
+                chunk.embedding_model = embedding_provider.model_name
+                chunk.embedding_dimensions = embedding_provider.dimensions
+                chunk.embedding_error = str(exc)
+        else:
+            embedded_count = len(chunks_to_embed)
+            for chunk, vector in zip(chunks_to_embed, vectors, strict=True):
+                chunk.embedding_status = SemanticChunkEmbeddingStatus.EMBEDDED.value
+                chunk.embedding_model = embedding_provider.model_name
+                chunk.embedding_dimensions = embedding_provider.dimensions
+                chunk.embedding_vector = vector
+                chunk.embedding_error = None
+                chunk.embedded_at = effective_now
+
+    db.flush()
+    return SemanticChunkSyncResultData(
+        created_count=created_count,
+        updated_count=updated_count,
+        deleted_count=deleted_count,
+        embedded_count=embedded_count,
+        failed_count=failed_count,
+        chunk_keys=tuple(candidate.chunk_key for candidate in candidates),
+    )
+
+
+def _segments_from_transcript(
+    transcript: Transcript,
+) -> list[TranscriptSegmentData]:
+    """Extract normalized segments from transcript JSON."""
+    if not transcript.segments_json:
+        return []
+
+    segments: list[TranscriptSegmentData] = []
+    for segment in transcript.segments_json:
+        text_value = segment.get("text")
+        if not isinstance(text_value, str) or not text_value.strip():
+            continue
+        segments.append(
+            TranscriptSegmentData(
+                text=" ".join(text_value.split()),
+                start_seconds=_optional_seconds(segment.get("start")),
+                end_seconds=_optional_seconds(segment.get("end")),
+            ),
+        )
+    return segments
+
+
+def _candidates_from_segments(
+    *,
+    transcript: Transcript,
+    segments: list[TranscriptSegmentData],
+    policy: SemanticChunkingPolicy,
+) -> list[SemanticChunkCandidateData]:
+    """Build timestamped candidates from transcript segments."""
+    candidates: list[SemanticChunkCandidateData] = []
+    current: list[TranscriptSegmentData] = []
+    current_words = 0
+
+    for segment in segments:
+        segment_words = len(segment.text.split())
+        if current and current_words + segment_words > policy.max_words:
+            candidates.append(
+                _candidate_from_segments(
+                    transcript=transcript,
+                    segments=current,
+                    chunk_index=len(candidates),
+                    policy=policy,
+                ),
+            )
+            current = _overlap_segments(segments=current, policy=policy)
+            current_words = sum(len(item.text.split()) for item in current)
+
+        current.append(segment)
+        current_words += segment_words
+
+    if current_words >= policy.min_words or not candidates:
+        candidates.append(
+            _candidate_from_segments(
+                transcript=transcript,
+                segments=current,
+                chunk_index=len(candidates),
+                policy=policy,
+            ),
+        )
+    return candidates
+
+
+def _candidate_from_segments(
+    *,
+    transcript: Transcript,
+    segments: list[TranscriptSegmentData],
+    chunk_index: int,
+    policy: SemanticChunkingPolicy,
+) -> SemanticChunkCandidateData:
+    """Create a chunk candidate from a list of transcript segments."""
+    text = " ".join(segment.text for segment in segments).strip()
+    words = text.split()
+    source_hash = _source_text_hash(text)
+    return SemanticChunkCandidateData(
+        chunk_index=chunk_index,
+        chunk_key=_chunk_key(
+            transcript=transcript,
+            chunk_index=chunk_index,
+            source_text_hash=source_hash,
+            pipeline_version=policy.pipeline_version,
+        ),
+        source_text_hash=source_hash,
+        text=text,
+        context_snippet=_context_snippet(words=words, policy=policy),
+        token_count=len(words),
+        start_seconds=_first_seconds(segment.start_seconds for segment in segments),
+        end_seconds=_last_seconds(segment.end_seconds for segment in segments),
+        pipeline_version=policy.pipeline_version,
+    )
+
+
+def _candidates_from_words(
+    *,
+    transcript: Transcript,
+    words: list[str],
+    policy: SemanticChunkingPolicy,
+) -> list[SemanticChunkCandidateData]:
+    """Build candidates from plain transcript words."""
+    candidates: list[SemanticChunkCandidateData] = []
+    start = 0
+    step = policy.max_words - policy.overlap_words
+
+    while start < len(words):
+        chunk_words = words[start : start + policy.max_words]
+        if len(chunk_words) < policy.min_words and candidates:
+            break
+        text = " ".join(chunk_words)
+        source_hash = _source_text_hash(text)
+        candidates.append(
+            SemanticChunkCandidateData(
+                chunk_index=len(candidates),
+                chunk_key=_chunk_key(
+                    transcript=transcript,
+                    chunk_index=len(candidates),
+                    source_text_hash=source_hash,
+                    pipeline_version=policy.pipeline_version,
+                ),
+                source_text_hash=source_hash,
+                text=text,
+                context_snippet=_context_snippet(words=chunk_words, policy=policy),
+                token_count=len(chunk_words),
+                start_seconds=None,
+                end_seconds=None,
+                pipeline_version=policy.pipeline_version,
+            ),
+        )
+        start += step
+    return candidates
+
+
+def _overlap_segments(
+    *,
+    segments: list[TranscriptSegmentData],
+    policy: SemanticChunkingPolicy,
+) -> list[TranscriptSegmentData]:
+    """Choose trailing segments to carry into the next chunk."""
+    if policy.overlap_words == 0:
+        return []
+
+    overlap: list[TranscriptSegmentData] = []
+    overlap_words = 0
+    for segment in reversed(segments):
+        segment_words = len(segment.text.split())
+        if overlap and overlap_words + segment_words > policy.overlap_words:
+            break
+        overlap.append(segment)
+        overlap_words += segment_words
+    return list(reversed(overlap))
+
+
+def _apply_candidate(
+    *,
+    chunk: SemanticChunk,
+    candidate: SemanticChunkCandidateData,
+) -> None:
+    """Apply candidate values to a semantic chunk row."""
+    chunk.chunk_index = candidate.chunk_index
+    chunk.pipeline_version = candidate.pipeline_version
+    chunk.source_text_hash = candidate.source_text_hash
+    chunk.text = candidate.text
+    chunk.context_snippet = candidate.context_snippet
+    chunk.token_count = candidate.token_count
+    chunk.start_seconds = candidate.start_seconds
+    chunk.end_seconds = candidate.end_seconds
+
+
+def _semantic_chunk_needs_update(
+    chunk: SemanticChunk,
+    candidate: SemanticChunkCandidateData,
+) -> bool:
+    """Check whether a persisted chunk differs from its candidate."""
+    return any(
+        (
+            chunk.chunk_index != candidate.chunk_index,
+            chunk.source_text_hash != candidate.source_text_hash,
+            chunk.text != candidate.text,
+            chunk.context_snippet != candidate.context_snippet,
+            chunk.token_count != candidate.token_count,
+            chunk.start_seconds != candidate.start_seconds,
+            chunk.end_seconds != candidate.end_seconds,
+        ),
+    )
+
+
+def _validate_embeddings(
+    *,
+    vectors: list[list[float]],
+    expected_count: int,
+    expected_dimensions: int,
+) -> None:
+    """Validate embedding provider output shape."""
+    if len(vectors) != expected_count:
+        raise ValueError("embedding provider returned an unexpected vector count")
+    for vector in vectors:
+        if len(vector) != expected_dimensions:
+            raise ValueError("embedding provider returned unexpected dimensions")
+
+
+def _transcript_text(
+    transcript: Transcript,
+) -> str:
+    """Choose the best available transcript text for chunking."""
+    text = transcript.cleaned_text or transcript.raw_text or ""
+    return " ".join(text.split())
+
+
+def _chunk_key(
+    *,
+    transcript: Transcript,
+    chunk_index: int,
+    source_text_hash: str,
+    pipeline_version: str,
+) -> str:
+    """Build a deterministic chunk idempotency key."""
+    return (
+        f"{pipeline_version}:transcript:{transcript.id}:chunk:{chunk_index}:"
+        f"{source_text_hash[:16]}"
+    )
+
+
+def _source_text_hash(
+    text: str,
+) -> str:
+    """Hash normalized chunk text."""
+    return sha256(" ".join(text.split()).encode("utf-8")).hexdigest()
+
+
+def _context_snippet(
+    *,
+    words: list[str],
+    policy: SemanticChunkingPolicy,
+) -> str:
+    """Build a short context snippet for ops and retrieval previews."""
+    if len(words) <= policy.context_words * 2 or policy.context_words == 0:
+        return " ".join(words)
+    prefix = " ".join(words[: policy.context_words])
+    suffix = " ".join(words[-policy.context_words :])
+    return f"{prefix} ... {suffix}"
+
+
+def _optional_seconds(
+    value: object,
+) -> int | None:
+    """Convert numeric segment offsets to whole seconds."""
+    if isinstance(value, int | float):
+        return max(0, round(value))
+    return None
+
+
+def _first_seconds(
+    values: Iterable[int | None],
+) -> int | None:
+    """Return the first non-null timestamp."""
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _last_seconds(
+    values: Iterable[int | None],
+) -> int | None:
+    """Return the last non-null timestamp."""
+    last_value: int | None = None
+    for value in values:
+        if value is not None:
+            last_value = value
+    return last_value

--- a/backend/tests/test_derivative_generation.py
+++ b/backend/tests/test_derivative_generation.py
@@ -1,0 +1,178 @@
+"""Tests for derivative generation orchestration."""
+
+from datetime import UTC, datetime
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    DerivativeGenerationRun,
+    DerivativeGenerationRunStatus,
+    Episode,
+    EpisodeSummary,
+    GraphTriple,
+    Media,
+    MediaSummary,
+    MediaType,
+    Mention,
+    Podcast,
+    SemanticChunk,
+    Transcript,
+)
+from podex.services.derivative_generation import (
+    DerivativeGenerationConfig,
+    generate_episode_derivatives,
+)
+from podex.services.derivative_summaries import GeneratedSummaryData, SummarySourceData
+from podex.services.graph_relations import GraphTripleInputData
+from podex.services.semantic_chunks import SemanticChunkingPolicy
+
+
+class FakeSummaryProvider:
+    """Deterministic summary provider for orchestration tests."""
+
+    model_name = "fake-summary-v1"
+
+    def summarize(
+        self,
+        source: SummarySourceData,
+    ) -> GeneratedSummaryData:
+        """Return stable text from the supplied source."""
+        return GeneratedSummaryData(
+            summary_text=f"{source.resource_kind} summary",
+            short_summary=f"{source.resource_kind} short",
+        )
+
+
+def test_generate_episode_derivatives_orchestrates_derivative_layers(
+    db_session: Session,
+) -> None:
+    """Verify one orchestration run persists chunks, summaries, and triples."""
+    episode, transcript, media = _create_episode_graph(db_session)
+    config = DerivativeGenerationConfig(
+        pipeline_version="derivatives-v1",
+        chunk_pipeline_version="chunks-v1",
+        summary_prompt_version="summary-v1",
+    )
+    now = datetime(2026, 5, 22, tzinfo=UTC)
+
+    run = generate_episode_derivatives(
+        db=db_session,
+        episode=episode,
+        transcript=transcript,
+        config=config,
+        summary_provider=FakeSummaryProvider(),
+        chunking_policy=SemanticChunkingPolicy(
+            max_words=6,
+            overlap_words=0,
+            min_words=2,
+            pipeline_version=config.chunk_pipeline_version,
+        ),
+        graph_triples=[
+            GraphTripleInputData(
+                subject_media_id=media.id,
+                predicate="mentioned_context",
+                object_value="discussed on JRE",
+                source="orchestration-test",
+                provenance_episode_id=episode.id,
+            ),
+        ],
+        now=now,
+    )
+    db_session.commit()
+
+    assert_that(run.status).is_equal_to(DerivativeGenerationRunStatus.COMPLETED.value)
+    assert_that(run.semantic_chunks_created).is_equal_to(1)
+    assert_that(run.media_summaries_generated).is_equal_to(1)
+    assert_that(run.graph_triples_upserted).is_equal_to(1)
+    completed_at = run.completed_at
+    assert_that(completed_at).is_not_none()
+    if completed_at is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(completed_at.replace(tzinfo=UTC)).is_equal_to(now)
+    assert_that(db_session.query(SemanticChunk).count()).is_equal_to(1)
+    assert_that(db_session.query(EpisodeSummary).count()).is_equal_to(1)
+    assert_that(db_session.query(MediaSummary).count()).is_equal_to(1)
+    assert_that(db_session.query(GraphTriple).count()).is_equal_to(1)
+
+
+def test_generate_episode_derivatives_is_replay_safe(
+    db_session: Session,
+) -> None:
+    """Verify replaying the same run does not duplicate derivatives."""
+    episode, transcript, _media = _create_episode_graph(db_session)
+    config = DerivativeGenerationConfig(
+        pipeline_version="derivatives-v1",
+        chunk_pipeline_version="chunks-v1",
+        summary_prompt_version="summary-v1",
+    )
+
+    first = generate_episode_derivatives(
+        db=db_session,
+        episode=episode,
+        transcript=transcript,
+        config=config,
+        summary_provider=FakeSummaryProvider(),
+        chunking_policy=SemanticChunkingPolicy(
+            max_words=6,
+            overlap_words=0,
+            min_words=2,
+            pipeline_version=config.chunk_pipeline_version,
+        ),
+    )
+    second = generate_episode_derivatives(
+        db=db_session,
+        episode=episode,
+        transcript=transcript,
+        config=config,
+        summary_provider=FakeSummaryProvider(),
+        chunking_policy=SemanticChunkingPolicy(
+            max_words=6,
+            overlap_words=0,
+            min_words=2,
+            pipeline_version=config.chunk_pipeline_version,
+        ),
+    )
+    db_session.commit()
+
+    assert_that(second.id).is_equal_to(first.id)
+    assert_that(second.semantic_chunks_created).is_equal_to(0)
+    assert_that(second.semantic_chunks_updated).is_equal_to(0)
+    assert_that(db_session.query(DerivativeGenerationRun).count()).is_equal_to(1)
+    assert_that(db_session.query(SemanticChunk).count()).is_equal_to(1)
+    assert_that(db_session.query(EpisodeSummary).count()).is_equal_to(1)
+    assert_that(db_session.query(MediaSummary).count()).is_equal_to(1)
+
+
+def _create_episode_graph(
+    db_session: Session,
+) -> tuple[Episode, Transcript, Media]:
+    """Create a persisted JRE episode with transcript and media mention."""
+    podcast = Podcast(name="The Joe Rogan Experience", slug="jre")
+    db_session.add(podcast)
+    db_session.flush()
+    episode = Episode(
+        podcast_id=podcast.id,
+        title="JRE #1",
+        episode_number=1,
+    )
+    db_session.add(episode)
+    db_session.flush()
+    transcript = Transcript(
+        episode_id=episode.id,
+        provider="podscripts",
+        raw_text="Joe mentions a book during the conversation.",
+        cleaned_text="Joe mentions a book during the conversation.",
+    )
+    media = Media(type=MediaType.BOOK.value, title="Dune")
+    db_session.add_all([transcript, media])
+    db_session.flush()
+    db_session.add(
+        Mention(
+            episode_id=episode.id,
+            media_id=media.id,
+            context="Joe mentions Dune during the conversation.",
+        ),
+    )
+    db_session.flush()
+    return episode, transcript, media

--- a/backend/tests/test_derivative_summaries.py
+++ b/backend/tests/test_derivative_summaries.py
@@ -1,0 +1,228 @@
+"""Tests for durable episode and media derivative summaries."""
+
+from datetime import UTC, datetime
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    DerivativeSummaryKind,
+    Episode,
+    EpisodeSummary,
+    Media,
+    MediaSummary,
+    MediaType,
+    Mention,
+    Podcast,
+    SemanticChunk,
+    Transcript,
+)
+from podex.services.derivative_summaries import (
+    GeneratedSummaryData,
+    SummarySourceData,
+    build_episode_summary_source,
+    generate_episode_summary,
+    generate_media_summary,
+    stable_source_text_hash,
+    upsert_episode_summary,
+)
+
+
+class FakeSummaryProvider:
+    """Deterministic summary provider for derivative summary tests."""
+
+    model_name = "fake-summary-v1"
+
+    def summarize(
+        self,
+        source: SummarySourceData,
+    ) -> GeneratedSummaryData:
+        """Return a stable summary derived from source metadata."""
+        return GeneratedSummaryData(
+            summary_text=f"{source.resource_kind}:{source.source_text[:30]}",
+            short_summary=f"{source.resource_kind} short",
+            highlights=[source.source_text_hash[:8]],
+            citations=[
+                {
+                    "resource_kind": source.resource_kind,
+                    "resource_id": source.resource_id,
+                },
+            ],
+            metadata_json={"provider": "fake"},
+        )
+
+
+def test_upsert_episode_summary_is_replay_safe(
+    db_session: Session,
+) -> None:
+    """Verify replaying the same summary version updates without duplicates."""
+    episode = _create_episode(db_session)
+    source_hash = stable_source_text_hash("episode source")
+    now = datetime(2026, 5, 22, tzinfo=UTC)
+
+    first = upsert_episode_summary(
+        db=db_session,
+        episode=episode,
+        summary_kind=DerivativeSummaryKind.OVERVIEW,
+        pipeline_version="derivatives-v1",
+        prompt_version="episode-prompt-v1",
+        source_model="summary-model-v1",
+        source_text_hash=source_hash,
+        summary_text="Initial summary",
+        generated_at=now,
+    )
+    second = upsert_episode_summary(
+        db=db_session,
+        episode=episode,
+        summary_kind=DerivativeSummaryKind.OVERVIEW,
+        pipeline_version="derivatives-v1",
+        prompt_version="episode-prompt-v1",
+        source_model="summary-model-v1",
+        source_text_hash=source_hash,
+        summary_text="Updated summary",
+        short_summary="Short",
+        highlights_json=["first highlight"],
+        generated_at=now,
+    )
+    db_session.commit()
+
+    assert_that(second.id).is_equal_to(first.id)
+    assert_that(second.summary_text).is_equal_to("Updated summary")
+    assert_that(second.short_summary).is_equal_to("Short")
+    assert_that(second.highlights_json).is_equal_to(["first highlight"])
+    assert_that(db_session.query(EpisodeSummary).count()).is_equal_to(1)
+
+
+def test_episode_summary_source_prefers_semantic_chunks(
+    db_session: Session,
+) -> None:
+    """Verify episode summaries use semantic chunks before raw transcript text."""
+    episode = _create_episode(db_session)
+    transcript = Transcript(
+        episode_id=episode.id,
+        provider="podscripts",
+        raw_text="raw transcript",
+        cleaned_text="cleaned transcript",
+    )
+    db_session.add(transcript)
+    db_session.flush()
+    db_session.add(
+        SemanticChunk(
+            episode_id=episode.id,
+            transcript_id=transcript.id,
+            chunk_key="chunk-key-1",
+            chunk_index=0,
+            pipeline_version="chunks-v1",
+            source_text_hash=stable_source_text_hash("cleaned transcript"),
+            text="semantic chunk text",
+            context_snippet="semantic chunk text",
+            token_count=3,
+        ),
+    )
+    db_session.flush()
+
+    source = build_episode_summary_source(db=db_session, episode=episode)
+
+    assert_that(source.source_text).is_equal_to("semantic chunk text")
+    assert_that(source.metadata_json["source"]).is_equal_to("semantic_chunks")
+    assert_that(source.metadata_json["chunk_count"]).is_equal_to(1)
+
+
+def test_generate_media_summary_is_version_tracked(
+    db_session: Session,
+) -> None:
+    """Verify media summary generation persists provenance and model metadata."""
+    episode = _create_episode(db_session)
+    media = Media(
+        type=MediaType.BOOK.value,
+        title="Dune",
+        author="Frank Herbert",
+        year=1965,
+        description="A desert planet epic.",
+    )
+    db_session.add(media)
+    db_session.flush()
+    db_session.add(
+        Mention(
+            episode_id=episode.id,
+            media_id=media.id,
+            context="Joe discussed Dune and its ecology.",
+        ),
+    )
+    db_session.flush()
+
+    first = generate_media_summary(
+        db=db_session,
+        media=media,
+        provider=FakeSummaryProvider(),
+        pipeline_version="derivatives-v1",
+        prompt_version="media-prompt-v1",
+    )
+    second = generate_media_summary(
+        db=db_session,
+        media=media,
+        provider=FakeSummaryProvider(),
+        pipeline_version="derivatives-v1",
+        prompt_version="media-prompt-v1",
+    )
+    db_session.commit()
+
+    assert_that(second.id).is_equal_to(first.id)
+    assert_that(second.source_model).is_equal_to("fake-summary-v1")
+    assert_that(second.summary_text).contains("media:Title: Dune")
+    assert_that(second.metadata_json).contains_key("mention_count")
+    assert_that(second.metadata_json).contains_key("provider")
+    assert_that(db_session.query(MediaSummary).count()).is_equal_to(1)
+
+
+def test_generate_episode_summary_creates_new_record_when_source_changes(
+    db_session: Session,
+) -> None:
+    """Verify source hash changes produce auditable summary versions."""
+    episode = _create_episode(db_session)
+    transcript = Transcript(
+        episode_id=episode.id,
+        provider="podscripts",
+        raw_text="first source",
+        cleaned_text="first source",
+    )
+    db_session.add(transcript)
+    db_session.flush()
+
+    first = generate_episode_summary(
+        db=db_session,
+        episode=episode,
+        provider=FakeSummaryProvider(),
+        pipeline_version="derivatives-v1",
+        prompt_version="episode-prompt-v1",
+    )
+    transcript.cleaned_text = "changed source"
+    second = generate_episode_summary(
+        db=db_session,
+        episode=episode,
+        provider=FakeSummaryProvider(),
+        pipeline_version="derivatives-v1",
+        prompt_version="episode-prompt-v1",
+    )
+    db_session.commit()
+
+    assert_that(second.id).is_not_equal_to(first.id)
+    assert_that(second.source_text_hash).is_not_equal_to(first.source_text_hash)
+    assert_that(db_session.query(EpisodeSummary).count()).is_equal_to(2)
+
+
+def _create_episode(
+    db_session: Session,
+) -> Episode:
+    """Create a persisted JRE episode."""
+    podcast = Podcast(name="The Joe Rogan Experience", slug="jre")
+    db_session.add(podcast)
+    db_session.flush()
+    episode = Episode(
+        podcast_id=podcast.id,
+        title="JRE #1",
+        episode_number=1,
+    )
+    db_session.add(episode)
+    db_session.flush()
+    return episode

--- a/backend/tests/test_semantic_chunks.py
+++ b/backend/tests/test_semantic_chunks.py
@@ -1,0 +1,229 @@
+"""Tests for semantic transcript chunk derivatives."""
+
+from datetime import UTC, datetime
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    Episode,
+    Podcast,
+    SemanticChunk,
+    SemanticChunkEmbeddingStatus,
+    Transcript,
+)
+from podex.services.semantic_chunks import (
+    SemanticChunkingPolicy,
+    build_semantic_chunk_candidates,
+    sync_semantic_chunks_for_transcript,
+)
+
+
+class FakeEmbeddingProvider:
+    """Deterministic embedding provider for semantic chunk tests."""
+
+    model_name = "fake-embedding-v1"
+    dimensions = 3
+
+    def embed_texts(
+        self,
+        texts: list[str],
+    ) -> list[list[float]]:
+        """Return stable toy vectors for the provided texts."""
+        return [
+            [float(index), float(len(text.split())), 1.0]
+            for index, text in enumerate(texts)
+        ]
+
+
+class BadEmbeddingProvider:
+    """Embedding provider that returns malformed vectors."""
+
+    model_name = "bad-embedding-v1"
+    dimensions = 3
+
+    def embed_texts(
+        self,
+        texts: list[str],
+    ) -> list[list[float]]:
+        """Return vectors with the wrong dimensions."""
+        return [[1.0, 2.0] for _text in texts]
+
+
+def test_build_semantic_chunk_candidates_uses_segment_timestamps(
+    db_session: Session,
+) -> None:
+    """Verify semantic chunks preserve transcript segment timestamp provenance."""
+    transcript = _create_transcript(
+        db_session=db_session,
+        segments_json=[
+            {"start": 0.2, "end": 5.2, "text": "alpha beta gamma"},
+            {"start": 5.6, "end": 9.1, "text": "delta epsilon zeta"},
+            {"start": 9.8, "end": 12.4, "text": "eta theta iota"},
+        ],
+    )
+    policy = SemanticChunkingPolicy(max_words=6, overlap_words=3, min_words=2)
+
+    candidates = build_semantic_chunk_candidates(
+        transcript=transcript,
+        policy=policy,
+    )
+
+    assert_that(candidates).is_length(2)
+    assert_that(candidates[0].text).is_equal_to(
+        "alpha beta gamma delta epsilon zeta",
+    )
+    assert_that(candidates[0].start_seconds).is_equal_to(0)
+    assert_that(candidates[0].end_seconds).is_equal_to(9)
+    assert_that(candidates[1].text).is_equal_to("delta epsilon zeta eta theta iota")
+    assert_that(candidates[1].start_seconds).is_equal_to(6)
+    assert_that(candidates[1].end_seconds).is_equal_to(12)
+
+
+def test_sync_semantic_chunks_is_replay_safe(
+    db_session: Session,
+) -> None:
+    """Verify repeated syncs avoid duplicate semantic chunks."""
+    transcript = _create_transcript(
+        db_session=db_session,
+        cleaned_text="one two three four five six seven eight nine ten",
+    )
+    policy = SemanticChunkingPolicy(max_words=5, overlap_words=2, min_words=2)
+
+    first = sync_semantic_chunks_for_transcript(
+        db=db_session,
+        transcript=transcript,
+        policy=policy,
+    )
+    second = sync_semantic_chunks_for_transcript(
+        db=db_session,
+        transcript=transcript,
+        policy=policy,
+    )
+    db_session.commit()
+
+    assert_that(first.created_count).is_equal_to(3)
+    assert_that(first.updated_count).is_equal_to(0)
+    assert_that(second.created_count).is_equal_to(0)
+    assert_that(second.updated_count).is_equal_to(0)
+    assert_that(db_session.query(SemanticChunk).count()).is_equal_to(3)
+
+
+def test_sync_semantic_chunks_persists_embeddings(
+    db_session: Session,
+) -> None:
+    """Verify embedding providers populate semantic chunk vector metadata."""
+    transcript = _create_transcript(
+        db_session=db_session,
+        cleaned_text="one two three four five six",
+    )
+    policy = SemanticChunkingPolicy(max_words=6, overlap_words=0, min_words=2)
+    now = datetime(2026, 5, 22, tzinfo=UTC)
+
+    result = sync_semantic_chunks_for_transcript(
+        db=db_session,
+        transcript=transcript,
+        embedding_provider=FakeEmbeddingProvider(),
+        policy=policy,
+        now=now,
+    )
+    db_session.commit()
+
+    chunk = db_session.query(SemanticChunk).one()
+    assert_that(result.embedded_count).is_equal_to(1)
+    assert_that(chunk.embedding_status).is_equal_to(
+        SemanticChunkEmbeddingStatus.EMBEDDED.value,
+    )
+    assert_that(chunk.embedding_model).is_equal_to("fake-embedding-v1")
+    assert_that(chunk.embedding_dimensions).is_equal_to(3)
+    assert_that(chunk.embedding_vector).is_equal_to([0.0, 6.0, 1.0])
+    embedded_at = chunk.embedded_at
+    assert_that(embedded_at).is_not_none()
+    if embedded_at is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(embedded_at.replace(tzinfo=UTC)).is_equal_to(now)
+
+
+def test_sync_semantic_chunks_marks_bad_embedding_output_failed(
+    db_session: Session,
+) -> None:
+    """Verify malformed provider output records failure without dropping chunks."""
+    transcript = _create_transcript(
+        db_session=db_session,
+        cleaned_text="one two three four five six",
+    )
+    policy = SemanticChunkingPolicy(max_words=6, overlap_words=0, min_words=2)
+
+    result = sync_semantic_chunks_for_transcript(
+        db=db_session,
+        transcript=transcript,
+        embedding_provider=BadEmbeddingProvider(),
+        policy=policy,
+    )
+    db_session.commit()
+
+    chunk = db_session.query(SemanticChunk).one()
+    assert_that(result.failed_count).is_equal_to(1)
+    assert_that(chunk.embedding_status).is_equal_to(
+        SemanticChunkEmbeddingStatus.FAILED.value,
+    )
+    assert_that(chunk.embedding_error).contains("unexpected dimensions")
+
+
+def test_sync_semantic_chunks_deletes_stale_replay_windows(
+    db_session: Session,
+) -> None:
+    """Verify transcript text changes remove obsolete semantic chunks."""
+    transcript = _create_transcript(
+        db_session=db_session,
+        cleaned_text="one two three four five six seven eight nine ten",
+    )
+    policy = SemanticChunkingPolicy(max_words=5, overlap_words=0, min_words=2)
+    sync_semantic_chunks_for_transcript(
+        db=db_session,
+        transcript=transcript,
+        policy=policy,
+    )
+    transcript.cleaned_text = "alpha beta gamma delta epsilon"
+
+    result = sync_semantic_chunks_for_transcript(
+        db=db_session,
+        transcript=transcript,
+        policy=policy,
+    )
+    db_session.commit()
+
+    chunks = db_session.query(SemanticChunk).all()
+    assert_that(result.deleted_count).is_equal_to(2)
+    assert_that(result.created_count).is_equal_to(1)
+    assert_that(chunks).is_length(1)
+    assert_that(chunks[0].text).is_equal_to("alpha beta gamma delta epsilon")
+
+
+def _create_transcript(
+    *,
+    db_session: Session,
+    cleaned_text: str | None = None,
+    segments_json: list[dict[str, object]] | None = None,
+) -> Transcript:
+    """Create a persisted transcript with podcast and episode parents."""
+    podcast = Podcast(name="The Joe Rogan Experience", slug="jre")
+    db_session.add(podcast)
+    db_session.flush()
+    episode = Episode(
+        podcast_id=podcast.id,
+        title="JRE #1",
+        episode_number=1,
+    )
+    db_session.add(episode)
+    db_session.flush()
+    transcript = Transcript(
+        episode_id=episode.id,
+        provider="podscripts",
+        raw_text=cleaned_text,
+        cleaned_text=cleaned_text,
+        segments_json=segments_json,
+    )
+    db_session.add(transcript)
+    db_session.flush()
+    return transcript


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(derivatives): add chunking, summaries, triples, and orchestration`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Second slice of the derivatives theme (#108 old PR5; source: the #103 branch):

- `services/semantic_chunks.py` (#24): deterministic transcript chunking with idempotent chunk keys, token counts, and embedding status bookkeeping.
- `services/derivative_summaries.py` (#66): episode/media summary generation with pipeline/prompt versioning and source-text hashes for replay safety.
- `services/graph_relations.py` (#25): the graph-triple upserts deferred from the merge slice — stable-keyed, validated media/literal triples.
- `services/derivative_generation.py` (#67): per-episode orchestration (chunks → summaries → triples) recording `DerivativeGenerationRun` audit rows with counters.
- `services/derivative_coverage.py`: coverage reporting over the derivative layer.
- Ported test modules for chunks, summaries, and generation.

Remaining for the theme: D3 — publish/backfill wiring (#96), production embedding provider config (#97), and merge re-pointing (#98); the LLM summary text itself flows through the #253 prompt seam (no embedded prompts — semgrep gate green).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Relates to #24
- Relates to #25
- Relates to #66
- Relates to #67
- Relates to #108

## Details

Verified: `uv run lintro tst` (308 passed) at 85.3% coverage; ruff/mypy/bandit/pydoclint clean; prompt-boundary semgrep gate unaffected.