### PR TITLE
feat(media): re-point derivative data to the target during canonical merge

### DIFF
--- a/backend/src/podex/services/ops_media_commands.py
+++ b/backend/src/podex/services/ops_media_commands.py
@@ -818,6 +818,11 @@ def merge_ops_media(
         source_media=source_media,
         target_media=target_media,
     )
+    _repoint_derivatives_to_target(
+        db=db,
+        source_media=source_media,
+        target_media=target_media,
+    )
     db.delete(source_media)
     db.flush()
 
@@ -829,3 +834,160 @@ def merge_ops_media(
         source_id=source_media_id,
         target=merged_target,
     )
+
+
+def _repoint_derivatives_to_target(
+    *,
+    db: Session,
+    source_media: Media,
+    target_media: Media,
+) -> None:
+    """Re-point derivative data from a merged source onto the target.
+
+    External references move (deduplicated against the target), relations
+    and graph triples are re-keyed onto the target (self-references and key
+    collisions are dropped), and source media summaries are deleted so the
+    derivative pipeline regenerates them for the canonical record (#98).
+
+    Args:
+        db: Database session.
+        source_media: Media record being merged away.
+        target_media: Surviving canonical media record.
+    """
+    from podex.models import (
+        GraphTriple,
+        MediaRelation,
+        MediaRelationType,
+        MediaSummary,
+    )
+    from podex.services.graph_relations import (
+        GraphTripleInputData,
+        stable_graph_triple_key,
+        stable_media_relation_key,
+    )
+
+    for ref in list(source_media.external_refs):
+        duplicate = (
+            db.query(MediaExternalRef)
+            .filter(
+                MediaExternalRef.media_id == target_media.id,
+                MediaExternalRef.source == ref.source,
+                MediaExternalRef.external_id == ref.external_id,
+            )
+            .first()
+        )
+        if duplicate is not None:
+            db.delete(ref)
+        else:
+            # Reassign via the relationship so deleting the source does not
+            # null the FK through the collection cascade.
+            ref.media = target_media
+
+    relations = (
+        db.query(MediaRelation)
+        .filter(
+            (MediaRelation.subject_media_id == source_media.id)
+            | (MediaRelation.object_media_id == source_media.id),
+        )
+        .all()
+    )
+    for relation in relations:
+        subject_id = (
+            target_media.id
+            if relation.subject_media_id == source_media.id
+            else relation.subject_media_id
+        )
+        object_id = (
+            target_media.id
+            if relation.object_media_id == source_media.id
+            else relation.object_media_id
+        )
+        if subject_id == object_id:
+            db.delete(relation)
+            continue
+        new_key = stable_media_relation_key(
+            subject_media_id=subject_id,
+            object_media_id=object_id,
+            relation_type=MediaRelationType(relation.relation_type),
+            source=relation.source,
+            provenance_episode_id=relation.provenance_episode_id,
+        )
+        collision = (
+            db.query(MediaRelation)
+            .filter(
+                MediaRelation.relation_key == new_key,
+                MediaRelation.id != relation.id,
+            )
+            .first()
+        )
+        if collision is not None:
+            db.delete(relation)
+            continue
+        relation.subject_media = (
+            target_media
+            if relation.subject_media_id == source_media.id
+            else relation.subject_media
+        )
+        relation.object_media = (
+            target_media
+            if relation.object_media_id == source_media.id
+            else relation.object_media
+        )
+        relation.relation_key = new_key
+
+    triples = (
+        db.query(GraphTriple)
+        .filter(
+            (GraphTriple.subject_media_id == source_media.id)
+            | (GraphTriple.object_media_id == source_media.id),
+        )
+        .all()
+    )
+    for triple in triples:
+        subject_id = (
+            target_media.id
+            if triple.subject_media_id == source_media.id
+            else triple.subject_media_id
+        )
+        object_id = (
+            target_media.id
+            if triple.object_media_id == source_media.id
+            else triple.object_media_id
+        )
+        if object_id is not None and subject_id == object_id:
+            db.delete(triple)
+            continue
+        new_key = stable_graph_triple_key(
+            GraphTripleInputData(
+                subject_media_id=subject_id,
+                predicate=triple.predicate,
+                source=triple.source,
+                object_media_id=object_id,
+                object_value=triple.object_value,
+                provenance_episode_id=triple.provenance_episode_id,
+                provenance_mention_id=triple.provenance_mention_id,
+            ),
+        )
+        collision = (
+            db.query(GraphTriple)
+            .filter(
+                GraphTriple.triple_key == new_key,
+                GraphTriple.id != triple.id,
+            )
+            .first()
+        )
+        if collision is not None:
+            db.delete(triple)
+            continue
+        if triple.subject_media_id == source_media.id:
+            triple.subject_media = target_media
+        if triple.object_media_id == source_media.id:
+            triple.object_media = target_media
+        triple.triple_key = new_key
+
+    for summary in (
+        db.query(MediaSummary).filter(MediaSummary.media_id == source_media.id).all()
+    ):
+        db.delete(summary)
+
+    db.flush()

--- a/backend/tests/test_ops_media_commands.py
+++ b/backend/tests/test_ops_media_commands.py
@@ -287,3 +287,97 @@ def test_query_helper_subqueries_and_edit_edge_cases(
         ),
     )
     assert_that(typed).is_not_none()
+
+
+def test_merge_repoints_derivative_data_to_target(db_session: Session) -> None:
+    """Merging re-points refs, relations, and triples; drops source summaries."""
+    from datetime import UTC, datetime
+
+    from podex.models import (
+        GraphTriple,
+        GraphTripleObjectKind,
+        MediaExternalRef,
+        MediaRelation,
+        MediaSummary,
+        MediaType,
+    )
+    from podex.services.graph_relations import (
+        GraphTripleInputData,
+        stable_media_relation_key,
+        upsert_graph_triple,
+        upsert_media_relation,
+    )
+
+    source = Media(type=MediaType.BOOK, title="Dune (dupe)")
+    target = Media(type=MediaType.BOOK, title="Dune")
+    other = Media(type=MediaType.MOVIE, title="Dune (1984)")
+    db_session.add_all([source, target, other])
+    db_session.commit()
+
+    db_session.add(
+        MediaExternalRef(
+            media_id=source.id,
+            source="wikipedia",
+            external_id="Dune_(novel)",
+        ),
+    )
+    upsert_media_relation(
+        db=db_session,
+        subject_media_id=other.id,
+        object_media_id=source.id,
+        relation_type=MediaRelationType.ADAPTED_FROM,
+        source="review",
+    )
+    upsert_graph_triple(
+        db=db_session,
+        payload=GraphTripleInputData(
+            subject_media_id=source.id,
+            predicate="published_year",
+            source="test",
+            object_value="1965",
+        ),
+    )
+    db_session.add(
+        MediaSummary(
+            media_id=source.id,
+            summary_key="dupe:overview:v1",
+            summary_kind="overview",
+            pipeline_version="v1",
+            prompt_version="p1",
+            source_text_hash="e" * 64,
+            source_model="claude-opus-4-8",
+            summary_text="Summary of the duplicate record.",
+            generated_at=datetime(2026, 7, 18, tzinfo=UTC),
+        ),
+    )
+    db_session.commit()
+
+    result = merge_ops_media(
+        db=db_session,
+        source_media_id=source.id,
+        target_media_id=target.id,
+    )
+    db_session.commit()
+
+    assert_that(result).is_not_none()
+    refs = db_session.query(MediaExternalRef).all()
+    assert_that(refs).is_length(1)
+    assert_that(refs[0].media_id).is_equal_to(target.id)
+    relations = db_session.query(MediaRelation).all()
+    assert_that(relations).is_length(1)
+    assert_that(relations[0].object_media_id).is_equal_to(target.id)
+    assert_that(relations[0].relation_key).is_equal_to(
+        stable_media_relation_key(
+            subject_media_id=other.id,
+            object_media_id=target.id,
+            relation_type=MediaRelationType.ADAPTED_FROM,
+            source="review",
+        ),
+    )
+    triples = db_session.query(GraphTriple).all()
+    assert_that(triples).is_length(1)
+    assert_that(triples[0].subject_media_id).is_equal_to(target.id)
+    assert_that(triples[0].object_kind).is_equal_to(
+        GraphTripleObjectKind.LITERAL.value,
+    )
+    assert_that(db_session.query(MediaSummary).count()).is_equal_to(0)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(media): re-point derivative data to the target during canonical merge`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Implements #98 — with the derivative layer now on main (#268/#270), `merge_ops_media` had to become derivative-aware or a merge would orphan/nullify graph data through the source-delete cascade:

- **External refs**: moved to the target, deduplicated against `(source, external_id)`.
- **Media relations**: subject/object re-pointed with `relation_key` recomputed via `stable_media_relation_key`; post-merge self-relations and key collisions are dropped.
- **Graph triples**: same treatment via `stable_graph_triple_key`, preserving literal objects and provenance links.
- **Media summaries**: source summaries are deleted — they describe the removed record; the derivative pipeline regenerates for the canonical target.
- Reassignments go through ORM relationships (not raw FK writes) so `db.delete(source)` cannot cascade-null the moved rows — the failure mode the new test caught.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #98
- Relates to #108

## Details

Verified: `uv run lintro tst` (309 passed) at 85.2% coverage; ruff/mypy/bandit/pydoclint clean. The new test seeds refs + relations + triples + summaries on a duplicate record, merges, and asserts every row survives on the target with recomputed stable keys (and summaries are gone).