### PR TITLE
feat(services): add transcript retention, sampling, and encrypted artifact services

### DIFF
--- a/backend/alembic/versions/0008_add_media_enrichment_columns.py
+++ b/backend/alembic/versions/0008_add_media_enrichment_columns.py
@@ -6,6 +6,7 @@ Create Date: 2026-07-18 00:00:00.000000
 """
 
 from collections.abc import Sequence
+from typing import Any
 
 import sqlalchemy as sa
 
@@ -16,7 +17,7 @@ down_revision: str | None = "0007"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-_COLUMNS: list[sa.Column] = [
+_COLUMNS: list["sa.Column[Any]"] = [
     sa.Column("google_books_id", sa.String(length=50), nullable=True),
     sa.Column("open_library_id", sa.String(length=50), nullable=True),
     sa.Column("imdb_id", sa.String(length=20), nullable=True),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
   "rapidfuzz>=3.9",
   "spotipy>=2.24",
   "anthropic>=0.40",
+  "cryptography>=48.0.0",
+  "boto3>=1.43.14",
 ]
 
 [project.urls]
@@ -103,6 +105,12 @@ module = [
   "tests.test_migrations",
 ]
 warn_unused_ignores = false
+
+# boto3 ships no inline types and the stubs are not installed in the CI lint
+# image; treat it as untyped rather than pulling in boto3-stubs.
+[[tool.mypy.overrides]]
+module = ["boto3.*", "botocore.*"]
+ignore_missing_imports = true
 
 [tool.lintro]
 line_length = 88

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -1,6 +1,7 @@
 """Application configuration loaded from the environment."""
 
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -42,6 +43,19 @@ class Settings(BaseSettings):
     # ``ge=0`` bound catches negative overrides at startup instead of allowing
     # a misconfigured value to disable caching in a surprising way.
     stats_cache_ttl_seconds: float = Field(default=30.0, ge=0, allow_inf_nan=False)
+
+    # Encrypted raw transcript artifact storage. Raw transcripts are stored
+    # only as encrypted objects; without an encryption key no artifact store
+    # is built and raw storage is unavailable. Placeholder-free by default —
+    # keys and buckets come from the deployment environment.
+    transcript_artifact_storage_backend: str = "encrypted_filesystem"
+    transcript_artifact_storage_path: Path = Path("./data/transcript-artifacts")
+    transcript_artifact_encryption_key: str = ""
+    transcript_artifact_s3_bucket: str = ""
+    transcript_artifact_s3_endpoint_url: str = ""
+    transcript_artifact_s3_region_name: str = ""
+    transcript_artifact_s3_access_key_id: str = ""
+    transcript_artifact_s3_secret_access_key: str = ""
 
 
 @lru_cache

--- a/backend/src/podex/models/episode.py
+++ b/backend/src/podex/models/episode.py
@@ -13,6 +13,7 @@ from podex.models.base import Base
 if TYPE_CHECKING:
     from podex.models.derivative_generation_run import DerivativeGenerationRun
     from podex.models.episode_summary import EpisodeSummary
+    from podex.models.podcast import Podcast
     from podex.models.semantic_chunk import SemanticChunk
     from podex.models.transcript import Transcript
 
@@ -78,6 +79,7 @@ class Episode(Base):
         server_default=func.now(),
     )
 
+    podcast: Mapped["Podcast"] = relationship(back_populates="episodes")
     transcripts: Mapped[list["Transcript"]] = relationship(
         back_populates="episode",
     )

--- a/backend/src/podex/models/podcast.py
+++ b/backend/src/podex/models/podcast.py
@@ -2,13 +2,17 @@
 
 from datetime import datetime
 from enum import StrEnum, auto
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, String, func
 from sqlalchemy import Enum as SAEnum
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from podex.models.base import Base
 from podex.models.episode import DiscoverySource
+
+if TYPE_CHECKING:
+    from podex.models.episode import Episode
 
 
 class PodcastStatus(StrEnum):
@@ -60,3 +64,5 @@ class Podcast(Base):
         DateTime(timezone=True),
         server_default=func.now(),
     )
+
+    episodes: Mapped[list["Episode"]] = relationship(back_populates="podcast")

--- a/backend/src/podex/services/retention_sampling.py
+++ b/backend/src/podex/services/retention_sampling.py
@@ -1,0 +1,273 @@
+"""Stratified transcript retention sampling for the calibration corpus."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from math import ceil
+
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import Query, Session
+
+from podex.models import (
+    Episode,
+    MentionCandidate,
+    Podcast,
+    Transcript,
+    TranscriptArtifact,
+)
+from podex.services.transcript_retention import (
+    TranscriptRetentionPolicy,
+    TranscriptRetentionSampleKey,
+    TranscriptRetentionService,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionSampleStratumData:
+    """Coverage for one source/topic/confidence/age sample stratum."""
+
+    source: str
+    topic: str
+    confidence_band: str
+    age_bucket: str
+    eligible_count: int
+    sampled_count: int
+    target_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionSamplingReportData:
+    """Coverage report for the permanent transcript calibration corpus."""
+
+    policy_version: str
+    sample_rate: float
+    eligible_count: int
+    sampled_count: int
+    target_count: int
+    strata: list[RetentionSampleStratumData]
+
+
+@dataclass(frozen=True, slots=True)
+class _CandidateTranscriptData:
+    """Eligible transcript plus its stable stratification dimensions."""
+
+    transcript: Transcript
+    source: str
+    topic: str
+    confidence_band: str
+    age_bucket: str
+    score: float
+
+
+def recalculate_retention_sample(
+    *,
+    db: Session,
+    policy: TranscriptRetentionPolicy,
+    now: datetime | None = None,
+) -> RetentionSamplingReportData:
+    """Assign deterministic retention exemptions across all populated strata."""
+    effective_now = now or datetime.now(UTC)
+    service = TranscriptRetentionService(policy=policy)
+    candidates = _eligible_candidates(db=db, service=service, now=effective_now)
+    grouped: dict[tuple[str, str, str, str], list[_CandidateTranscriptData]] = {}
+    for candidate in candidates:
+        key = (
+            candidate.source,
+            candidate.topic,
+            candidate.confidence_band,
+            candidate.age_bucket,
+        )
+        grouped.setdefault(key, []).append(candidate)
+
+    strata: list[RetentionSampleStratumData] = []
+    for key, group in sorted(grouped.items()):
+        selected_count = (
+            max(1, ceil(len(group) * policy.retention_sample_rate))
+            if policy.retention_sample_rate > 0
+            else 0
+        )
+        selected_ids = {
+            item.transcript.id
+            for item in sorted(
+                group, key=lambda item: (item.score, item.transcript.id)
+            )[:selected_count]
+        }
+        for item in group:
+            item.transcript.retention_exempt_sample = item.transcript.id in selected_ids
+            item.transcript.retention_policy_version = policy.sample_version
+            item.transcript.retention_sample_rate = policy.retention_sample_rate
+            item.transcript.retention_sample_score = item.score
+            item.transcript.retention_sample_strata_json = {
+                "source": item.source,
+                "topic": item.topic,
+                "confidence_band": item.confidence_band,
+                "age_bucket": item.age_bucket,
+            }
+        strata.append(
+            RetentionSampleStratumData(
+                source=key[0],
+                topic=key[1],
+                confidence_band=key[2],
+                age_bucket=key[3],
+                eligible_count=len(group),
+                sampled_count=selected_count,
+                target_count=selected_count,
+            )
+        )
+
+    db.flush()
+    return _to_report(policy=policy, candidates=candidates, strata=strata)
+
+
+def get_retention_sampling_report(
+    *,
+    db: Session,
+    policy: TranscriptRetentionPolicy | None = None,
+) -> RetentionSamplingReportData:
+    """Build coverage metrics for currently persisted sample assignments."""
+    effective_policy = policy or TranscriptRetentionPolicy()
+    transcripts = (
+        _with_retained_raw_payload(db.query(Transcript))
+        .filter(Transcript.purged_at.is_(None))
+        .order_by(Transcript.id.asc())
+        .all()
+    )
+    grouped: dict[tuple[str, str, str, str], list[Transcript]] = {}
+    for transcript in transcripts:
+        strata = transcript.retention_sample_strata_json or {}
+        key = (
+            strata.get("source", "unassigned"),
+            strata.get("topic", "unassigned"),
+            strata.get("confidence_band", "unassigned"),
+            strata.get("age_bucket", "unassigned"),
+        )
+        grouped.setdefault(key, []).append(transcript)
+    persisted_version = next(
+        (
+            transcript.retention_policy_version
+            for transcript in transcripts
+            if transcript.retention_policy_version is not None
+        ),
+        effective_policy.sample_version,
+    )
+    persisted_rate = next(
+        (
+            transcript.retention_sample_rate
+            for transcript in transcripts
+            if transcript.retention_sample_rate is not None
+        ),
+        effective_policy.retention_sample_rate,
+    )
+    report_strata = [
+        RetentionSampleStratumData(
+            source=key[0],
+            topic=key[1],
+            confidence_band=key[2],
+            age_bucket=key[3],
+            eligible_count=len(group),
+            sampled_count=sum(
+                1 for transcript in group if transcript.retention_exempt_sample
+            ),
+            target_count=(
+                max(1, ceil(len(group) * persisted_rate)) if persisted_rate > 0 else 0
+            ),
+        )
+        for key, group in sorted(grouped.items())
+    ]
+    return RetentionSamplingReportData(
+        policy_version=persisted_version,
+        sample_rate=persisted_rate,
+        eligible_count=len(transcripts),
+        sampled_count=sum(
+            1 for transcript in transcripts if transcript.retention_exempt_sample
+        ),
+        target_count=sum(item.target_count for item in report_strata),
+        strata=report_strata,
+    )
+
+
+def _eligible_candidates(
+    *,
+    db: Session,
+    service: TranscriptRetentionService,
+    now: datetime,
+) -> list[_CandidateTranscriptData]:
+    """Load eligible transcripts and derive their sample strata."""
+    transcripts = (
+        _with_retained_raw_payload(db.query(Transcript))
+        .join(Episode, Episode.id == Transcript.episode_id)
+        .join(Podcast, Podcast.id == Episode.podcast_id)
+        .filter(Transcript.purged_at.is_(None))
+        .order_by(Transcript.id.asc())
+        .all()
+    )
+    candidates: list[_CandidateTranscriptData] = []
+    for transcript in transcripts:
+        episode = transcript.episode
+        extraction = (
+            db.query(MentionCandidate)
+            .filter(MentionCandidate.episode_id == episode.id)
+            .order_by(MentionCandidate.confidence.desc(), MentionCandidate.id.asc())
+            .first()
+        )
+        confidence = extraction.confidence if extraction is not None else None
+        topic = extraction.media_type if extraction is not None else "unknown"
+        source = episode.podcast.slug
+        acquired_at = transcript.fetched_at or transcript.created_at
+        sample = service.choose_sample(
+            sample_key=TranscriptRetentionSampleKey(
+                transcript_key=f"transcript:{transcript.id}",
+                source_key=source,
+                topic_key=topic,
+            ),
+            acquired_at=acquired_at,
+            now=now,
+            extraction_confidence=confidence,
+        )
+        candidates.append(
+            _CandidateTranscriptData(
+                transcript=transcript,
+                source=source,
+                topic=topic,
+                confidence_band=sample.confidence_band.value,
+                age_bucket=sample.age_bucket.value,
+                score=sample.score,
+            )
+        )
+    return candidates
+
+
+def _with_retained_raw_payload(query: Query[Transcript]) -> Query[Transcript]:
+    """Include legacy inline inputs and encrypted artifact-backed inputs."""
+    return (
+        query.outerjoin(
+            TranscriptArtifact,
+            and_(
+                TranscriptArtifact.transcript_id == Transcript.id,
+                TranscriptArtifact.purged_at.is_(None),
+            ),
+        )
+        .filter(
+            or_(
+                Transcript.raw_text.is_not(None),
+                TranscriptArtifact.id.is_not(None),
+            ),
+        )
+        .distinct()
+    )
+
+
+def _to_report(
+    *,
+    policy: TranscriptRetentionPolicy,
+    candidates: list[_CandidateTranscriptData],
+    strata: list[RetentionSampleStratumData],
+) -> RetentionSamplingReportData:
+    """Build a report from a completed recalculation batch."""
+    return RetentionSamplingReportData(
+        policy_version=policy.sample_version,
+        sample_rate=policy.retention_sample_rate,
+        eligible_count=len(candidates),
+        sampled_count=sum(item.sampled_count for item in strata),
+        target_count=sum(item.target_count for item in strata),
+        strata=strata,
+    )

--- a/backend/src/podex/services/transcript_acquisition.py
+++ b/backend/src/podex/services/transcript_acquisition.py
@@ -1,0 +1,35 @@
+"""Data contracts for transcript acquisition results.
+
+Acquisition providers (podscripts, Whisper, and future sources) return these
+shapes; retention and artifact storage consume them. The provider
+implementations live in the transcription theme and are ported separately.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class TranscriptResult:
+    """Result of a transcription."""
+
+    provider: str
+    raw_text: str
+    segments: list[dict[str, str | float]] = field(default_factory=list)
+    fetched_at: datetime | None = None
+    audio_duration_seconds: float = 0.0
+    model_used: str = ""
+
+
+@dataclass
+class TranscriptAcquisitionResult:
+    """Result from attempting to acquire a transcript."""
+
+    success: bool
+    result: TranscriptResult | None
+    source: str
+    error: str | None = None
+    should_store_raw: bool = True
+    source_retention_opt_out: bool = False

--- a/backend/src/podex/services/transcript_artifacts.py
+++ b/backend/src/podex/services/transcript_artifacts.py
@@ -1,0 +1,526 @@
+"""Private storage commands for encrypted raw transcript artifacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Protocol
+
+import boto3
+from cryptography.fernet import Fernet
+from sqlalchemy.orm import Session
+
+from podex.config import Settings
+from podex.models import Episode, Transcript, TranscriptArtifact, TranscriptDigest
+from podex.services.transcript_acquisition import (
+    TranscriptAcquisitionResult,
+)
+from podex.services.transcript_retention_policies import (
+    apply_stored_acquisition_opt_out,
+)
+
+RAW_TRANSCRIPT_CONTENT_TYPE = "application/vnd.podex.transcript+json"
+
+
+class TranscriptArtifactStorageBackend(StrEnum):
+    """Supported private raw transcript storage adapters."""
+
+    ENCRYPTED_FILESYSTEM = auto()
+    ENCRYPTED_S3 = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class StoredTranscriptArtifactData:
+    """Metadata returned when an encrypted object is written."""
+
+    storage_key: str
+    storage_backend: str
+    encryption_key_id: str
+    byte_size: int
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptReacquisitionData:
+    """New hot transcript and stored payload created from a purged asset."""
+
+    transcript: Transcript
+    artifact: TranscriptArtifact
+    prior_digest: TranscriptDigest
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptProcessingPayloadData:
+    """Decrypted raw input required by cleanup and extraction stages."""
+
+    raw_text: str
+    segments: list[dict[str, Any]]
+
+
+class TranscriptArtifactStore(Protocol):
+    """Port for private encrypted raw transcript object storage."""
+
+    def put_json(
+        self,
+        *,
+        storage_key: str,
+        payload: dict[str, Any],
+    ) -> StoredTranscriptArtifactData:
+        """Write an encrypted JSON payload and return object metadata."""
+        ...
+
+    def get_json(self, *, storage_key: str) -> dict[str, Any]:
+        """Read and decrypt one JSON payload."""
+        ...
+
+    def delete(self, *, storage_key: str) -> None:
+        """Delete a stored encrypted payload if it exists."""
+        ...
+
+
+class S3ObjectClient(Protocol):
+    """Minimum S3 client contract required by encrypted artifact storage."""
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        """Write one encrypted object to a private bucket."""
+        ...
+
+    def delete_object(self, **kwargs: Any) -> dict[str, Any]:
+        """Delete one encrypted object from a private bucket."""
+        ...
+
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        """Read one encrypted object from a private bucket."""
+        ...
+
+
+class TranscriptAcquisitionClient(Protocol):
+    """Port for obtaining a fresh provider transcript during re-acquisition."""
+
+    def acquire(self, episode: Episode) -> TranscriptAcquisitionResult:
+        """Acquire a transcript result for one episode."""
+        ...
+
+
+class EncryptedFilesystemTranscriptArtifactStore:
+    """Encrypted local object adapter for development and single-host deploys.
+
+    Args:
+        root_path: Directory under which encrypted transcript objects live.
+        encryption_key: URL-safe Fernet key supplied from secure configuration.
+    """
+
+    def __init__(
+        self,
+        *,
+        root_path: Path,
+        encryption_key: str,
+    ) -> None:
+        if not encryption_key:
+            raise ValueError("TRANSCRIPT_ARTIFACT_ENCRYPTION_KEY must be configured")
+        self.root_path = root_path
+        self.fernet = Fernet(encryption_key.encode("ascii"))
+        self.key_id = sha256(encryption_key.encode("ascii")).hexdigest()[:16]
+
+    def put_json(
+        self,
+        *,
+        storage_key: str,
+        payload: dict[str, Any],
+    ) -> StoredTranscriptArtifactData:
+        """Encrypt and persist one transcript JSON object."""
+        object_path = self._object_path(storage_key=storage_key)
+        object_path.parent.mkdir(parents=True, exist_ok=True)
+        plaintext = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        ciphertext = self.fernet.encrypt(plaintext)
+        object_path.write_bytes(ciphertext)
+        return StoredTranscriptArtifactData(
+            storage_key=storage_key,
+            storage_backend="encrypted_filesystem",
+            encryption_key_id=self.key_id,
+            byte_size=len(ciphertext),
+        )
+
+    def delete(self, *, storage_key: str) -> None:
+        """Delete an encrypted object if it remains on disk."""
+        self._object_path(storage_key=storage_key).unlink(missing_ok=True)
+
+    def get_json(self, *, storage_key: str) -> dict[str, Any]:
+        """Read and decrypt one local transcript JSON object."""
+        ciphertext = self._object_path(storage_key=storage_key).read_bytes()
+        return _decode_encrypted_payload(fernet=self.fernet, ciphertext=ciphertext)
+
+    def _object_path(self, *, storage_key: str) -> Path:
+        """Resolve a constrained relative object key under the storage root."""
+        root = self.root_path.resolve()
+        candidate = (root / storage_key).resolve()
+        if candidate != root and root not in candidate.parents:
+            raise ValueError("Transcript artifact storage key escapes storage root")
+        return candidate
+
+
+class EncryptedS3TranscriptArtifactStore:
+    """Encrypted S3-compatible object adapter for hosted deployments.
+
+    Args:
+        bucket: Private bucket holding encrypted artifact objects.
+        encryption_key: URL-safe Fernet key supplied from secure configuration.
+        endpoint_url: Optional endpoint for S3-compatible providers.
+        region_name: Optional S3 region.
+        access_key_id: Optional static credential for S3-compatible providers.
+        secret_access_key: Optional corresponding secret credential.
+        client: Optional injected S3 client for tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        encryption_key: str,
+        endpoint_url: str = "",
+        region_name: str = "",
+        access_key_id: str = "",
+        secret_access_key: str = "",
+        client: S3ObjectClient | None = None,
+    ) -> None:
+        if not bucket:
+            raise ValueError("TRANSCRIPT_ARTIFACT_S3_BUCKET must be configured")
+        if not encryption_key:
+            raise ValueError("TRANSCRIPT_ARTIFACT_ENCRYPTION_KEY must be configured")
+        self.bucket = bucket
+        self.fernet = Fernet(encryption_key.encode("ascii"))
+        self.key_id = sha256(encryption_key.encode("ascii")).hexdigest()[:16]
+        self.client = client or _build_s3_client(
+            endpoint_url=endpoint_url,
+            region_name=region_name,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+        )
+
+    def put_json(
+        self,
+        *,
+        storage_key: str,
+        payload: dict[str, Any],
+    ) -> StoredTranscriptArtifactData:
+        """Encrypt and upload one transcript JSON object."""
+        plaintext = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        ciphertext = self.fernet.encrypt(plaintext)
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=storage_key,
+            Body=ciphertext,
+            ContentType="application/octet-stream",
+            Metadata={"podex-key-id": self.key_id},
+        )
+        return StoredTranscriptArtifactData(
+            storage_key=storage_key,
+            storage_backend=TranscriptArtifactStorageBackend.ENCRYPTED_S3.value,
+            encryption_key_id=self.key_id,
+            byte_size=len(ciphertext),
+        )
+
+    def delete(self, *, storage_key: str) -> None:
+        """Delete an encrypted artifact object from its private bucket."""
+        self.client.delete_object(Bucket=self.bucket, Key=storage_key)
+
+    def get_json(self, *, storage_key: str) -> dict[str, Any]:
+        """Download and decrypt one S3-compatible transcript JSON object."""
+        response = self.client.get_object(Bucket=self.bucket, Key=storage_key)
+        body = response["Body"]
+        ciphertext = body.read() if hasattr(body, "read") else body
+        if not isinstance(ciphertext, bytes):
+            raise ValueError("Encrypted transcript artifact body must be bytes")
+        return _decode_encrypted_payload(fernet=self.fernet, ciphertext=ciphertext)
+
+
+def build_transcript_artifact_store(
+    *,
+    settings: Settings,
+) -> TranscriptArtifactStore | None:
+    """Build the configured private artifact adapter when a key is supplied."""
+    if not settings.transcript_artifact_encryption_key:
+        return None
+    backend = TranscriptArtifactStorageBackend(
+        settings.transcript_artifact_storage_backend,
+    )
+    if backend is TranscriptArtifactStorageBackend.ENCRYPTED_S3:
+        return EncryptedS3TranscriptArtifactStore(
+            bucket=settings.transcript_artifact_s3_bucket,
+            encryption_key=settings.transcript_artifact_encryption_key,
+            endpoint_url=settings.transcript_artifact_s3_endpoint_url,
+            region_name=settings.transcript_artifact_s3_region_name,
+            access_key_id=settings.transcript_artifact_s3_access_key_id,
+            secret_access_key=settings.transcript_artifact_s3_secret_access_key,
+        )
+    return EncryptedFilesystemTranscriptArtifactStore(
+        root_path=settings.transcript_artifact_storage_path,
+        encryption_key=settings.transcript_artifact_encryption_key,
+    )
+
+
+def _build_s3_client(
+    *,
+    endpoint_url: str,
+    region_name: str,
+    access_key_id: str,
+    secret_access_key: str,
+) -> S3ObjectClient:
+    """Build an S3 client using default credentials unless explicitly supplied."""
+    kwargs: dict[str, str] = {}
+    if endpoint_url:
+        kwargs["endpoint_url"] = endpoint_url
+    if region_name:
+        kwargs["region_name"] = region_name
+    if access_key_id or secret_access_key:
+        if not access_key_id or not secret_access_key:
+            raise ValueError("S3 artifact credentials must be configured together")
+        kwargs["aws_access_key_id"] = access_key_id
+        kwargs["aws_secret_access_key"] = secret_access_key
+    client: S3ObjectClient = boto3.client("s3", **kwargs)
+    return client
+
+
+def persist_transcript_acquisition(
+    *,
+    db: Session,
+    episode: Episode,
+    acquisition: TranscriptAcquisitionResult,
+    artifact_store: TranscriptArtifactStore | None,
+    reacquired_from_digest: TranscriptDigest | None = None,
+) -> tuple[Transcript, TranscriptArtifact | None]:
+    """Persist a successful acquisition and its private raw object.
+
+    Args:
+        db: Database session.
+        episode: Episode whose source payload was acquired.
+        acquisition: Successful provider result and storage policy.
+        artifact_store: Configured private encrypted object adapter.
+        reacquired_from_digest: Optional proof record that triggered reacquisition.
+
+    Returns:
+        New transcript plus stored artifact metadata when raw storage is allowed.
+
+    Raises:
+        ValueError: If acquisition failed or raw storage lacks an adapter.
+    """
+    if not acquisition.success or acquisition.result is None:
+        raise ValueError("Cannot persist an unsuccessful transcript acquisition")
+    acquisition = apply_stored_acquisition_opt_out(
+        db=db,
+        podcast_id=episode.podcast_id,
+        source_key=acquisition.result.provider,
+        acquisition=acquisition,
+    )
+    if acquisition.result is None:
+        raise ValueError("Stored transcript acquisition no longer has a result")
+    if acquisition.should_store_raw and artifact_store is None:
+        raise ValueError("Encrypted transcript artifact storage is not configured")
+
+    result = acquisition.result
+    transcript = Transcript(
+        episode_id=episode.id,
+        provider=result.provider,
+        raw_text=None,
+        segments_json=None,
+        fetched_at=result.fetched_at,
+        retention_tier="hot",
+        source_retention_opt_out=acquisition.source_retention_opt_out,
+    )
+    db.add(transcript)
+    db.flush()
+
+    if not acquisition.should_store_raw:
+        return transcript, None
+
+    if artifact_store is None:  # pragma: no cover - guarded above
+        raise AssertionError
+    artifact = _store_raw_transcript_artifact(
+        db=db,
+        transcript=transcript,
+        artifact_store=artifact_store,
+        raw_text=result.raw_text,
+        segments=result.segments,
+        reacquired_from_digest=reacquired_from_digest,
+    )
+    return transcript, artifact
+
+
+def load_transcript_processing_payload(
+    *,
+    db: Session,
+    transcript: Transcript,
+    artifact_store: TranscriptArtifactStore | None,
+) -> TranscriptProcessingPayloadData | None:
+    """Load private processing input from encrypted storage or legacy columns.
+
+    New acquisitions store raw inputs only in an encrypted artifact. The column
+    fallback allows already-ingested transcripts to finish processing without a
+    data migration.
+
+    Args:
+        db: Database session.
+        transcript: Transcript requiring cleanup or extraction input.
+        artifact_store: Configured encrypted artifact adapter.
+
+    Returns:
+        Raw processing input, or ``None`` if no retained raw payload remains.
+
+    Raises:
+        ValueError: If artifact metadata exists without a configured store or
+            if a stored payload is malformed.
+    """
+    artifact = (
+        db.query(TranscriptArtifact)
+        .filter(
+            TranscriptArtifact.transcript_id == transcript.id,
+            TranscriptArtifact.purged_at.is_(None),
+        )
+        .order_by(TranscriptArtifact.id.desc())
+        .first()
+    )
+    if artifact is not None:
+        if artifact_store is None:
+            raise ValueError("Encrypted transcript artifact storage is not configured")
+        payload = artifact_store.get_json(storage_key=artifact.storage_key)
+        raw_text = payload.get("raw_text")
+        segments = payload.get("segments")
+        if not isinstance(raw_text, str) or not isinstance(segments, list):
+            raise ValueError("Encrypted transcript artifact payload is malformed")
+        if not all(isinstance(segment, dict) for segment in segments):
+            raise ValueError("Encrypted transcript artifact segments are malformed")
+        return TranscriptProcessingPayloadData(
+            raw_text=raw_text,
+            segments=segments,
+        )
+
+    if transcript.raw_text is None and transcript.segments_json is None:
+        return None
+    return TranscriptProcessingPayloadData(
+        raw_text=transcript.raw_text or "",
+        segments=transcript.segments_json or [],
+    )
+
+
+def reacquire_purged_transcript(
+    *,
+    db: Session,
+    transcript: Transcript,
+    acquirer: TranscriptAcquisitionClient,
+    artifact_store: TranscriptArtifactStore | None,
+) -> TranscriptReacquisitionData:
+    """Acquire a fresh hot raw asset for an already purged transcript.
+
+    Args:
+        db: Database session.
+        transcript: Purged source transcript requiring a fresh processing run.
+        acquirer: Provider orchestration used to obtain the new transcript.
+        artifact_store: Configured encrypted artifact storage adapter.
+
+    Returns:
+        Newly stored transcript, artifact, and preserved prior digest.
+
+    Raises:
+        ValueError: If the transcript is not purged or acquisition cannot persist.
+    """
+    if transcript.purged_at is None:
+        raise ValueError("Only purged transcripts can be re-acquired")
+    prior_digest = (
+        db.query(TranscriptDigest)
+        .filter(TranscriptDigest.transcript_id == transcript.id)
+        .order_by(TranscriptDigest.id.desc())
+        .first()
+    )
+    if prior_digest is None:
+        raise ValueError("Purged transcript is missing its digest proof")
+
+    acquisition = acquirer.acquire(transcript.episode)
+    if not acquisition.success:
+        raise ValueError(acquisition.error or "Transcript re-acquisition failed")
+    if not acquisition.should_store_raw:
+        raise ValueError(
+            "Re-acquired transcript cannot be retained under source policy"
+        )
+
+    fresh_transcript, artifact = persist_transcript_acquisition(
+        db=db,
+        episode=transcript.episode,
+        acquisition=acquisition,
+        artifact_store=artifact_store,
+        reacquired_from_digest=prior_digest,
+    )
+    if artifact is None:
+        raise ValueError("Re-acquisition did not create a raw transcript artifact")
+    return TranscriptReacquisitionData(
+        transcript=fresh_transcript,
+        artifact=artifact,
+        prior_digest=prior_digest,
+    )
+
+
+def _store_raw_transcript_artifact(
+    *,
+    db: Session,
+    transcript: Transcript,
+    artifact_store: TranscriptArtifactStore,
+    raw_text: str,
+    segments: list[dict[str, Any]],
+    reacquired_from_digest: TranscriptDigest | None,
+) -> TranscriptArtifact:
+    """Write one raw transcript payload and persist its provenance metadata."""
+    source_hash = sha256(raw_text.encode("utf-8")).hexdigest()
+    storage_key = f"transcripts/{transcript.episode_id}/{transcript.id}/raw.json.enc"
+    stored = artifact_store.put_json(
+        storage_key=storage_key,
+        payload={
+            "provider": transcript.provider,
+            "raw_text": raw_text,
+            "segments": segments,
+            "fetched_at": (
+                transcript.fetched_at.isoformat()
+                if transcript.fetched_at is not None
+                else None
+            ),
+        },
+    )
+    artifact = TranscriptArtifact(
+        transcript_id=transcript.id,
+        episode_id=transcript.episode_id,
+        reacquired_from_digest_id=(
+            reacquired_from_digest.id if reacquired_from_digest is not None else None
+        ),
+        storage_key=stored.storage_key,
+        storage_backend=stored.storage_backend,
+        encryption_key_id=stored.encryption_key_id,
+        provider=transcript.provider,
+        source_text_hash=source_hash,
+        content_type=RAW_TRANSCRIPT_CONTENT_TYPE,
+        byte_size=stored.byte_size,
+        provenance_json={
+            "acquisition_provider": transcript.provider,
+            "fetched_at": (
+                transcript.fetched_at.isoformat()
+                if transcript.fetched_at is not None
+                else None
+            ),
+        },
+        stored_at=datetime.now(UTC),
+    )
+    db.add(artifact)
+    db.flush()
+    return artifact
+
+
+def _decode_encrypted_payload(
+    *,
+    fernet: Fernet,
+    ciphertext: bytes,
+) -> dict[str, Any]:
+    """Decrypt an encrypted raw JSON object and validate its root shape."""
+    payload = json.loads(fernet.decrypt(ciphertext).decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Encrypted transcript artifact JSON must be an object")
+    return payload

--- a/backend/src/podex/services/transcript_retention.py
+++ b/backend/src/podex/services/transcript_retention.py
@@ -1,0 +1,338 @@
+"""Transcript retention policy primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import StrEnum, auto
+from hashlib import sha256
+
+
+class TranscriptLifecycleTier(StrEnum):
+    """Raw transcript lifecycle tiers."""
+
+    HOT = auto()
+    WARM = auto()
+    COLD = auto()
+    PURGED = auto()
+
+
+class TranscriptRetentionBlocker(StrEnum):
+    """Reasons a raw transcript cannot be purged yet."""
+
+    ALREADY_PURGED = auto()
+    ACTIVE_RETENTION_WINDOW = auto()
+    DIGEST_REQUIRED = auto()
+    LOW_CONFIDENCE = auto()
+    MISSING_CONFIDENCE = auto()
+    RETENTION_EXEMPT_SAMPLE = auto()
+
+
+class TranscriptConfidenceBand(StrEnum):
+    """Confidence bands used for stratified retention sampling."""
+
+    UNKNOWN = auto()
+    LOW = auto()
+    MEDIUM = auto()
+    HIGH = auto()
+
+
+class TranscriptAgeBucket(StrEnum):
+    """Age buckets used for stratified retention sampling."""
+
+    RECENT = auto()
+    MID_LIFE = auto()
+    OLDER = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptRetentionPolicy:
+    """Configurable policy for raw transcript lifecycle decisions."""
+
+    hot_retention_period: timedelta = timedelta(days=30)
+    warm_retention_period: timedelta = timedelta(days=180)
+    min_purge_confidence: float = 0.85
+    require_digest_before_purge: bool = True
+    retention_sample_rate: float = 0.075
+    sample_version: str = "retention-sample-v1"
+    low_confidence_max: float = 0.5
+
+    def __post_init__(self) -> None:
+        """Validate policy thresholds."""
+        if self.hot_retention_period < timedelta():
+            raise ValueError("hot_retention_period must be non-negative")
+        if self.warm_retention_period < self.hot_retention_period:
+            raise ValueError(
+                "warm_retention_period must be greater than or equal to "
+                "hot_retention_period",
+            )
+        if not 0 <= self.min_purge_confidence <= 1:
+            raise ValueError("min_purge_confidence must be between 0 and 1")
+        if not 0 <= self.retention_sample_rate <= 1:
+            raise ValueError("retention_sample_rate must be between 0 and 1")
+        if not 0 <= self.low_confidence_max <= 1:
+            raise ValueError("low_confidence_max must be between 0 and 1")
+        if self.low_confidence_max > self.min_purge_confidence:
+            raise ValueError(
+                "low_confidence_max must be less than or equal to min_purge_confidence",
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptRetentionState:
+    """Pure input state for a raw transcript retention evaluation."""
+
+    acquired_at: datetime
+    extraction_confidence: float | None = None
+    digest_created_at: datetime | None = None
+    purged_at: datetime | None = None
+    retention_exempt_sample: bool = False
+    source_retention_opt_out: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptRetentionDecision:
+    """Policy decision for a transcript retention evaluation."""
+
+    tier: TranscriptLifecycleTier
+    purge_eligible: bool
+    purge_blockers: tuple[TranscriptRetentionBlocker, ...]
+    retention_suppressed: bool
+    age: timedelta
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptRetentionSampleKey:
+    """Stable sampling identity and dimensions for a transcript."""
+
+    transcript_key: str
+    source_key: str
+    topic_key: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptRetentionSampleDecision:
+    """Deterministic retention sample assignment."""
+
+    retention_exempt: bool
+    confidence_band: TranscriptConfidenceBand
+    age_bucket: TranscriptAgeBucket
+    sample_version: str
+    score: float
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptRetentionService:
+    """Evaluate raw transcript lifecycle tiers and purge eligibility."""
+
+    policy: TranscriptRetentionPolicy = field(default_factory=TranscriptRetentionPolicy)
+
+    def classify_tier(
+        self,
+        *,
+        state: TranscriptRetentionState,
+        now: datetime,
+    ) -> TranscriptLifecycleTier:
+        """Classify a transcript into its lifecycle tier.
+
+        Args:
+            state: Current transcript retention state.
+            now: Timestamp used for age-sensitive decisions.
+
+        Returns:
+            Lifecycle tier implied by the policy and state.
+        """
+        if state.purged_at is not None:
+            return TranscriptLifecycleTier.PURGED
+
+        if state.source_retention_opt_out:
+            return TranscriptLifecycleTier.COLD
+
+        age = _age_at(acquired_at=state.acquired_at, now=now)
+        if age < self.policy.hot_retention_period:
+            return TranscriptLifecycleTier.HOT
+        if age < self.policy.warm_retention_period:
+            return TranscriptLifecycleTier.WARM
+        return TranscriptLifecycleTier.COLD
+
+    def evaluate(
+        self,
+        *,
+        state: TranscriptRetentionState,
+        now: datetime,
+    ) -> TranscriptRetentionDecision:
+        """Evaluate lifecycle tier and purge eligibility.
+
+        Args:
+            state: Current transcript retention state.
+            now: Timestamp used for age-sensitive decisions.
+
+        Returns:
+            Full retention decision including purge blockers.
+        """
+        tier = self.classify_tier(state=state, now=now)
+        blockers = self._purge_blockers(state=state, tier=tier)
+
+        return TranscriptRetentionDecision(
+            tier=tier,
+            purge_eligible=len(blockers) == 0,
+            purge_blockers=tuple(blockers),
+            retention_suppressed=state.source_retention_opt_out
+            and tier != TranscriptLifecycleTier.PURGED,
+            age=_age_at(acquired_at=state.acquired_at, now=now),
+        )
+
+    def choose_sample(
+        self,
+        *,
+        sample_key: TranscriptRetentionSampleKey,
+        acquired_at: datetime,
+        now: datetime,
+        extraction_confidence: float | None,
+    ) -> TranscriptRetentionSampleDecision:
+        """Choose whether a transcript belongs to the retention sample.
+
+        Args:
+            sample_key: Stable transcript sampling identity and strata.
+            acquired_at: Transcript acquisition timestamp.
+            now: Timestamp used to derive age strata.
+            extraction_confidence: Latest extraction confidence, when known.
+
+        Returns:
+            Deterministic sampling decision.
+        """
+        confidence_band = self.confidence_band(
+            extraction_confidence=extraction_confidence,
+        )
+        age_bucket = self.age_bucket(acquired_at=acquired_at, now=now)
+        score = _stable_score(
+            parts=(
+                self.policy.sample_version,
+                sample_key.source_key,
+                sample_key.topic_key or "",
+                confidence_band.value,
+                age_bucket.value,
+                sample_key.transcript_key,
+            ),
+        )
+
+        return TranscriptRetentionSampleDecision(
+            retention_exempt=score < self.policy.retention_sample_rate,
+            confidence_band=confidence_band,
+            age_bucket=age_bucket,
+            sample_version=self.policy.sample_version,
+            score=score,
+        )
+
+    def confidence_band(
+        self,
+        *,
+        extraction_confidence: float | None,
+    ) -> TranscriptConfidenceBand:
+        """Map extraction confidence to a sampling band.
+
+        Args:
+            extraction_confidence: Latest extraction confidence, when known.
+
+        Returns:
+            Sampling confidence band.
+        """
+        if extraction_confidence is None:
+            return TranscriptConfidenceBand.UNKNOWN
+        if extraction_confidence < self.policy.low_confidence_max:
+            return TranscriptConfidenceBand.LOW
+        if extraction_confidence < self.policy.min_purge_confidence:
+            return TranscriptConfidenceBand.MEDIUM
+        return TranscriptConfidenceBand.HIGH
+
+    def age_bucket(
+        self,
+        *,
+        acquired_at: datetime,
+        now: datetime,
+    ) -> TranscriptAgeBucket:
+        """Map transcript age to a sampling bucket.
+
+        Args:
+            acquired_at: Transcript acquisition timestamp.
+            now: Timestamp used for age-sensitive decisions.
+
+        Returns:
+            Sampling age bucket.
+        """
+        age = _age_at(acquired_at=acquired_at, now=now)
+        if age < self.policy.hot_retention_period:
+            return TranscriptAgeBucket.RECENT
+        if age < self.policy.warm_retention_period:
+            return TranscriptAgeBucket.MID_LIFE
+        return TranscriptAgeBucket.OLDER
+
+    def _purge_blockers(
+        self,
+        *,
+        state: TranscriptRetentionState,
+        tier: TranscriptLifecycleTier,
+    ) -> list[TranscriptRetentionBlocker]:
+        """Build the purge blocker list for a transcript state."""
+        blockers: list[TranscriptRetentionBlocker] = []
+
+        if tier == TranscriptLifecycleTier.PURGED:
+            return [TranscriptRetentionBlocker.ALREADY_PURGED]
+
+        if state.source_retention_opt_out:
+            return blockers
+
+        if tier != TranscriptLifecycleTier.COLD:
+            blockers.append(TranscriptRetentionBlocker.ACTIVE_RETENTION_WINDOW)
+
+        if state.retention_exempt_sample:
+            blockers.append(TranscriptRetentionBlocker.RETENTION_EXEMPT_SAMPLE)
+
+        if state.extraction_confidence is None:
+            blockers.append(TranscriptRetentionBlocker.MISSING_CONFIDENCE)
+        elif state.extraction_confidence < self.policy.min_purge_confidence:
+            blockers.append(TranscriptRetentionBlocker.LOW_CONFIDENCE)
+
+        if self.policy.require_digest_before_purge and state.digest_created_at is None:
+            blockers.append(TranscriptRetentionBlocker.DIGEST_REQUIRED)
+
+        return blockers
+
+
+def _age_at(
+    *,
+    acquired_at: datetime,
+    now: datetime,
+) -> timedelta:
+    """Calculate non-negative transcript age.
+
+    Args:
+        acquired_at: Transcript acquisition timestamp.
+        now: Timestamp used for age-sensitive decisions.
+
+    Returns:
+        Transcript age clamped to zero for clock skew.
+    """
+    normalized_acquired_at = acquired_at
+    normalized_now = now
+    if acquired_at.tzinfo is None and now.tzinfo is not None:
+        normalized_now = now.replace(tzinfo=None)
+    elif acquired_at.tzinfo is not None and now.tzinfo is None:
+        normalized_acquired_at = acquired_at.replace(tzinfo=None)
+    return max(normalized_now - normalized_acquired_at, timedelta())
+
+
+def _stable_score(
+    *,
+    parts: tuple[str, ...],
+) -> float:
+    """Calculate a stable score between 0 and 1 for sampling.
+
+    Args:
+        parts: Stable sampling key components.
+
+    Returns:
+        Floating point score in the range [0, 1).
+    """
+    digest = sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return int(digest[:12], 16) / float(0xFFFFFFFFFFFF + 1)

--- a/backend/src/podex/services/transcript_retention_commands.py
+++ b/backend/src/podex/services/transcript_retention_commands.py
@@ -1,0 +1,216 @@
+"""Persistence commands for transcript retention policy decisions."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    DerivativeGenerationRun,
+    Transcript,
+    TranscriptArtifact,
+    TranscriptDigest,
+)
+from podex.services.transcript_artifacts import TranscriptArtifactStore
+from podex.services.transcript_retention import (
+    TranscriptRetentionDecision,
+    TranscriptRetentionPolicy,
+    TranscriptRetentionSampleKey,
+    TranscriptRetentionService,
+    TranscriptRetentionState,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptRetentionEvaluationData:
+    """Persisted transcript retention evaluation summary."""
+
+    transcript_id: int
+    decision: TranscriptRetentionDecision
+    retention_exempt_sample: bool
+
+
+def create_transcript_digest(
+    *,
+    db: Session,
+    transcript: Transcript,
+    purged_at: datetime,
+) -> TranscriptDigest:
+    """Persist proof of raw-transcript processing before payload deletion.
+
+    Args:
+        db: Database session.
+        transcript: Transcript about to be purged.
+        purged_at: Timestamp of the purge operation.
+
+    Returns:
+        Replay-safe durable digest record.
+    """
+    source_text = transcript.cleaned_text or transcript.raw_text or ""
+    source_hash = sha256(source_text.encode("utf-8")).hexdigest()
+    digest_key = f"transcript:{transcript.id}:purge:{source_hash}"
+    existing = (
+        db.query(TranscriptDigest)
+        .filter(TranscriptDigest.digest_key == digest_key)
+        .first()
+    )
+    if existing is not None:
+        return existing
+
+    extraction_versions = [
+        version
+        for (version,) in db.query(DerivativeGenerationRun.pipeline_version)
+        .filter(DerivativeGenerationRun.transcript_id == transcript.id)
+        .distinct()
+        .order_by(DerivativeGenerationRun.pipeline_version.asc())
+        .all()
+    ]
+    summary_text = transcript.digest_text or _compact_digest_text(source_text)
+    digest = TranscriptDigest(
+        transcript_id=transcript.id,
+        episode_id=transcript.episode_id,
+        digest_key=digest_key,
+        source_text_hash=source_hash,
+        provider=transcript.provider,
+        policy_version=transcript.retention_policy_version,
+        summary_text=summary_text,
+        sampling_strata_json=transcript.retention_sample_strata_json,
+        extraction_versions_json=extraction_versions,
+        metadata_json={
+            "retention_tier": transcript.retention_tier,
+            "retention_exempt_sample": transcript.retention_exempt_sample,
+        },
+        generated_at=purged_at,
+        purged_at=purged_at,
+    )
+    db.add(digest)
+    db.flush()
+    return digest
+
+
+def evaluate_transcript_retention(
+    *,
+    db: Session,
+    transcript: Transcript,
+    extraction_confidence: float | None,
+    source_retention_opt_out: bool = False,
+    policy: TranscriptRetentionPolicy | None = None,
+    now: datetime | None = None,
+) -> TranscriptRetentionEvaluationData:
+    """Evaluate and persist retention state for a transcript.
+
+    Args:
+        db: Database session.
+        transcript: Transcript to evaluate.
+        extraction_confidence: Latest extraction confidence for purge gating.
+        source_retention_opt_out: Whether the source suppresses raw retention.
+        policy: Optional policy override.
+        now: Deterministic evaluation timestamp.
+
+    Returns:
+        Persisted retention evaluation summary.
+    """
+    effective_now = now or datetime.now(UTC)
+    service = TranscriptRetentionService(
+        policy=policy or TranscriptRetentionPolicy(),
+    )
+    acquired_at = transcript.fetched_at or transcript.created_at
+    sample = service.choose_sample(
+        sample_key=TranscriptRetentionSampleKey(
+            transcript_key=f"transcript:{transcript.id}",
+            source_key=transcript.provider,
+            topic_key=None,
+        ),
+        acquired_at=acquired_at,
+        now=effective_now,
+        extraction_confidence=extraction_confidence,
+    )
+    decision = service.evaluate(
+        state=TranscriptRetentionState(
+            acquired_at=acquired_at,
+            extraction_confidence=extraction_confidence,
+            digest_created_at=transcript.digest_created_at,
+            purged_at=transcript.purged_at,
+            retention_exempt_sample=sample.retention_exempt
+            or transcript.retention_exempt_sample,
+            source_retention_opt_out=source_retention_opt_out,
+        ),
+        now=effective_now,
+    )
+
+    transcript.retention_tier = decision.tier.value
+    transcript.retention_policy_version = service.policy.sample_version
+    transcript.retention_evaluated_at = effective_now
+    transcript.retention_exempt_sample = (
+        sample.retention_exempt or transcript.retention_exempt_sample
+    )
+    transcript.source_retention_opt_out = source_retention_opt_out
+    transcript.retention_blockers_json = [
+        blocker.value for blocker in decision.purge_blockers
+    ]
+    transcript.purge_eligible_at = effective_now if decision.purge_eligible else None
+    db.flush()
+
+    return TranscriptRetentionEvaluationData(
+        transcript_id=transcript.id,
+        decision=decision,
+        retention_exempt_sample=sample.retention_exempt,
+    )
+
+
+def purge_transcript_if_eligible(
+    *,
+    db: Session,
+    transcript: Transcript,
+    artifact_store: TranscriptArtifactStore | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Purge raw transcript fields when the latest evaluation allows it.
+
+    Args:
+        db: Database session.
+        transcript: Transcript to purge.
+        artifact_store: Private object adapter used to delete raw artifacts.
+        now: Deterministic purge timestamp.
+
+    Returns:
+        ``True`` when raw transcript fields were purged.
+    """
+    if transcript.purge_eligible_at is None or transcript.purged_at is not None:
+        return False
+
+    purged_at = now or datetime.now(UTC)
+    active_artifacts = (
+        db.query(TranscriptArtifact)
+        .filter(
+            TranscriptArtifact.transcript_id == transcript.id,
+            TranscriptArtifact.purged_at.is_(None),
+        )
+        .all()
+    )
+    if active_artifacts and artifact_store is None:
+        raise ValueError("Encrypted transcript artifact storage is not configured")
+    create_transcript_digest(db=db, transcript=transcript, purged_at=purged_at)
+    for artifact in active_artifacts:
+        if artifact_store is None:  # pragma: no cover - guarded above
+            raise AssertionError
+        artifact_store.delete(storage_key=artifact.storage_key)
+        artifact.purged_at = purged_at
+    transcript.raw_text = None
+    transcript.cleaned_text = None
+    transcript.segments_json = None
+    transcript.purged_at = purged_at
+    transcript.retention_tier = "purged"
+    db.flush()
+    return True
+
+
+def _compact_digest_text(text: str, max_length: int = 1000) -> str:
+    """Build a compact, non-empty digest summary from raw text."""
+    compacted = " ".join(text.split())
+    if not compacted:
+        return "Raw transcript was purged after retention evaluation."
+    if len(compacted) <= max_length:
+        return compacted
+    return f"{compacted[: max_length - 3].rstrip()}..."

--- a/backend/src/podex/services/transcript_retention_policies.py
+++ b/backend/src/podex/services/transcript_retention_policies.py
@@ -1,0 +1,102 @@
+"""Persistence services for source-scoped transcript retention policy."""
+
+from dataclasses import replace
+from datetime import timedelta
+
+from sqlalchemy.orm import Session
+
+from podex.models import Transcript, TranscriptSourceRetentionPolicy
+from podex.services.transcript_acquisition import TranscriptAcquisitionResult
+from podex.services.transcript_retention import TranscriptRetentionPolicy
+
+
+def upsert_transcript_source_retention_policy(
+    *,
+    db: Session,
+    transcript: Transcript,
+    policy: TranscriptRetentionPolicy,
+    source_retention_opt_out: bool,
+) -> TranscriptSourceRetentionPolicy:
+    """Save lifecycle configuration for a transcript's podcast and source."""
+    record = (
+        db.query(TranscriptSourceRetentionPolicy)
+        .filter(
+            TranscriptSourceRetentionPolicy.podcast_id == transcript.episode.podcast_id,
+            TranscriptSourceRetentionPolicy.source_key == transcript.provider,
+        )
+        .first()
+    )
+    if record is None:
+        record = TranscriptSourceRetentionPolicy(
+            podcast_id=transcript.episode.podcast_id,
+            source_key=transcript.provider,
+            policy_version=policy.sample_version,
+            hot_days=policy.hot_retention_period.days,
+            warm_days=policy.warm_retention_period.days,
+            min_purge_confidence=policy.min_purge_confidence,
+            source_retention_opt_out=source_retention_opt_out,
+        )
+        db.add(record)
+    else:
+        record.policy_version = policy.sample_version
+        record.hot_days = policy.hot_retention_period.days
+        record.warm_days = policy.warm_retention_period.days
+        record.min_purge_confidence = policy.min_purge_confidence
+        record.source_retention_opt_out = source_retention_opt_out
+    db.flush()
+    return record
+
+
+def get_transcript_source_retention_policy(
+    *,
+    db: Session,
+    transcript: Transcript,
+) -> TranscriptSourceRetentionPolicy | None:
+    """Get persisted lifecycle configuration for a transcript source."""
+    return (
+        db.query(TranscriptSourceRetentionPolicy)
+        .filter(
+            TranscriptSourceRetentionPolicy.podcast_id == transcript.episode.podcast_id,
+            TranscriptSourceRetentionPolicy.source_key == transcript.provider,
+        )
+        .first()
+    )
+
+
+def to_retention_policy(
+    *,
+    record: TranscriptSourceRetentionPolicy,
+) -> TranscriptRetentionPolicy:
+    """Convert stored thresholds into the pure retention policy contract."""
+    return TranscriptRetentionPolicy(
+        hot_retention_period=timedelta(days=record.hot_days),
+        warm_retention_period=timedelta(days=record.warm_days),
+        min_purge_confidence=record.min_purge_confidence,
+        retention_sample_rate=0,
+        sample_version=record.policy_version,
+    )
+
+
+def apply_stored_acquisition_opt_out(
+    *,
+    db: Session,
+    podcast_id: int,
+    source_key: str,
+    acquisition: TranscriptAcquisitionResult,
+) -> TranscriptAcquisitionResult:
+    """Apply a saved opt-out to a new payload from the same source."""
+    record = (
+        db.query(TranscriptSourceRetentionPolicy)
+        .filter(
+            TranscriptSourceRetentionPolicy.podcast_id == podcast_id,
+            TranscriptSourceRetentionPolicy.source_key == source_key,
+        )
+        .first()
+    )
+    if record is None or not record.source_retention_opt_out:
+        return acquisition
+    return replace(
+        acquisition,
+        should_store_raw=False,
+        source_retention_opt_out=True,
+    )

--- a/backend/tests/test_retention_sampling.py
+++ b/backend/tests/test_retention_sampling.py
@@ -1,0 +1,73 @@
+"""Tests for stratified permanent transcript sampling."""
+
+from datetime import UTC, datetime, timedelta
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import Episode, MentionCandidate, Podcast, Transcript
+from podex.services.retention_sampling import (
+    get_retention_sampling_report,
+    recalculate_retention_sample,
+)
+from podex.services.transcript_retention import TranscriptRetentionPolicy
+
+
+def test_recalculate_retention_sample_selects_target_with_persisted_strata(
+    db_session: Session,
+) -> None:
+    """Verify a stratum receives its deterministic target number of exemptions."""
+    now = datetime(2026, 5, 24, tzinfo=UTC)
+    podcast = Podcast(name="Sampling Podcast", slug="sampling-podcast")
+    db_session.add(podcast)
+    db_session.flush()
+    for index in range(10):
+        episode = Episode(podcast_id=podcast.id, title=f"Episode {index}")
+        db_session.add(episode)
+        db_session.flush()
+        db_session.add(
+            MentionCandidate(
+                episode_id=episode.id,
+                media_type="book",
+                raw_title=f"Book {index}",
+                confidence=0.95,
+            )
+        )
+        db_session.add(
+            Transcript(
+                episode_id=episode.id,
+                provider="rss",
+                raw_text="calibration text",
+                fetched_at=now - timedelta(days=1),
+            )
+        )
+    db_session.flush()
+
+    report = recalculate_retention_sample(
+        db=db_session,
+        policy=TranscriptRetentionPolicy(
+            retention_sample_rate=0.1,
+            sample_version="sample-policy-v2",
+        ),
+        now=now,
+    )
+    db_session.commit()
+
+    assert_that(report.eligible_count).is_equal_to(10)
+    assert_that(report.sampled_count).is_equal_to(1)
+    assert_that(report.strata[0].source).is_equal_to("sampling-podcast")
+    assert_that(report.strata[0].topic).is_equal_to("book")
+    selected = (
+        db_session.query(Transcript)
+        .filter(Transcript.retention_exempt_sample.is_(True))
+        .all()
+    )
+    assert_that(selected).is_length(1)
+    assert_that(selected[0].retention_policy_version).is_equal_to("sample-policy-v2")
+    assert_that(selected[0].retention_sample_strata_json).contains_entry(
+        {"confidence_band": "high"},
+    )
+
+    persisted = get_retention_sampling_report(db=db_session)
+    assert_that(persisted.policy_version).is_equal_to("sample-policy-v2")
+    assert_that(persisted.sample_rate).is_equal_to(0.1)

--- a/backend/tests/test_transcript_artifacts.py
+++ b/backend/tests/test_transcript_artifacts.py
@@ -1,0 +1,331 @@
+"""Tests for encrypted raw transcript artifact lifecycle commands."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from assertpy import assert_that
+from cryptography.fernet import Fernet
+from sqlalchemy.orm import Session
+
+from podex.config import Settings
+from podex.models import (
+    Episode,
+    Podcast,
+    Transcript,
+    TranscriptDigest,
+    TranscriptSourceRetentionPolicy,
+)
+from podex.services.transcript_acquisition import (
+    TranscriptAcquisitionResult,
+    TranscriptResult,
+)
+from podex.services.transcript_artifacts import (
+    EncryptedFilesystemTranscriptArtifactStore,
+    EncryptedS3TranscriptArtifactStore,
+    StoredTranscriptArtifactData,
+    TranscriptArtifactStorageBackend,
+    build_transcript_artifact_store,
+    load_transcript_processing_payload,
+    persist_transcript_acquisition,
+    reacquire_purged_transcript,
+)
+
+
+class RecordingArtifactStore:
+    """Record payload writes and deletes while exercising lifecycle services."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, dict[str, Any]] = {}
+        self.deleted: list[str] = []
+
+    def put_json(
+        self,
+        *,
+        storage_key: str,
+        payload: dict[str, Any],
+    ) -> StoredTranscriptArtifactData:
+        """Capture an artifact payload and return representative metadata."""
+        self.objects[storage_key] = payload
+        return StoredTranscriptArtifactData(
+            storage_key=storage_key,
+            storage_backend="recording",
+            encryption_key_id="key-v1",
+            byte_size=120,
+        )
+
+    def delete(self, *, storage_key: str) -> None:
+        """Capture deletion of a stored payload."""
+        self.deleted.append(storage_key)
+        self.objects.pop(storage_key, None)
+
+    def get_json(self, *, storage_key: str) -> dict[str, Any]:
+        """Return a previously captured raw payload."""
+        return self.objects[storage_key]
+
+
+class RecordingS3Client:
+    """Capture encrypted S3-compatible operations for adapter tests."""
+
+    def __init__(self) -> None:
+        self.put_requests: list[dict[str, Any]] = []
+        self.delete_requests: list[dict[str, Any]] = []
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        """Capture one object upload."""
+        self.put_requests.append(kwargs)
+        return {}
+
+    def delete_object(self, **kwargs: Any) -> dict[str, Any]:
+        """Capture one object deletion."""
+        self.delete_requests.append(kwargs)
+        return {}
+
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        """Return bytes from the matching captured upload."""
+        key = kwargs["Key"]
+        body = next(
+            request["Body"] for request in self.put_requests if request["Key"] == key
+        )
+        return {"Body": body}
+
+
+class SuccessfulAcquirer:
+    """Return a deterministic fresh transcript for re-acquisition."""
+
+    def acquire(self, episode: Episode) -> TranscriptAcquisitionResult:
+        """Return a provider result for the requested episode."""
+        return TranscriptAcquisitionResult(
+            success=True,
+            result=TranscriptResult(
+                provider="podscripts.co",
+                raw_text="freshly reacquired transcript",
+                segments=[{"start": 0, "text": "freshly reacquired transcript"}],
+                fetched_at=datetime(2026, 5, 24, 10, 0, tzinfo=UTC),
+            ),
+            source="podscripts.co",
+        )
+
+
+def _create_episode(db_session: Session) -> Episode:
+    """Create an episode parent for artifact command tests."""
+    podcast = Podcast(name="Artifact Podcast", slug="artifact-podcast")
+    db_session.add(podcast)
+    db_session.flush()
+    episode = Episode(podcast_id=podcast.id, title="Artifact Episode")
+    db_session.add(episode)
+    db_session.flush()
+    return episode
+
+
+def _acquisition() -> TranscriptAcquisitionResult:
+    """Build a successful source payload for persistence tests."""
+    return TranscriptAcquisitionResult(
+        success=True,
+        result=TranscriptResult(
+            provider="podscripts.co",
+            raw_text="raw private transcript",
+            segments=[{"start": 0, "text": "raw private transcript"}],
+            fetched_at=datetime(2026, 5, 24, 9, 0, tzinfo=UTC),
+        ),
+        source="podscripts.co",
+    )
+
+
+def test_encrypted_filesystem_store_does_not_write_plaintext(tmp_path: Path) -> None:
+    """Verify stored raw payload bytes are encrypted at rest."""
+    store = EncryptedFilesystemTranscriptArtifactStore(
+        root_path=tmp_path,
+        encryption_key=Fernet.generate_key().decode("ascii"),
+    )
+
+    stored = store.put_json(
+        storage_key="transcripts/1/1/raw.json.enc",
+        payload={"raw_text": "confidential raw transcript"},
+    )
+
+    ciphertext = (tmp_path / stored.storage_key).read_bytes()
+    assert_that(ciphertext).does_not_contain(b"confidential raw transcript")
+    assert_that(stored.storage_backend).is_equal_to("encrypted_filesystem")
+    assert_that(store.get_json(storage_key=stored.storage_key)).contains_entry(
+        {"raw_text": "confidential raw transcript"},
+    )
+
+
+def test_encrypted_s3_store_uploads_ciphertext_and_deletes_by_key() -> None:
+    """Verify S3-compatible storage receives only encrypted transcript bytes."""
+    client = RecordingS3Client()
+    store = EncryptedS3TranscriptArtifactStore(
+        bucket="private-transcripts",
+        encryption_key=Fernet.generate_key().decode("ascii"),
+        client=client,
+    )
+
+    stored = store.put_json(
+        storage_key="transcripts/1/1/raw.json.enc",
+        payload={"raw_text": "confidential raw transcript"},
+    )
+    loaded = store.get_json(storage_key=stored.storage_key)
+    store.delete(storage_key=stored.storage_key)
+
+    uploaded_body = client.put_requests[0]["Body"]
+    assert_that(uploaded_body).does_not_contain(b"confidential raw transcript")
+    assert_that(client.put_requests[0]["Bucket"]).is_equal_to("private-transcripts")
+    assert_that(stored.storage_backend).is_equal_to("encrypted_s3")
+    assert_that(loaded).contains_entry({"raw_text": "confidential raw transcript"})
+    assert_that(client.delete_requests[0]).is_equal_to(
+        {"Bucket": "private-transcripts", "Key": stored.storage_key},
+    )
+
+
+def test_build_artifact_store_selects_encrypted_filesystem_by_default(
+    tmp_path: Path,
+) -> None:
+    """Verify local deployments retain the encrypted filesystem adapter."""
+    store = build_transcript_artifact_store(
+        settings=Settings(
+            transcript_artifact_storage_path=tmp_path,
+            transcript_artifact_encryption_key=Fernet.generate_key().decode("ascii"),
+        ),
+    )
+
+    assert_that(store).is_instance_of(EncryptedFilesystemTranscriptArtifactStore)
+
+
+def test_build_artifact_store_selects_s3_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify hosted configuration selects the S3-compatible adapter."""
+    client = RecordingS3Client()
+    monkeypatch.setattr(
+        "podex.services.transcript_artifacts._build_s3_client",
+        lambda **_kwargs: client,
+    )
+
+    store = build_transcript_artifact_store(
+        settings=Settings(
+            transcript_artifact_storage_backend=(
+                TranscriptArtifactStorageBackend.ENCRYPTED_S3.value
+            ),
+            transcript_artifact_encryption_key=Fernet.generate_key().decode("ascii"),
+            transcript_artifact_s3_bucket="private-transcripts",
+        ),
+    )
+
+    assert_that(store).is_instance_of(EncryptedS3TranscriptArtifactStore)
+
+
+def test_persist_transcript_acquisition_writes_artifact_provenance(
+    db_session: Session,
+) -> None:
+    """Verify raw acquisition writes an external payload metadata record."""
+    episode = _create_episode(db_session)
+    store = RecordingArtifactStore()
+
+    transcript, artifact = persist_transcript_acquisition(
+        db=db_session,
+        episode=episode,
+        acquisition=_acquisition(),
+        artifact_store=store,
+    )
+
+    assert_that(transcript.retention_tier).is_equal_to("hot")
+    assert_that(transcript.raw_text).is_none()
+    assert_that(transcript.segments_json).is_none()
+    assert_that(artifact).is_not_none()
+    if artifact is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(artifact.storage_backend).is_equal_to("recording")
+    assert_that(artifact.provider).is_equal_to("podscripts.co")
+    assert_that(store.objects[artifact.storage_key]["raw_text"]).is_equal_to(
+        "raw private transcript"
+    )
+    payload = load_transcript_processing_payload(
+        db=db_session,
+        transcript=transcript,
+        artifact_store=store,
+    )
+    assert_that(payload).is_not_none()
+    if payload is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(payload.raw_text).is_equal_to("raw private transcript")
+    assert_that(payload.segments).is_length(1)
+
+
+def test_persist_transcript_acquisition_honors_saved_source_opt_out(
+    db_session: Session,
+) -> None:
+    """Verify a saved source opt-out prevents future raw artifact retention."""
+    episode = _create_episode(db_session)
+    db_session.add(
+        TranscriptSourceRetentionPolicy(
+            podcast_id=episode.podcast_id,
+            source_key="podscripts.co",
+            policy_version="source-opt-out-v1",
+            hot_days=30,
+            warm_days=180,
+            min_purge_confidence=0.85,
+            source_retention_opt_out=True,
+        )
+    )
+    db_session.flush()
+    store = RecordingArtifactStore()
+
+    transcript, artifact = persist_transcript_acquisition(
+        db=db_session,
+        episode=episode,
+        acquisition=_acquisition(),
+        artifact_store=store,
+    )
+
+    assert_that(transcript.source_retention_opt_out).is_true()
+    assert_that(transcript.raw_text).is_none()
+    assert_that(transcript.segments_json).is_none()
+    assert_that(artifact).is_none()
+    assert_that(store.objects).is_empty()
+
+
+def test_reacquire_purged_transcript_creates_hot_asset_from_digest(
+    db_session: Session,
+) -> None:
+    """Verify re-acquisition retains old proof and starts a new hot asset."""
+    episode = _create_episode(db_session)
+    purged_at = datetime(2026, 5, 23, 9, 0, tzinfo=UTC)
+    prior = Transcript(
+        episode_id=episode.id,
+        provider="podscripts.co",
+        raw_text=None,
+        segments_json=None,
+        fetched_at=purged_at,
+        retention_tier="purged",
+        purged_at=purged_at,
+    )
+    db_session.add(prior)
+    db_session.flush()
+    digest = TranscriptDigest(
+        transcript_id=prior.id,
+        episode_id=episode.id,
+        digest_key=f"transcript:{prior.id}:purge:test",
+        source_text_hash="abc123",
+        provider=prior.provider,
+        summary_text="retained proof",
+        generated_at=purged_at,
+        purged_at=purged_at,
+    )
+    db_session.add(digest)
+    db_session.flush()
+    store = RecordingArtifactStore()
+
+    result = reacquire_purged_transcript(
+        db=db_session,
+        transcript=prior,
+        acquirer=SuccessfulAcquirer(),
+        artifact_store=store,
+    )
+
+    assert_that(result.transcript.id).is_not_equal_to(prior.id)
+    assert_that(result.transcript.retention_tier).is_equal_to("hot")
+    assert_that(result.transcript.purged_at).is_none()
+    assert_that(result.artifact.reacquired_from_digest_id).is_equal_to(digest.id)
+    assert_that(result.prior_digest.id).is_equal_to(digest.id)

--- a/backend/tests/test_transcript_retention.py
+++ b/backend/tests/test_transcript_retention.py
@@ -1,0 +1,207 @@
+"""Tests for transcript retention policy primitives."""
+
+from datetime import datetime, timedelta
+
+from assertpy import assert_that
+
+from podex.services.transcript_retention import (
+    TranscriptAgeBucket,
+    TranscriptConfidenceBand,
+    TranscriptLifecycleTier,
+    TranscriptRetentionBlocker,
+    TranscriptRetentionPolicy,
+    TranscriptRetentionSampleKey,
+    TranscriptRetentionService,
+    TranscriptRetentionState,
+)
+
+
+def test_classify_tier_transitions_from_hot_to_warm_to_cold() -> None:
+    """Verify age-based transcript lifecycle tier transitions."""
+    now = datetime(2026, 5, 10, 12, 0, 0)
+    service = TranscriptRetentionService(
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=7),
+            warm_retention_period=timedelta(days=30),
+        ),
+    )
+
+    hot = service.classify_tier(
+        state=TranscriptRetentionState(acquired_at=now - timedelta(days=1)),
+        now=now,
+    )
+    warm = service.classify_tier(
+        state=TranscriptRetentionState(acquired_at=now - timedelta(days=14)),
+        now=now,
+    )
+    cold = service.classify_tier(
+        state=TranscriptRetentionState(acquired_at=now - timedelta(days=45)),
+        now=now,
+    )
+
+    assert_that(hot).is_equal_to(TranscriptLifecycleTier.HOT)
+    assert_that(warm).is_equal_to(TranscriptLifecycleTier.WARM)
+    assert_that(cold).is_equal_to(TranscriptLifecycleTier.COLD)
+
+
+def test_source_opt_out_suppresses_raw_transcript_retention() -> None:
+    """Verify source opt-out bypasses active raw transcript retention tiers."""
+    now = datetime(2026, 5, 10, 12, 0, 0)
+    service = TranscriptRetentionService(
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=30),
+            warm_retention_period=timedelta(days=180),
+            min_purge_confidence=0.85,
+        ),
+    )
+
+    decision = service.evaluate(
+        state=TranscriptRetentionState(
+            acquired_at=now - timedelta(days=1),
+            extraction_confidence=0.95,
+            digest_created_at=now,
+            source_retention_opt_out=True,
+        ),
+        now=now,
+    )
+
+    assert_that(decision.tier).is_equal_to(TranscriptLifecycleTier.COLD)
+    assert_that(decision.retention_suppressed).is_true()
+    assert_that(decision.purge_eligible).is_true()
+    assert_that(decision.purge_blockers).is_empty()
+
+
+def test_source_opt_out_does_not_wait_for_derivative_prerequisites() -> None:
+    """Verify creator/source opt-out allows immediate raw retention suppression."""
+    now = datetime(2026, 5, 10, 12, 0, 0)
+    service = TranscriptRetentionService(
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=30),
+            warm_retention_period=timedelta(days=180),
+            min_purge_confidence=0.85,
+        ),
+    )
+
+    decision = service.evaluate(
+        state=TranscriptRetentionState(
+            acquired_at=now - timedelta(days=1),
+            source_retention_opt_out=True,
+        ),
+        now=now,
+    )
+
+    assert_that(decision.tier).is_equal_to(TranscriptLifecycleTier.COLD)
+    assert_that(decision.purge_eligible).is_true()
+    assert_that(decision.purge_blockers).is_empty()
+
+
+def test_low_confidence_blocks_purge() -> None:
+    """Verify cold transcripts still need enough extraction confidence to purge."""
+    now = datetime(2026, 5, 10, 12, 0, 0)
+    service = TranscriptRetentionService(
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=7),
+            warm_retention_period=timedelta(days=30),
+            min_purge_confidence=0.85,
+        ),
+    )
+
+    decision = service.evaluate(
+        state=TranscriptRetentionState(
+            acquired_at=now - timedelta(days=45),
+            extraction_confidence=0.6,
+            digest_created_at=now,
+        ),
+        now=now,
+    )
+
+    assert_that(decision.tier).is_equal_to(TranscriptLifecycleTier.COLD)
+    assert_that(decision.purge_eligible).is_false()
+    assert_that(decision.purge_blockers).contains(
+        TranscriptRetentionBlocker.LOW_CONFIDENCE,
+    )
+
+
+def test_digest_is_required_before_purge() -> None:
+    """Verify purge eligibility waits for a transcript digest."""
+    now = datetime(2026, 5, 10, 12, 0, 0)
+    service = TranscriptRetentionService(
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=7),
+            warm_retention_period=timedelta(days=30),
+            min_purge_confidence=0.85,
+        ),
+    )
+
+    decision = service.evaluate(
+        state=TranscriptRetentionState(
+            acquired_at=now - timedelta(days=45),
+            extraction_confidence=0.9,
+        ),
+        now=now,
+    )
+
+    assert_that(decision.tier).is_equal_to(TranscriptLifecycleTier.COLD)
+    assert_that(decision.purge_eligible).is_false()
+    assert_that(decision.purge_blockers).contains(
+        TranscriptRetentionBlocker.DIGEST_REQUIRED,
+    )
+
+
+def test_retention_exempt_sample_blocks_purge() -> None:
+    """Verify retention-exempt samples are preserved from purge."""
+    now = datetime(2026, 5, 10, 12, 0, 0)
+    service = TranscriptRetentionService(
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=7),
+            warm_retention_period=timedelta(days=30),
+            min_purge_confidence=0.85,
+        ),
+    )
+
+    decision = service.evaluate(
+        state=TranscriptRetentionState(
+            acquired_at=now - timedelta(days=45),
+            extraction_confidence=0.9,
+            digest_created_at=now,
+            retention_exempt_sample=True,
+        ),
+        now=now,
+    )
+
+    assert_that(decision.tier).is_equal_to(TranscriptLifecycleTier.COLD)
+    assert_that(decision.purge_eligible).is_false()
+    assert_that(decision.purge_blockers).contains(
+        TranscriptRetentionBlocker.RETENTION_EXEMPT_SAMPLE,
+    )
+
+
+def test_retention_sampling_returns_strata_and_exemption() -> None:
+    """Verify deterministic retention sampling returns auditable strata."""
+    now = datetime(2026, 5, 10, 12, 0, 0)
+    service = TranscriptRetentionService(
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=7),
+            warm_retention_period=timedelta(days=30),
+            min_purge_confidence=0.85,
+            retention_sample_rate=1.0,
+            sample_version="test-sample-v1",
+        ),
+    )
+
+    sample = service.choose_sample(
+        sample_key=TranscriptRetentionSampleKey(
+            transcript_key="episode-123",
+            source_key="source-a",
+            topic_key="books",
+        ),
+        acquired_at=now - timedelta(days=45),
+        now=now,
+        extraction_confidence=0.9,
+    )
+
+    assert_that(sample.retention_exempt).is_true()
+    assert_that(sample.confidence_band).is_equal_to(TranscriptConfidenceBand.HIGH)
+    assert_that(sample.age_bucket).is_equal_to(TranscriptAgeBucket.OLDER)
+    assert_that(sample.sample_version).is_equal_to("test-sample-v1")
+    assert_that(sample.score).is_between(0, 1)

--- a/backend/tests/test_transcript_retention_commands.py
+++ b/backend/tests/test_transcript_retention_commands.py
@@ -1,0 +1,242 @@
+"""Tests for persisted transcript retention commands."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    Episode,
+    Podcast,
+    Transcript,
+    TranscriptArtifact,
+    TranscriptDigest,
+)
+from podex.services.transcript_artifacts import StoredTranscriptArtifactData
+from podex.services.transcript_retention import (
+    TranscriptLifecycleTier,
+    TranscriptRetentionPolicy,
+)
+from podex.services.transcript_retention_commands import (
+    evaluate_transcript_retention,
+    purge_transcript_if_eligible,
+)
+
+
+def _create_transcript(db_session: Session, fetched_at: datetime) -> Transcript:
+    """Create a transcript fixture."""
+    podcast = Podcast(name="Retention Podcast", slug="retention-podcast")
+    db_session.add(podcast)
+    db_session.flush()
+    episode = Episode(podcast_id=podcast.id, title="Retention Episode")
+    db_session.add(episode)
+    db_session.flush()
+    transcript = Transcript(
+        episode_id=episode.id,
+        provider="podscripts",
+        raw_text="raw transcript",
+        cleaned_text="clean transcript",
+        segments_json=[{"start": 1, "text": "hello"}],
+        fetched_at=fetched_at,
+        digest_text="digest",
+        digest_created_at=fetched_at,
+    )
+    db_session.add(transcript)
+    db_session.flush()
+    return transcript
+
+
+def test_evaluate_transcript_retention_persists_policy_decision(
+    db_session: Session,
+) -> None:
+    """Verify retention evaluation updates transcript lifecycle fields."""
+    now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+    transcript = _create_transcript(
+        db_session=db_session,
+        fetched_at=now - timedelta(days=45),
+    )
+
+    result = evaluate_transcript_retention(
+        db=db_session,
+        transcript=transcript,
+        extraction_confidence=0.95,
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=7),
+            warm_retention_period=timedelta(days=30),
+            retention_sample_rate=0,
+        ),
+        now=now,
+    )
+    db_session.commit()
+
+    assert_that(result.decision.tier).is_equal_to(TranscriptLifecycleTier.COLD)
+    assert_that(transcript.retention_tier).is_equal_to("cold")
+    assert_that(transcript.retention_policy_version).is_equal_to("retention-sample-v1")
+    assert_that(transcript.purge_eligible_at).is_equal_to(now.replace(tzinfo=None))
+    assert_that(transcript.retention_blockers_json).is_empty()
+
+
+def test_purge_transcript_if_eligible_removes_raw_fields(
+    db_session: Session,
+) -> None:
+    """Verify eligible transcripts can purge raw transcript storage."""
+    now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+    transcript = _create_transcript(
+        db_session=db_session,
+        fetched_at=now - timedelta(days=45),
+    )
+    evaluate_transcript_retention(
+        db=db_session,
+        transcript=transcript,
+        extraction_confidence=0.95,
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=7),
+            warm_retention_period=timedelta(days=30),
+            retention_sample_rate=0,
+        ),
+        now=now,
+    )
+
+    purged = purge_transcript_if_eligible(
+        db=db_session,
+        transcript=transcript,
+        now=now,
+    )
+    db_session.commit()
+
+    assert_that(purged).is_true()
+    assert_that(transcript.raw_text).is_none()
+    assert_that(transcript.cleaned_text).is_none()
+    assert_that(transcript.segments_json).is_none()
+    assert_that(transcript.retention_tier).is_equal_to("purged")
+    digest = db_session.query(TranscriptDigest).one()
+    assert_that(digest.transcript_id).is_equal_to(transcript.id)
+    assert_that(digest.summary_text).is_equal_to("digest")
+    assert_that(digest.source_text_hash).is_not_empty()
+
+
+def test_purge_transcript_if_eligible_deletes_external_raw_artifact(
+    db_session: Session,
+) -> None:
+    """Verify purge removes an externally stored raw object as one operation."""
+
+    class RecordingStore:
+        """Capture artifact deletes during purge."""
+
+        deleted: list[str] = []
+
+        def put_json(
+            self,
+            *,
+            storage_key: str,
+            payload: dict[str, object],
+        ) -> StoredTranscriptArtifactData:
+            """Satisfy the storage protocol for this deletion-only test."""
+            return StoredTranscriptArtifactData(
+                storage_key=storage_key,
+                storage_backend="fake",
+                encryption_key_id="key",
+                byte_size=0,
+            )
+
+        def delete(self, *, storage_key: str) -> None:
+            """Capture a deleted storage key."""
+            self.deleted.append(storage_key)
+
+        def get_json(self, *, storage_key: str) -> dict[str, Any]:
+            """Satisfy the storage protocol for this deletion-only test."""
+            raise AssertionError(f"Unexpected artifact read for {storage_key}")
+
+    now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+    transcript = _create_transcript(
+        db_session=db_session,
+        fetched_at=now - timedelta(days=45),
+    )
+    artifact = TranscriptArtifact(
+        transcript_id=transcript.id,
+        episode_id=transcript.episode_id,
+        storage_key=f"transcripts/{transcript.episode_id}/{transcript.id}/raw.json.enc",
+        storage_backend="fake",
+        encryption_key_id="key",
+        provider=transcript.provider,
+        source_text_hash="hash",
+        content_type="application/json",
+        byte_size=12,
+        stored_at=now,
+    )
+    db_session.add(artifact)
+    evaluate_transcript_retention(
+        db=db_session,
+        transcript=transcript,
+        extraction_confidence=0.95,
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=7),
+            warm_retention_period=timedelta(days=30),
+            retention_sample_rate=0,
+        ),
+        now=now,
+    )
+    store = RecordingStore()
+
+    purged = purge_transcript_if_eligible(
+        db=db_session,
+        transcript=transcript,
+        artifact_store=store,
+        now=now,
+    )
+    db_session.commit()
+
+    assert_that(purged).is_true()
+    assert_that(store.deleted).contains(artifact.storage_key)
+    assert_that(artifact.purged_at).is_equal_to(now.replace(tzinfo=None))
+
+
+def test_source_opt_out_allows_immediate_retention_suppression(
+    db_session: Session,
+) -> None:
+    """Verify source opt-out bypasses derivative prerequisites."""
+    now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+    transcript = _create_transcript(db_session=db_session, fetched_at=now)
+    transcript.digest_text = None
+    transcript.digest_created_at = None
+
+    result = evaluate_transcript_retention(
+        db=db_session,
+        transcript=transcript,
+        extraction_confidence=None,
+        source_retention_opt_out=True,
+        now=now,
+    )
+    db_session.commit()
+
+    assert_that(result.decision.purge_eligible).is_true()
+    assert_that(transcript.source_retention_opt_out).is_true()
+    assert_that(transcript.purge_eligible_at).is_equal_to(now.replace(tzinfo=None))
+
+
+def test_existing_calibration_sample_remains_exempt_during_evaluation(
+    db_session: Session,
+) -> None:
+    """Verify retention evaluation cannot discard an assigned corpus member."""
+    now = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+    transcript = _create_transcript(
+        db_session=db_session,
+        fetched_at=now - timedelta(days=45),
+    )
+    transcript.retention_exempt_sample = True
+
+    result = evaluate_transcript_retention(
+        db=db_session,
+        transcript=transcript,
+        extraction_confidence=0.95,
+        policy=TranscriptRetentionPolicy(
+            hot_retention_period=timedelta(days=7),
+            warm_retention_period=timedelta(days=30),
+            retention_sample_rate=0,
+        ),
+        now=now,
+    )
+
+    assert_that(transcript.retention_exempt_sample).is_true()
+    assert_that(result.decision.purge_eligible).is_false()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -140,12 +140,138 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/4f/b93620c09e81b8dd28558e73862d7b61f938c5a9db9366fab4b0bb53512f/boto3-1.43.51.tar.gz", hash = "sha256:b5a416cc703db73b69b22bef563c89c1fb14a4b10a93628d3c7abc4dd1aaf979", size = 112649, upload-time = "2026-07-17T19:33:23.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/7e/86204db9235f08e051a83e039ec5af209211e3ac51ed3644c4350c150b72/boto3-1.43.51-py3-none-any.whl", hash = "sha256:a97057bb609fd38c80448db6a93db770786775dabd651401debf09816d4553d7", size = 140030, upload-time = "2026-07-17T19:33:21.381Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/f5/5a6b4fe037ba689fd4a9eaf31af8b681e4c1eb82debc470d18dec99eac62/botocore-1.43.51.tar.gz", hash = "sha256:e0e5e88585fdb01dcb6b533ac2dd3f18d5d45092a14ccbfd330e3576a4152128", size = 15713861, upload-time = "2026-07-17T19:33:12.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/ca/9080b2f261ad9209e4d790b4282951df46274f786edb5c416a27fb18f4c6/botocore-1.43.51-py3-none-any.whl", hash = "sha256:7c2c538c932bddc95834e177ce6f91dcc388c6a7934b4f8d0db13caa30e3e543", size = 15399252, upload-time = "2026-07-17T19:33:08.808Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/67/85c89a59ba36a671e79638f44d466749f08179266a57e4f2ffdf92174072/cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc", size = 183845, upload-time = "2026-07-06T21:32:26.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dd/e3b0baa2d3d6a857ac72b7efbf18e32e487c9cdafcc13049ad765495b15e/cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7", size = 184186, upload-time = "2026-07-06T21:32:28.025Z" },
+    { url = "https://files.pythonhosted.org/packages/65/68/9f3ef890cf3c6ab97bd531c5677f67613d302165d16f8142b2811782a614/cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93", size = 211892, upload-time = "2026-07-06T21:32:29.565Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d7/1a74539db16d8bfd839ff1515948948efbb162e574650fd3d846896eea95/cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2", size = 218793, upload-time = "2026-07-06T21:32:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d1/9a5b7169499e8e8d8e636de70b97ac7c9447104d2ff1a2cd94790cea5162/cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c", size = 205737, upload-time = "2026-07-06T21:32:32.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b0/e131a9c41f10607926278453d9596163594fe1c4ebc46efe3b5e5b34eb84/cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f", size = 204909, upload-time = "2026-07-06T21:32:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d2/4398416cd699b35167947c6e22aca52c47e69ad5695073c9f1f2c52e04aa/cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565", size = 217883, upload-time = "2026-07-06T21:32:35.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/d4fe77b589e5e82d43ebc809bf2e6474afe8e48e32ea050b9357645b6471/cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c", size = 221251, upload-time = "2026-07-06T21:32:36.527Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f0/a2fc43084c0433caf7f461bccc013e28f848d04ee1c5ed7fce71423cf4d9/cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02", size = 214250, upload-time = "2026-07-06T21:32:37.852Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8c/b925975448cf20634a9fbd5efceb807219db452653648d2897c0989cab2d/cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e", size = 219441, upload-time = "2026-07-06T21:32:39.146Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/da/5c4918a2d61d86fa927d716cb3d8e4626ef8dc8f605a599d32f33897f59a/cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479", size = 174496, upload-time = "2026-07-06T21:32:40.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c8/6c2de1d55cf35ef8b92885d5ef280790f0fb9634d87ea1cc315176aecd61/cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458", size = 185113, upload-time = "2026-07-06T21:32:41.761Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4e/e8d7cb5783f1841a3c8fb3a7735838d7484d08ec08c9f984b14cac1ac0e9/cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d", size = 179927, upload-time = "2026-07-06T21:32:42.961Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
 ]
 
 [[package]]
@@ -330,6 +456,62 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
 ]
 
 [[package]]
@@ -659,6 +841,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
     { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
     { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1033,6 +1224,8 @@ dependencies = [
     { name = "alembic" },
     { name = "anthropic" },
     { name = "beautifulsoup4" },
+    { name = "boto3" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "feedparser" },
     { name = "httpx" },
@@ -1063,6 +1256,8 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "anthropic", specifier = ">=0.40" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "boto3", specifier = ">=1.43.14" },
+    { name = "cryptography", specifier = ">=48.0.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "feedparser", specifier = ">=6.0" },
     { name = "httpx", specifier = ">=0.28" },
@@ -1155,6 +1350,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
     { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
     { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -1325,6 +1529,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -1511,10 +1727,31 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
+]
+
+[[package]]
 name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
 
 [[package]]
 name = "sniffio"


### PR DESCRIPTION
## Summary

Completes the retention theme (slice R2 of the #108 split stack) on top of the retention models from #274. Transcripts move through hot/warm/cold tiers, exempt research samples are selected via stratified sampling, purges leave a durable digest proof, and raw transcript payloads live only as encrypted artifacts (local filesystem or S3-compatible) — never as plaintext columns for new acquisitions.

## Type

- [x] `feat` — New feature

## Changes Made

- Add `transcript_retention.py`: retention policy evaluation, tier transitions, purge eligibility planning, and digest creation on purge
- Add `transcript_retention_commands.py`: operator-facing purge/tiering commands that delete encrypted artifacts and null legacy plaintext columns
- Add `transcript_retention_policies.py`: per-podcast/source retention policy upsert/lookup and stored opt-out enforcement on acquisition
- Add `retention_sampling.py`: stratified exempt-sample selection with persisted strata metadata
- Add `transcript_artifacts.py`: encrypted raw transcript artifact storage (Fernet) with filesystem and S3-compatible adapters, processing-payload loading with legacy column fallback, and purged-transcript re-acquisition
- Add `transcript_acquisition.py`: acquisition result data contracts (provider implementations arrive with the transcription theme)
- Add `podcast`/`episodes` ORM relationships and transcript-artifact storage settings; add `boto3` + `cryptography` dependencies
- Port retention/sampling/artifact test suites (23 tests); one `EpisodeIterator`-dependent test deferred to the scheduler theme

## Closes

- Closes #9
- Closes #27
- Closes #74
- Closes #99
- Relates to #108

## Testing

- [x] Ported retention, sampling, commands, and artifact test suites pass
- [x] Full backend suite passes with coverage ≥85% (85.02%)
- [x] Migration replay + schema-drift guard passes

## Quality Checks

- [x] `lintro chk` (ruff, mypy, bandit, pydoclint) clean — health 100/100
- [x] `ruff format` applied

## Checklist

- [x] Code follows repo conventions
- [x] No tuned prompts, ranking parameters, real hostnames, or secrets (#108 boundary); `.env`-style settings are placeholder-free defaults