### PR TITLE
feat(accounts): add account identity, sessions, saves, follows, and preferences

### DIFF
--- a/backend/alembic/versions/0012_add_account_models.py
+++ b/backend/alembic/versions/0012_add_account_models.py
@@ -1,0 +1,215 @@
+"""Add account auth and personalization models.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-07-19 00:34:32.831077
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0012"
+down_revision: str | None = "0011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.create_table(
+        "account_users",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("email", sa.String(length=320), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_signed_in_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_account_users_email"), "account_users", ["email"], unique=True
+    )
+    op.create_table(
+        "account_followed_podcasts",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("podcast_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["podcast_id"],
+            ["podcasts.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["account_users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id", "podcast_id", name="uq_account_followed_podcasts_user_podcast"
+        ),
+    )
+    op.create_index(
+        op.f("ix_account_followed_podcasts_podcast_id"),
+        "account_followed_podcasts",
+        ["podcast_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_account_followed_podcasts_user_id"),
+        "account_followed_podcasts",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_table(
+        "account_preferences",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("digest_enabled", sa.Boolean(), nullable=False),
+        sa.Column("digest_frequency", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["account_users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_account_preferences_user_id"),
+        "account_preferences",
+        ["user_id"],
+        unique=True,
+    )
+    op.create_table(
+        "account_saved_media",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("media_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["media_id"],
+            ["media.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["account_users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id", "media_id", name="uq_account_saved_media_user_media"
+        ),
+    )
+    op.create_index(
+        op.f("ix_account_saved_media_media_id"),
+        "account_saved_media",
+        ["media_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_account_saved_media_user_id"),
+        "account_saved_media",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_table(
+        "magic_link_tokens",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_digest", sa.String(length=64), nullable=False),
+        sa.Column("redirect_path", sa.String(length=300), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["account_users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_magic_link_tokens_expires_at"),
+        "magic_link_tokens",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_magic_link_tokens_token_digest"),
+        "magic_link_tokens",
+        ["token_digest"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_magic_link_tokens_user_id"),
+        "magic_link_tokens",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_table(
+        "user_sessions",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_digest", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["account_users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_user_sessions_expires_at"),
+        "user_sessions",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_user_sessions_token_digest"),
+        "user_sessions",
+        ["token_digest"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_user_sessions_user_id"), "user_sessions", ["user_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    op.drop_index(op.f("ix_user_sessions_user_id"), table_name="user_sessions")
+    op.drop_index(op.f("ix_user_sessions_token_digest"), table_name="user_sessions")
+    op.drop_index(op.f("ix_user_sessions_expires_at"), table_name="user_sessions")
+    op.drop_table("user_sessions")
+    op.drop_index(op.f("ix_magic_link_tokens_user_id"), table_name="magic_link_tokens")
+    op.drop_index(
+        op.f("ix_magic_link_tokens_token_digest"), table_name="magic_link_tokens"
+    )
+    op.drop_index(
+        op.f("ix_magic_link_tokens_expires_at"), table_name="magic_link_tokens"
+    )
+    op.drop_table("magic_link_tokens")
+    op.drop_index(
+        op.f("ix_account_saved_media_user_id"), table_name="account_saved_media"
+    )
+    op.drop_index(
+        op.f("ix_account_saved_media_media_id"), table_name="account_saved_media"
+    )
+    op.drop_table("account_saved_media")
+    op.drop_index(
+        op.f("ix_account_preferences_user_id"), table_name="account_preferences"
+    )
+    op.drop_table("account_preferences")
+    op.drop_index(
+        op.f("ix_account_followed_podcasts_user_id"),
+        table_name="account_followed_podcasts",
+    )
+    op.drop_index(
+        op.f("ix_account_followed_podcasts_podcast_id"),
+        table_name="account_followed_podcasts",
+    )
+    op.drop_table("account_followed_podcasts")
+    op.drop_index(op.f("ix_account_users_email"), table_name="account_users")
+    op.drop_table("account_users")

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -57,6 +57,20 @@ class Settings(BaseSettings):
     transcript_artifact_s3_access_key_id: str = ""
     transcript_artifact_s3_secret_access_key: str = ""
 
+    # Passwordless account authentication. Magic-link email delivery stays
+    # disabled until SMTP settings are provided by the deployment
+    # environment; defaults are placeholder-free.
+    auth_magic_link_ttl_minutes: int = 15
+    auth_session_ttl_days: int = 30
+    auth_session_cookie_name: str = "podex_session"
+    auth_session_cookie_secure: bool = True
+    smtp_host: str = ""
+    smtp_port: int = 587
+    smtp_username: str = ""
+    smtp_password: str = ""
+    smtp_from_email: str = ""
+    smtp_starttls: bool = True
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -4,6 +4,10 @@ Importing the models here registers them on ``Base.metadata`` so that
 metadata-based table creation and Alembic autogenerate see every table.
 """
 
+from podex.models.account_followed_podcast import AccountFollowedPodcast
+from podex.models.account_preference import AccountPreference
+from podex.models.account_saved_media import AccountSavedMedia
+from podex.models.account_user import AccountUser
 from podex.models.base import Base
 from podex.models.derivative_generation_run import (
     DerivativeGenerationRun,
@@ -17,6 +21,7 @@ from podex.models.episode import DiscoverySource, Episode
 from podex.models.episode_summary import EpisodeSummary
 from podex.models.graph_triple import GraphTriple, GraphTripleObjectKind
 from podex.models.ingestion_run import IngestionRun, IngestionRunStatus
+from podex.models.magic_link_token import MagicLinkToken
 from podex.models.media import Media, MediaType
 from podex.models.media_alias import MediaAlias, MediaAliasSourceType
 from podex.models.media_external_ref import MediaExternalRef, MediaExternalRefSource
@@ -45,8 +50,13 @@ from podex.models.transcript_digest import TranscriptDigest
 from podex.models.transcript_source_retention_policy import (
     TranscriptSourceRetentionPolicy,
 )
+from podex.models.user_session import UserSession
 
 __all__ = [
+    "AccountFollowedPodcast",
+    "AccountPreference",
+    "AccountSavedMedia",
+    "AccountUser",
     "Base",
     "DerivativeGenerationRun",
     "DerivativeGenerationRunStatus",
@@ -55,6 +65,7 @@ __all__ = [
     "EpisodeSummary",
     "GraphTriple",
     "GraphTripleObjectKind",
+    "MagicLinkToken",
     "MediaSummary",
     "SemanticChunk",
     "SemanticChunkEmbeddingStatus",
@@ -87,4 +98,5 @@ __all__ = [
     "TranscriptDigest",
     "TranscriptSourceRetentionPolicy",
     "ScheduledWorkStatus",
+    "UserSession",
 ]

--- a/backend/src/podex/models/account_followed_podcast.py
+++ b/backend/src/podex/models/account_followed_podcast.py
@@ -1,0 +1,26 @@
+"""Followed public podcast sources for an account."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AccountFollowedPodcast(Base):
+    """A user's followed public podcast source."""
+
+    __tablename__ = "account_followed_podcasts"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "podcast_id",
+            name="uq_account_followed_podcasts_user_podcast",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("account_users.id"), index=True)
+    podcast_id: Mapped[int] = mapped_column(ForeignKey("podcasts.id"), index=True)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))

--- a/backend/src/podex/models/account_preference.py
+++ b/backend/src/podex/models/account_preference.py
@@ -1,0 +1,28 @@
+"""Account notification preference persistence."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Boolean, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AccountPreference(Base):
+    """User-controlled preferences for notification delivery."""
+
+    __tablename__ = "account_preferences"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("account_users.id"),
+        unique=True,
+        index=True,
+    )
+    digest_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    digest_frequency: Mapped[str] = mapped_column(String(20), default="daily")
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/backend/src/podex/models/account_saved_media.py
+++ b/backend/src/podex/models/account_saved_media.py
@@ -1,0 +1,26 @@
+"""Saved public catalog media for an account."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AccountSavedMedia(Base):
+    """A user's saved reference to a canonical public media record."""
+
+    __tablename__ = "account_saved_media"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "media_id",
+            name="uq_account_saved_media_user_media",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("account_users.id"), index=True)
+    media_id: Mapped[int] = mapped_column(ForeignKey("media.id"), index=True)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))

--- a/backend/src/podex/models/account_user.py
+++ b/backend/src/podex/models/account_user.py
@@ -1,0 +1,19 @@
+"""Public account identity model."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AccountUser(Base):
+    """Minimal email-backed identity for personalized product features."""
+
+    __tablename__ = "account_users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(String(320), unique=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    last_signed_in_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/src/podex/models/magic_link_token.py
+++ b/backend/src/podex/models/magic_link_token.py
@@ -1,0 +1,22 @@
+"""Passwordless authentication challenge model."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class MagicLinkToken(Base):
+    """One-time hashed token issued for passwordless authentication."""
+
+    __tablename__ = "magic_link_tokens"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("account_users.id"), index=True)
+    token_digest: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    redirect_path: Mapped[str | None] = mapped_column(String(300))
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))

--- a/backend/src/podex/models/user_session.py
+++ b/backend/src/podex/models/user_session.py
@@ -1,0 +1,22 @@
+"""Authenticated account session model."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class UserSession(Base):
+    """Revocable session represented to clients by an opaque cookie token."""
+
+    __tablename__ = "user_sessions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("account_users.id"), index=True)
+    token_digest: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))

--- a/backend/src/podex/services/account_auth.py
+++ b/backend/src/podex/services/account_auth.py
@@ -1,0 +1,168 @@
+"""Passwordless account authentication and session persistence."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from hashlib import sha256
+from secrets import token_urlsafe
+
+from sqlalchemy.orm import Session
+
+from podex.models import AccountUser, MagicLinkToken, UserSession
+
+
+@dataclass(frozen=True, slots=True)
+class MagicLinkIssueData:
+    """One-time credential to deliver to an account email address."""
+
+    email: str
+    token: str
+    expires_at: datetime
+    redirect_path: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class AuthenticatedSessionData:
+    """Authenticated user and the newly issued browser session token."""
+
+    user: AccountUser
+    token: str
+    expires_at: datetime
+
+
+def issue_magic_link(
+    *,
+    db: Session,
+    email: str,
+    redirect_path: str | None,
+    ttl_minutes: int,
+    now: datetime | None = None,
+) -> MagicLinkIssueData:
+    """Create a one-time magic-link challenge for a normalized email address."""
+    effective_now = now or datetime.now(UTC)
+    normalized_email = email.strip().casefold()
+    user = db.query(AccountUser).filter(AccountUser.email == normalized_email).first()
+    if user is None:
+        user = AccountUser(email=normalized_email)
+        db.add(user)
+        db.flush()
+
+    db.query(MagicLinkToken).filter(
+        MagicLinkToken.user_id == user.id,
+        MagicLinkToken.consumed_at.is_(None),
+    ).update({MagicLinkToken.consumed_at: effective_now}, synchronize_session=False)
+    raw_token = token_urlsafe(32)
+    expires_at = effective_now + timedelta(minutes=ttl_minutes)
+    db.add(
+        MagicLinkToken(
+            user_id=user.id,
+            token_digest=_token_digest(raw_token),
+            redirect_path=redirect_path,
+            expires_at=expires_at,
+        ),
+    )
+    db.flush()
+    return MagicLinkIssueData(
+        email=normalized_email,
+        token=raw_token,
+        expires_at=expires_at,
+        redirect_path=redirect_path,
+    )
+
+
+def authenticate_magic_link(
+    *,
+    db: Session,
+    token: str,
+    session_ttl_days: int,
+    now: datetime | None = None,
+) -> AuthenticatedSessionData | None:
+    """Consume a valid magic link and issue a revocable browser session."""
+    effective_now = now or datetime.now(UTC)
+    challenge = (
+        db.query(MagicLinkToken)
+        .filter(MagicLinkToken.token_digest == _token_digest(token))
+        .first()
+    )
+    if (
+        challenge is None
+        or challenge.consumed_at is not None
+        or _as_utc(challenge.expires_at) <= effective_now
+    ):
+        return None
+
+    user = db.query(AccountUser).filter(AccountUser.id == challenge.user_id).one()
+    raw_session_token = token_urlsafe(32)
+    expires_at = effective_now + timedelta(days=session_ttl_days)
+    challenge.consumed_at = effective_now
+    user.last_signed_in_at = effective_now
+    db.add(
+        UserSession(
+            user_id=user.id,
+            token_digest=_token_digest(raw_session_token),
+            expires_at=expires_at,
+            last_seen_at=effective_now,
+        ),
+    )
+    db.flush()
+    return AuthenticatedSessionData(
+        user=user,
+        token=raw_session_token,
+        expires_at=expires_at,
+    )
+
+
+def get_authenticated_user(
+    *,
+    db: Session,
+    session_token: str | None,
+    now: datetime | None = None,
+) -> AccountUser | None:
+    """Resolve an active browser session to its account user."""
+    if not session_token:
+        return None
+    effective_now = now or datetime.now(UTC)
+    session = (
+        db.query(UserSession)
+        .filter(UserSession.token_digest == _token_digest(session_token))
+        .first()
+    )
+    if (
+        session is None
+        or session.revoked_at is not None
+        or _as_utc(session.expires_at) <= effective_now
+    ):
+        return None
+    session.last_seen_at = effective_now
+    db.flush()
+    return db.query(AccountUser).filter(AccountUser.id == session.user_id).one()
+
+
+def revoke_user_session(
+    *,
+    db: Session,
+    session_token: str | None,
+    now: datetime | None = None,
+) -> bool:
+    """Revoke an existing browser session token when present."""
+    if not session_token:
+        return False
+    session = (
+        db.query(UserSession)
+        .filter(UserSession.token_digest == _token_digest(session_token))
+        .first()
+    )
+    if session is None or session.revoked_at is not None:
+        return False
+    session.revoked_at = now or datetime.now(UTC)
+    db.flush()
+    return True
+
+
+def _token_digest(token: str) -> str:
+    """Hash an opaque credential before persistent lookup or storage."""
+    return sha256(token.encode("utf-8")).hexdigest()
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normalize SQLite-naive or timezone-aware timestamps for comparison."""
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)

--- a/backend/src/podex/services/account_follows.py
+++ b/backend/src/podex/services/account_follows.py
@@ -1,0 +1,90 @@
+"""Authenticated account followed-podcast operations."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from podex.models import AccountFollowedPodcast, Podcast
+from podex.services.podcast_queries import get_podcast
+
+
+@dataclass(frozen=True, slots=True)
+class FollowedPodcastData:
+    """A followed association and its public catalog representation."""
+
+    podcast: Podcast
+    followed_at: datetime
+
+
+def _get_public_podcast_by_id(
+    *,
+    db: Session,
+    podcast_id: int,
+) -> Podcast | None:
+    """Resolve a canonical podcast record for account associations."""
+    return get_podcast(db, podcast_id)
+
+
+def list_followed_podcasts(*, db: Session, user_id: int) -> list[FollowedPodcastData]:
+    """List a user's followed podcast sources, newest first."""
+    rows = (
+        db.query(AccountFollowedPodcast)
+        .filter(AccountFollowedPodcast.user_id == user_id)
+        .order_by(
+            AccountFollowedPodcast.created_at.desc(),
+            AccountFollowedPodcast.id.desc(),
+        )
+        .all()
+    )
+    followed: list[FollowedPodcastData] = []
+    for row in rows:
+        podcast = _get_public_podcast_by_id(db=db, podcast_id=row.podcast_id)
+        if podcast is not None:
+            followed.append(
+                FollowedPodcastData(podcast=podcast, followed_at=row.created_at),
+            )
+    return followed
+
+
+def follow_podcast(
+    *,
+    db: Session,
+    user_id: int,
+    podcast_id: int,
+) -> FollowedPodcastData | None:
+    """Idempotently follow an existing public podcast source."""
+    podcast = _get_public_podcast_by_id(db=db, podcast_id=podcast_id)
+    if podcast is None:
+        return None
+    existing = (
+        db.query(AccountFollowedPodcast)
+        .filter(
+            AccountFollowedPodcast.user_id == user_id,
+            AccountFollowedPodcast.podcast_id == podcast_id,
+        )
+        .first()
+    )
+    if existing is not None:
+        return FollowedPodcastData(podcast=podcast, followed_at=existing.created_at)
+    row = AccountFollowedPodcast(user_id=user_id, podcast_id=podcast_id)
+    db.add(row)
+    db.flush()
+    return FollowedPodcastData(podcast=podcast, followed_at=row.created_at)
+
+
+def unfollow_podcast(*, db: Session, user_id: int, podcast_id: int) -> bool:
+    """Remove a public podcast source from a user's follows."""
+    row = (
+        db.query(AccountFollowedPodcast)
+        .filter(
+            AccountFollowedPodcast.user_id == user_id,
+            AccountFollowedPodcast.podcast_id == podcast_id,
+        )
+        .first()
+    )
+    if row is None:
+        return False
+    db.delete(row)
+    db.flush()
+    return True

--- a/backend/src/podex/services/account_preferences.py
+++ b/backend/src/podex/services/account_preferences.py
@@ -1,0 +1,37 @@
+"""Authenticated account preference operations."""
+
+from typing import Literal
+
+from sqlalchemy.orm import Session
+
+from podex.models import AccountPreference
+
+DigestFrequency = Literal["immediate", "daily", "weekly"]
+
+
+def get_account_preferences(*, db: Session, user_id: int) -> AccountPreference:
+    """Load account preferences, establishing sensible defaults when absent."""
+    preferences = (
+        db.query(AccountPreference).filter(AccountPreference.user_id == user_id).first()
+    )
+    if preferences is not None:
+        return preferences
+    preferences = AccountPreference(user_id=user_id)
+    db.add(preferences)
+    db.flush()
+    return preferences
+
+
+def update_account_preferences(
+    *,
+    db: Session,
+    user_id: int,
+    digest_enabled: bool,
+    digest_frequency: DigestFrequency,
+) -> AccountPreference:
+    """Persist digest delivery preferences for an account."""
+    preferences = get_account_preferences(db=db, user_id=user_id)
+    preferences.digest_enabled = digest_enabled
+    preferences.digest_frequency = digest_frequency
+    db.flush()
+    return preferences

--- a/backend/src/podex/services/account_saves.py
+++ b/backend/src/podex/services/account_saves.py
@@ -1,0 +1,71 @@
+"""Authenticated account saved-media operations."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from podex.models import AccountSavedMedia, Media
+from podex.services.media_queries import get_media
+
+
+@dataclass(frozen=True, slots=True)
+class SavedMediaData:
+    """A saved association and its public catalog representation."""
+
+    media: Media
+    saved_at: datetime
+
+
+def list_saved_media(*, db: Session, user_id: int) -> list[SavedMediaData]:
+    """List a user's saved public media, most recently saved first."""
+    rows = (
+        db.query(AccountSavedMedia)
+        .filter(AccountSavedMedia.user_id == user_id)
+        .order_by(AccountSavedMedia.created_at.desc(), AccountSavedMedia.id.desc())
+        .all()
+    )
+    saved: list[SavedMediaData] = []
+    for row in rows:
+        media = get_media(db, row.media_id)
+        if media is not None:
+            saved.append(SavedMediaData(media=media, saved_at=row.created_at))
+    return saved
+
+
+def save_media(*, db: Session, user_id: int, media_id: int) -> SavedMediaData | None:
+    """Idempotently save an existing public media record for an account."""
+    media = get_media(db, media_id)
+    if media is None:
+        return None
+    existing = (
+        db.query(AccountSavedMedia)
+        .filter(
+            AccountSavedMedia.user_id == user_id,
+            AccountSavedMedia.media_id == media_id,
+        )
+        .first()
+    )
+    if existing is not None:
+        return SavedMediaData(media=media, saved_at=existing.created_at)
+    row = AccountSavedMedia(user_id=user_id, media_id=media_id)
+    db.add(row)
+    db.flush()
+    return SavedMediaData(media=media, saved_at=row.created_at)
+
+
+def remove_saved_media(*, db: Session, user_id: int, media_id: int) -> bool:
+    """Remove a public media record from a user's saves."""
+    row = (
+        db.query(AccountSavedMedia)
+        .filter(
+            AccountSavedMedia.user_id == user_id,
+            AccountSavedMedia.media_id == media_id,
+        )
+        .first()
+    )
+    if row is None:
+        return False
+    db.delete(row)
+    db.flush()
+    return True

--- a/backend/src/podex/services/magic_link_delivery.py
+++ b/backend/src/podex/services/magic_link_delivery.py
@@ -1,0 +1,59 @@
+"""Email delivery adapter for account sign-in links."""
+
+import smtplib
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Protocol
+
+from podex.config import Settings
+
+
+class MagicLinkSender(Protocol):
+    """Boundary for delivering passwordless sign-in links."""
+
+    def send_magic_link(self, *, email: str, verification_url: str) -> None:
+        """Deliver a sign-in URL to one verified destination."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class SmtpMagicLinkSender:
+    """SMTP-backed sign-in link delivery adapter."""
+
+    host: str
+    port: int
+    from_email: str
+    username: str
+    password: str
+    starttls: bool
+
+    def send_magic_link(self, *, email: str, verification_url: str) -> None:
+        """Send a short-lived passwordless sign-in link by email."""
+        message = EmailMessage()
+        message["Subject"] = "Sign in to Podex"
+        message["From"] = self.from_email
+        message["To"] = email
+        message.set_content(
+            "Use this link to sign in to Podex. It expires shortly and can be used "
+            f"only once:\n\n{verification_url}\n",
+        )
+        with smtplib.SMTP(self.host, self.port, timeout=10) as smtp:
+            if self.starttls:
+                smtp.starttls()
+            if self.username:
+                smtp.login(self.username, self.password)
+            smtp.send_message(message)
+
+
+def build_magic_link_sender(*, settings: Settings) -> MagicLinkSender | None:
+    """Build SMTP delivery when sign-in email configuration is present."""
+    if not settings.smtp_host or not settings.smtp_from_email:
+        return None
+    return SmtpMagicLinkSender(
+        host=settings.smtp_host,
+        port=settings.smtp_port,
+        from_email=settings.smtp_from_email,
+        username=settings.smtp_username,
+        password=settings.smtp_password,
+        starttls=settings.smtp_starttls,
+    )

--- a/backend/tests/test_account_auth.py
+++ b/backend/tests/test_account_auth.py
@@ -1,0 +1,211 @@
+"""Tests for passwordless account authentication and sessions."""
+
+from datetime import UTC, datetime, timedelta
+
+from assertpy import assert_that
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.models import AccountUser, MagicLinkToken, UserSession
+from podex.services.account_auth import (
+    authenticate_magic_link,
+    get_authenticated_user,
+    issue_magic_link,
+    revoke_user_session,
+)
+
+_NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+
+
+def test_issue_magic_link_creates_user_and_hashed_token(
+    db_session: Session,
+) -> None:
+    """A first sign-in request creates the account and a hashed challenge."""
+    issued = issue_magic_link(
+        db=db_session,
+        email="  Reader@Example.COM ",
+        redirect_path="/account",
+        ttl_minutes=15,
+        now=_NOW,
+    )
+    db_session.commit()
+
+    user = db_session.execute(select(AccountUser)).scalar_one()
+    challenge = db_session.execute(select(MagicLinkToken)).scalar_one()
+    assert_that(issued.email).is_equal_to("reader@example.com")
+    assert_that(user.email).is_equal_to("reader@example.com")
+    assert_that(challenge.token_digest).is_not_equal_to(issued.token)
+    assert_that(challenge.redirect_path).is_equal_to("/account")
+    assert_that(issued.expires_at).is_equal_to(_NOW + timedelta(minutes=15))
+
+
+def test_reissue_invalidates_prior_outstanding_challenge(
+    db_session: Session,
+) -> None:
+    """Requesting a second link consumes the earlier unconsumed challenge."""
+    first = issue_magic_link(
+        db=db_session,
+        email="reader@example.com",
+        redirect_path=None,
+        ttl_minutes=15,
+        now=_NOW,
+    )
+    issue_magic_link(
+        db=db_session,
+        email="reader@example.com",
+        redirect_path=None,
+        ttl_minutes=15,
+        now=_NOW,
+    )
+    db_session.commit()
+
+    stale = authenticate_magic_link(
+        db=db_session,
+        token=first.token,
+        session_ttl_days=30,
+        now=_NOW,
+    )
+    assert_that(stale).is_none()
+
+
+def test_authenticate_magic_link_issues_single_use_session(
+    db_session: Session,
+) -> None:
+    """A valid link signs the user in exactly once."""
+    issued = issue_magic_link(
+        db=db_session,
+        email="reader@example.com",
+        redirect_path=None,
+        ttl_minutes=15,
+        now=_NOW,
+    )
+    session = authenticate_magic_link(
+        db=db_session,
+        token=issued.token,
+        session_ttl_days=30,
+        now=_NOW,
+    )
+    db_session.commit()
+
+    assert_that(session).is_not_none()
+    if session is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(session.user.last_signed_in_at).is_equal_to(
+        _NOW.replace(tzinfo=None),
+    )
+    replay = authenticate_magic_link(
+        db=db_session,
+        token=issued.token,
+        session_ttl_days=30,
+        now=_NOW,
+    )
+    assert_that(replay).is_none()
+
+
+def test_expired_magic_link_is_rejected(db_session: Session) -> None:
+    """A link past its TTL cannot be redeemed."""
+    issued = issue_magic_link(
+        db=db_session,
+        email="reader@example.com",
+        redirect_path=None,
+        ttl_minutes=15,
+        now=_NOW,
+    )
+    late = authenticate_magic_link(
+        db=db_session,
+        token=issued.token,
+        session_ttl_days=30,
+        now=_NOW + timedelta(minutes=16),
+    )
+    assert_that(late).is_none()
+
+
+def test_get_authenticated_user_resolves_and_touches_session(
+    db_session: Session,
+) -> None:
+    """An active session token resolves to its user and updates last-seen."""
+    issued = issue_magic_link(
+        db=db_session,
+        email="reader@example.com",
+        redirect_path=None,
+        ttl_minutes=15,
+        now=_NOW,
+    )
+    session = authenticate_magic_link(
+        db=db_session,
+        token=issued.token,
+        session_ttl_days=30,
+        now=_NOW,
+    )
+    if session is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    later = _NOW + timedelta(hours=2)
+
+    user = get_authenticated_user(
+        db=db_session,
+        session_token=session.token,
+        now=later,
+    )
+    db_session.commit()
+
+    assert_that(user).is_not_none()
+    if user is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(user.email).is_equal_to("reader@example.com")
+    stored = db_session.execute(select(UserSession)).scalar_one()
+    assert_that(stored.last_seen_at).is_equal_to(later.replace(tzinfo=None))
+    assert_that(
+        get_authenticated_user(db=db_session, session_token=None),
+    ).is_none()
+    assert_that(
+        get_authenticated_user(
+            db=db_session,
+            session_token="unknown-token",  # nosec B106 - not a credential
+            now=later,
+        ),
+    ).is_none()
+
+
+def test_expired_or_revoked_session_is_rejected(db_session: Session) -> None:
+    """Sessions past expiry or explicitly revoked stop resolving."""
+    issued = issue_magic_link(
+        db=db_session,
+        email="reader@example.com",
+        redirect_path=None,
+        ttl_minutes=15,
+        now=_NOW,
+    )
+    session = authenticate_magic_link(
+        db=db_session,
+        token=issued.token,
+        session_ttl_days=30,
+        now=_NOW,
+    )
+    if session is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+
+    expired = get_authenticated_user(
+        db=db_session,
+        session_token=session.token,
+        now=_NOW + timedelta(days=31),
+    )
+    assert_that(expired).is_none()
+
+    revoked = revoke_user_session(
+        db=db_session,
+        session_token=session.token,
+        now=_NOW,
+    )
+    db_session.commit()
+    assert_that(revoked).is_true()
+    assert_that(
+        get_authenticated_user(
+            db=db_session,
+            session_token=session.token,
+            now=_NOW,
+        ),
+    ).is_none()
+    assert_that(
+        revoke_user_session(db=db_session, session_token=session.token),
+    ).is_false()
+    assert_that(revoke_user_session(db=db_session, session_token=None)).is_false()

--- a/backend/tests/test_account_personalization.py
+++ b/backend/tests/test_account_personalization.py
@@ -1,0 +1,182 @@
+"""Tests for account saves, follows, preferences, and link delivery."""
+
+from email.message import EmailMessage
+
+import pytest
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.config import Settings
+from podex.models import AccountUser
+from podex.services.account_follows import (
+    follow_podcast,
+    list_followed_podcasts,
+    unfollow_podcast,
+)
+from podex.services.account_preferences import (
+    get_account_preferences,
+    update_account_preferences,
+)
+from podex.services.account_saves import (
+    list_saved_media,
+    remove_saved_media,
+    save_media,
+)
+from podex.services.magic_link_delivery import (
+    SmtpMagicLinkSender,
+    build_magic_link_sender,
+)
+from tests.conftest import seed_catalog_graph
+
+
+def _create_user(db_session: Session) -> AccountUser:
+    user = AccountUser(email="reader@example.com")
+    db_session.add(user)
+    db_session.flush()
+    return user
+
+
+def test_save_media_is_idempotent_and_listable(db_session: Session) -> None:
+    """Saving twice keeps one row; listing returns the catalog record."""
+    graph = seed_catalog_graph(db_session)
+    user = _create_user(db_session)
+
+    first = save_media(db=db_session, user_id=user.id, media_id=graph.media_id)
+    second = save_media(db=db_session, user_id=user.id, media_id=graph.media_id)
+    db_session.commit()
+
+    assert_that(first).is_not_none()
+    assert_that(second).is_not_none()
+    listed = list_saved_media(db=db_session, user_id=user.id)
+    assert_that(listed).is_length(1)
+    assert_that(listed[0].media.title).is_equal_to("Dune")
+    assert_that(
+        save_media(db=db_session, user_id=user.id, media_id=999_999),
+    ).is_none()
+
+
+def test_remove_saved_media(db_session: Session) -> None:
+    """Removing a save deletes the association exactly once."""
+    graph = seed_catalog_graph(db_session)
+    user = _create_user(db_session)
+    save_media(db=db_session, user_id=user.id, media_id=graph.media_id)
+    db_session.commit()
+
+    assert_that(
+        remove_saved_media(db=db_session, user_id=user.id, media_id=graph.media_id),
+    ).is_true()
+    db_session.commit()
+    assert_that(list_saved_media(db=db_session, user_id=user.id)).is_empty()
+    assert_that(
+        remove_saved_media(db=db_session, user_id=user.id, media_id=graph.media_id),
+    ).is_false()
+
+
+def test_follow_and_unfollow_podcast(db_session: Session) -> None:
+    """Following is idempotent and unfollowing removes the association."""
+    graph = seed_catalog_graph(db_session)
+    user = _create_user(db_session)
+
+    first = follow_podcast(db=db_session, user_id=user.id, podcast_id=graph.podcast_id)
+    second = follow_podcast(db=db_session, user_id=user.id, podcast_id=graph.podcast_id)
+    db_session.commit()
+
+    assert_that(first).is_not_none()
+    assert_that(second).is_not_none()
+    followed = list_followed_podcasts(db=db_session, user_id=user.id)
+    assert_that(followed).is_length(1)
+    assert_that(followed[0].podcast.slug).is_equal_to("example-show")
+    assert_that(
+        follow_podcast(db=db_session, user_id=user.id, podcast_id=999_999),
+    ).is_none()
+    assert_that(
+        unfollow_podcast(db=db_session, user_id=user.id, podcast_id=graph.podcast_id),
+    ).is_true()
+    db_session.commit()
+    assert_that(list_followed_podcasts(db=db_session, user_id=user.id)).is_empty()
+    assert_that(
+        unfollow_podcast(db=db_session, user_id=user.id, podcast_id=graph.podcast_id),
+    ).is_false()
+
+
+def test_account_preferences_default_and_update(db_session: Session) -> None:
+    """Preferences are created on first read and persist updates."""
+    user = _create_user(db_session)
+
+    preferences = get_account_preferences(db=db_session, user_id=user.id)
+    db_session.commit()
+    assert_that(preferences.digest_enabled).is_true()
+    assert_that(preferences.digest_frequency).is_equal_to("daily")
+
+    updated = update_account_preferences(
+        db=db_session,
+        user_id=user.id,
+        digest_enabled=False,
+        digest_frequency="weekly",
+    )
+    db_session.commit()
+    assert_that(updated.id).is_equal_to(preferences.id)
+    assert_that(updated.digest_enabled).is_false()
+    assert_that(updated.digest_frequency).is_equal_to("weekly")
+
+
+def test_build_magic_link_sender_requires_smtp_configuration() -> None:
+    """No sender is built until SMTP host and from-address are configured."""
+    assert_that(build_magic_link_sender(settings=Settings())).is_none()
+    sender = build_magic_link_sender(
+        settings=Settings(
+            smtp_host="smtp.example.com",
+            smtp_from_email="signin@example.com",
+        ),
+    )
+    assert_that(sender).is_instance_of(SmtpMagicLinkSender)
+
+
+def test_smtp_sender_builds_single_use_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SMTP adapter logs in when configured and sends one message."""
+    sent: dict[str, object] = {}
+
+    class _FakeSmtp:
+        def __init__(self, host: str, port: int, timeout: int) -> None:
+            sent["endpoint"] = (host, port)
+
+        def __enter__(self) -> "_FakeSmtp":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def starttls(self) -> None:
+            sent["starttls"] = True
+
+        def login(self, username: str, password: str) -> None:
+            sent["login"] = username
+
+        def send_message(self, message: EmailMessage) -> None:
+            sent["message"] = message
+
+    monkeypatch.setattr("smtplib.SMTP", _FakeSmtp)
+    sender = SmtpMagicLinkSender(
+        host="smtp.example.com",
+        port=587,
+        from_email="signin@example.com",
+        username="mailer",
+        password="secret",  # noqa: S106 # nosec B106 - test fixture credential
+        starttls=True,
+    )
+
+    sender.send_magic_link(
+        email="reader@example.com",
+        verification_url="https://podex.example/auth/verify?token=abc",
+    )
+
+    message = sent["message"]
+    assert_that(sent["endpoint"]).is_equal_to(("smtp.example.com", 587))
+    assert_that(sent["starttls"]).is_true()
+    assert_that(sent["login"]).is_equal_to("mailer")
+    if not isinstance(message, EmailMessage):  # pragma: no cover - narrowed
+        raise AssertionError
+    assert_that(message["To"]).is_equal_to("reader@example.com")
+    assert_that(message.get_content()).contains("https://podex.example/auth/verify")


### PR DESCRIPTION
## Summary

First accounts slice of the #108 split stack: email-backed account identity with passwordless magic-link authentication and revocable sessions, plus the personalization primitives (saved media, followed podcasts, digest preferences). API endpoints and the alerts/digests engines follow in the next slices; issues close when their full vertical (service + API) is delivered.

## Type

- [x] `feat` — New feature

## Changes Made

- Add `AccountUser`, `MagicLinkToken`, `UserSession`, `AccountSavedMedia`, `AccountFollowedPodcast`, and `AccountPreference` models with migration `0012_add_account_models` (all tokens stored as SHA-256 digests, never plaintext)
- Add `account_auth` service: magic-link issue (normalizes email, invalidates prior challenges), single-use authenticate with TTL enforcement, session resolution with last-seen touch, and session revocation
- Add `account_saves` / `account_follows`: idempotent save/follow against the canonical catalog with existence checks, newest-first listing, and removal
- Add `account_preferences`: defaults-on-first-read digest preferences
- Add `magic_link_delivery`: SMTP adapter built only when SMTP settings are configured; auth/SMTP settings added with placeholder-free defaults
- Add service test suites (12 tests) covering issue/consume/expiry/revoke, idempotency, and delivery

## Closes

- Relates to #75
- Relates to #76
- Relates to #77
- Relates to #79
- Relates to #108

## Testing

- [x] Added auth and personalization service tests
- [x] Full backend suite passes with coverage ≥85% (85.49%)
- [x] Migration replay + schema-drift guard passes

## Quality Checks

- [x] `lintro chk` (ruff, mypy, bandit, pydoclint) clean — health 100/100
- [x] `ruff format` applied

## Checklist

- [x] Code follows repo conventions
- [x] No real hostnames, provider accounts, or secrets; settings default empty (#108 boundary)