### PR TITLE
feat(accounts): add alert rules, evaluation, and digest delivery

### DIFF
--- a/backend/alembic/versions/0013_add_account_alert_and_digest_models.py
+++ b/backend/alembic/versions/0013_add_account_alert_and_digest_models.py
@@ -1,0 +1,136 @@
+"""Add account alert and digest models.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-07-19 00:39:45.832737
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0013"
+down_revision: str | None = "0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.create_table(
+        "account_alert_rules",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("target_type", sa.String(length=20), nullable=False),
+        sa.Column("target_id", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=30), nullable=False),
+        sa.Column("baseline_count", sa.Integer(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("last_evaluated_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["account_users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "target_type",
+            "target_id",
+            "event_type",
+            name="uq_account_alert_rules_user_target_event",
+        ),
+    )
+    op.create_index(
+        op.f("ix_account_alert_rules_target_id"),
+        "account_alert_rules",
+        ["target_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_account_alert_rules_target_type"),
+        "account_alert_rules",
+        ["target_type"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_account_alert_rules_user_id"),
+        "account_alert_rules",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_table(
+        "account_digests",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("channel", sa.String(length=20), nullable=False),
+        sa.Column("subject", sa.String(length=255), nullable=False),
+        sa.Column("body_text", sa.Text(), nullable=False),
+        sa.Column("event_count", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("delivered_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["account_users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_account_digests_user_id"), "account_digests", ["user_id"], unique=False
+    )
+    op.create_table(
+        "account_alert_events",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("rule_id", sa.Integer(), nullable=False),
+        sa.Column("previous_count", sa.Integer(), nullable=False),
+        sa.Column("observed_count", sa.Integer(), nullable=False),
+        sa.Column("digest_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["digest_id"],
+            ["account_digests.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["rule_id"],
+            ["account_alert_rules.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_account_alert_events_digest_id"),
+        "account_alert_events",
+        ["digest_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_account_alert_events_rule_id"),
+        "account_alert_events",
+        ["rule_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    op.drop_index(
+        op.f("ix_account_alert_events_rule_id"), table_name="account_alert_events"
+    )
+    op.drop_index(
+        op.f("ix_account_alert_events_digest_id"), table_name="account_alert_events"
+    )
+    op.drop_table("account_alert_events")
+    op.drop_index(op.f("ix_account_digests_user_id"), table_name="account_digests")
+    op.drop_table("account_digests")
+    op.drop_index(
+        op.f("ix_account_alert_rules_user_id"), table_name="account_alert_rules"
+    )
+    op.drop_index(
+        op.f("ix_account_alert_rules_target_type"), table_name="account_alert_rules"
+    )
+    op.drop_index(
+        op.f("ix_account_alert_rules_target_id"), table_name="account_alert_rules"
+    )
+    op.drop_table("account_alert_rules")

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -4,6 +4,9 @@ Importing the models here registers them on ``Base.metadata`` so that
 metadata-based table creation and Alembic autogenerate see every table.
 """
 
+from podex.models.account_alert_event import AccountAlertEvent
+from podex.models.account_alert_rule import AccountAlertRule
+from podex.models.account_digest import AccountDigest
 from podex.models.account_followed_podcast import AccountFollowedPodcast
 from podex.models.account_preference import AccountPreference
 from podex.models.account_saved_media import AccountSavedMedia
@@ -53,6 +56,9 @@ from podex.models.transcript_source_retention_policy import (
 from podex.models.user_session import UserSession
 
 __all__ = [
+    "AccountAlertEvent",
+    "AccountAlertRule",
+    "AccountDigest",
     "AccountFollowedPodcast",
     "AccountPreference",
     "AccountSavedMedia",

--- a/backend/src/podex/models/account_alert_event.py
+++ b/backend/src/podex/models/account_alert_event.py
@@ -1,0 +1,27 @@
+"""Triggered account alert event persistence."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AccountAlertEvent(Base):
+    """A generated alert notification awaiting digest/delivery handling."""
+
+    __tablename__ = "account_alert_events"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    rule_id: Mapped[int] = mapped_column(
+        ForeignKey("account_alert_rules.id"),
+        index=True,
+    )
+    previous_count: Mapped[int] = mapped_column()
+    observed_count: Mapped[int] = mapped_column()
+    digest_id: Mapped[int | None] = mapped_column(
+        ForeignKey("account_digests.id"),
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))

--- a/backend/src/podex/models/account_alert_rule.py
+++ b/backend/src/podex/models/account_alert_rule.py
@@ -1,0 +1,37 @@
+"""Account alert rule persistence."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import Boolean, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AccountAlertRule(Base):
+    """Notification rule over an account-linked public catalog resource."""
+
+    __tablename__ = "account_alert_rules"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "target_type",
+            "target_id",
+            "event_type",
+            name="uq_account_alert_rules_user_target_event",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("account_users.id"), index=True)
+    target_type: Mapped[str] = mapped_column(String(20), index=True)
+    target_id: Mapped[int] = mapped_column(index=True)
+    event_type: Mapped[str] = mapped_column(String(30))
+    baseline_count: Mapped[int] = mapped_column(default=0)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    last_evaluated_at: Mapped[datetime | None] = mapped_column()
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/backend/src/podex/models/account_digest.py
+++ b/backend/src/podex/models/account_digest.py
@@ -1,0 +1,23 @@
+"""Delivered account notification digest persistence."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AccountDigest(Base):
+    """A durable record of alert activity delivered to an account."""
+
+    __tablename__ = "account_digests"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("account_users.id"), index=True)
+    channel: Mapped[str] = mapped_column(String(20), default="email")
+    subject: Mapped[str] = mapped_column(String(255))
+    body_text: Mapped[str] = mapped_column(Text)
+    event_count: Mapped[int] = mapped_column()
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    delivered_at: Mapped[datetime | None] = mapped_column()

--- a/backend/src/podex/services/account_alerts.py
+++ b/backend/src/podex/services/account_alerts.py
@@ -1,0 +1,196 @@
+"""Authenticated account alert rules and deterministic evaluation."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    AccountAlertEvent,
+    AccountAlertRule,
+    AccountFollowedPodcast,
+    AccountSavedMedia,
+    Episode,
+    Mention,
+)
+
+AlertTargetType = Literal["media", "podcast"]
+AlertEventType = Literal["new_mention", "new_episode"]
+
+
+@dataclass(frozen=True, slots=True)
+class AlertEventData:
+    """New notification event generated during evaluation."""
+
+    event: AccountAlertEvent
+    rule: AccountAlertRule
+
+
+def list_alert_rules(*, db: Session, user_id: int) -> list[AccountAlertRule]:
+    """List a user's alert rules from newest to oldest."""
+    return list(
+        db.query(AccountAlertRule)
+        .filter(AccountAlertRule.user_id == user_id)
+        .order_by(AccountAlertRule.created_at.desc(), AccountAlertRule.id.desc())
+        .all(),
+    )
+
+
+def create_alert_rule(
+    *,
+    db: Session,
+    user_id: int,
+    target_type: AlertTargetType,
+    target_id: int,
+    event_type: AlertEventType,
+) -> AccountAlertRule | None:
+    """Create an alert only for an account-linked public resource."""
+    if not _is_eligible_target(
+        db=db,
+        user_id=user_id,
+        target_type=target_type,
+        target_id=target_id,
+        event_type=event_type,
+    ):
+        return None
+    existing = (
+        db.query(AccountAlertRule)
+        .filter(
+            AccountAlertRule.user_id == user_id,
+            AccountAlertRule.target_type == target_type,
+            AccountAlertRule.target_id == target_id,
+            AccountAlertRule.event_type == event_type,
+        )
+        .first()
+    )
+    if existing is not None:
+        return existing
+    rule = AccountAlertRule(
+        user_id=user_id,
+        target_type=target_type,
+        target_id=target_id,
+        event_type=event_type,
+        baseline_count=_observed_count(
+            db=db,
+            target_type=target_type,
+            target_id=target_id,
+        ),
+    )
+    db.add(rule)
+    db.flush()
+    return rule
+
+
+def set_alert_rule_enabled(
+    *,
+    db: Session,
+    user_id: int,
+    rule_id: int,
+    enabled: bool,
+) -> AccountAlertRule | None:
+    """Enable or pause an alert rule belonging to the account."""
+    rule = _get_rule(db=db, user_id=user_id, rule_id=rule_id)
+    if rule is None:
+        return None
+    rule.enabled = enabled
+    db.flush()
+    return rule
+
+
+def delete_alert_rule(*, db: Session, user_id: int, rule_id: int) -> bool:
+    """Delete an account-owned alert rule."""
+    rule = _get_rule(db=db, user_id=user_id, rule_id=rule_id)
+    if rule is None:
+        return False
+    db.delete(rule)
+    db.flush()
+    return True
+
+
+def evaluate_alert_rules(
+    *,
+    db: Session,
+    user_id: int,
+    now: datetime | None = None,
+) -> list[AlertEventData]:
+    """Generate one notification event per rule whose public count increased."""
+    evaluated_at = now or datetime.now(UTC)
+    generated: list[AlertEventData] = []
+    for rule in list_alert_rules(db=db, user_id=user_id):
+        if not rule.enabled:
+            continue
+        observed_count = _observed_count(
+            db=db,
+            target_type=rule.target_type,
+            target_id=rule.target_id,
+        )
+        rule.last_evaluated_at = evaluated_at
+        if observed_count > rule.baseline_count:
+            event = AccountAlertEvent(
+                rule_id=rule.id,
+                previous_count=rule.baseline_count,
+                observed_count=observed_count,
+            )
+            rule.baseline_count = observed_count
+            db.add(event)
+            db.flush()
+            generated.append(AlertEventData(event=event, rule=rule))
+    db.flush()
+    return generated
+
+
+def _get_rule(*, db: Session, user_id: int, rule_id: int) -> AccountAlertRule | None:
+    """Load an account-owned alert rule."""
+    return (
+        db.query(AccountAlertRule)
+        .filter(
+            AccountAlertRule.id == rule_id,
+            AccountAlertRule.user_id == user_id,
+        )
+        .first()
+    )
+
+
+def _is_eligible_target(
+    *,
+    db: Session,
+    user_id: int,
+    target_type: AlertTargetType,
+    target_id: int,
+    event_type: AlertEventType,
+) -> bool:
+    """Require rule targets to be linked public resources of the correct kind."""
+    if target_type == "media" and event_type == "new_mention":
+        return (
+            db.query(AccountSavedMedia)
+            .filter(
+                AccountSavedMedia.user_id == user_id,
+                AccountSavedMedia.media_id == target_id,
+            )
+            .first()
+            is not None
+        )
+    if target_type == "podcast" and event_type == "new_episode":
+        return (
+            db.query(AccountFollowedPodcast)
+            .filter(
+                AccountFollowedPodcast.user_id == user_id,
+                AccountFollowedPodcast.podcast_id == target_id,
+            )
+            .first()
+            is not None
+        )
+    return False
+
+
+def _observed_count(
+    *,
+    db: Session,
+    target_type: str,
+    target_id: int,
+) -> int:
+    """Measure published events represented by a rule target."""
+    if target_type == "media":
+        return int(db.query(Mention).filter(Mention.media_id == target_id).count())
+    return int(db.query(Episode).filter(Episode.podcast_id == target_id).count())

--- a/backend/src/podex/services/account_alerts.py
+++ b/backend/src/podex/services/account_alerts.py
@@ -103,6 +103,9 @@ def delete_alert_rule(*, db: Session, user_id: int, rule_id: int) -> bool:
     rule = _get_rule(db=db, user_id=user_id, rule_id=rule_id)
     if rule is None:
         return False
+    db.query(AccountAlertEvent).filter(
+        AccountAlertEvent.rule_id == rule.id,
+    ).delete(synchronize_session=False)
     db.delete(rule)
     db.flush()
     return True

--- a/backend/src/podex/services/account_digests.py
+++ b/backend/src/podex/services/account_digests.py
@@ -1,0 +1,88 @@
+"""Account digest generation and delivery from alert events."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    AccountAlertEvent,
+    AccountAlertRule,
+    AccountDigest,
+    AccountUser,
+    Media,
+    Podcast,
+)
+from podex.services.notification_delivery import DigestSender
+
+
+def list_account_digests(*, db: Session, user_id: int) -> list[AccountDigest]:
+    """List previously delivered digests for an account."""
+    return list(
+        db.query(AccountDigest)
+        .filter(AccountDigest.user_id == user_id)
+        .order_by(AccountDigest.created_at.desc(), AccountDigest.id.desc())
+        .all(),
+    )
+
+
+def send_pending_digest(
+    *,
+    db: Session,
+    user: AccountUser,
+    sender: DigestSender,
+    now: datetime | None = None,
+) -> AccountDigest | None:
+    """Deliver undigested alert events once and persist the delivery record."""
+    events = (
+        db.query(AccountAlertEvent)
+        .join(AccountAlertRule, AccountAlertRule.id == AccountAlertEvent.rule_id)
+        .filter(
+            AccountAlertRule.user_id == user.id,
+            AccountAlertEvent.digest_id.is_(None),
+        )
+        .order_by(AccountAlertEvent.created_at.asc(), AccountAlertEvent.id.asc())
+        .all()
+    )
+    if not events:
+        return None
+    body_lines = ["New activity from your Podex alerts", ""]
+    for event in events:
+        rule = (
+            db.query(AccountAlertRule)
+            .filter(AccountAlertRule.id == event.rule_id)
+            .one()
+        )
+        body_lines.append(_event_summary(db=db, rule=rule, event=event))
+    body_lines.extend(["", "Manage your alerts in your Podex account."])
+    subject = f"Podex digest: {len(events)} new update{'s' if len(events) != 1 else ''}"
+    digest = AccountDigest(
+        user_id=user.id,
+        subject=subject,
+        body_text="\n".join(body_lines),
+        event_count=len(events),
+    )
+    db.add(digest)
+    db.flush()
+    sender.send_digest(email=user.email, subject=subject, body_text=digest.body_text)
+    delivered_at = now or datetime.now(UTC)
+    digest.delivered_at = delivered_at
+    for event in events:
+        event.digest_id = digest.id
+    db.flush()
+    return digest
+
+
+def _event_summary(
+    *,
+    db: Session,
+    rule: AccountAlertRule,
+    event: AccountAlertEvent,
+) -> str:
+    """Render one human-readable notification line."""
+    if rule.target_type == "media":
+        media = db.query(Media).filter(Media.id == rule.target_id).one()
+        count = event.observed_count - event.previous_count
+        return f"- {count} new mention{'s' if count != 1 else ''} of {media.title}"
+    podcast = db.query(Podcast).filter(Podcast.id == rule.target_id).one()
+    count = event.observed_count - event.previous_count
+    return f"- {count} new episode{'s' if count != 1 else ''} from {podcast.name}"

--- a/backend/src/podex/services/notification_delivery.py
+++ b/backend/src/podex/services/notification_delivery.py
@@ -1,0 +1,55 @@
+"""Email delivery adapter for user notification digests."""
+
+import smtplib
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Protocol
+
+from podex.config import Settings
+
+
+class DigestSender(Protocol):
+    """Delivery boundary for an assembled notification digest."""
+
+    def send_digest(self, *, email: str, subject: str, body_text: str) -> None:
+        """Send one account digest email."""
+
+
+@dataclass(frozen=True, slots=True)
+class SmtpDigestSender:
+    """Send notification digest mail through configured SMTP."""
+
+    host: str
+    port: int
+    from_email: str
+    username: str
+    password: str
+    starttls: bool
+
+    def send_digest(self, *, email: str, subject: str, body_text: str) -> None:
+        """Send one text-only digest email."""
+        message = EmailMessage()
+        message["Subject"] = subject
+        message["From"] = self.from_email
+        message["To"] = email
+        message.set_content(body_text)
+        with smtplib.SMTP(host=self.host, port=self.port) as smtp:
+            if self.starttls:
+                smtp.starttls()
+            if self.username:
+                smtp.login(user=self.username, password=self.password)
+            smtp.send_message(message)
+
+
+def build_digest_sender(*, settings: Settings) -> DigestSender | None:
+    """Build configured digest email delivery when SMTP is available."""
+    if not settings.smtp_host or not settings.smtp_from_email:
+        return None
+    return SmtpDigestSender(
+        host=settings.smtp_host,
+        port=settings.smtp_port,
+        from_email=settings.smtp_from_email,
+        username=settings.smtp_username,
+        password=settings.smtp_password,
+        starttls=settings.smtp_starttls,
+    )

--- a/backend/tests/test_account_alerts_digests.py
+++ b/backend/tests/test_account_alerts_digests.py
@@ -1,0 +1,275 @@
+"""Tests for account alert rules, evaluation, and digest delivery."""
+
+from datetime import UTC, datetime
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.config import Settings
+from podex.models import (
+    AccountAlertEvent,
+    AccountUser,
+    Episode,
+    Mention,
+)
+from podex.services.account_alerts import (
+    create_alert_rule,
+    delete_alert_rule,
+    evaluate_alert_rules,
+    list_alert_rules,
+    set_alert_rule_enabled,
+)
+from podex.services.account_digests import list_account_digests, send_pending_digest
+from podex.services.account_follows import follow_podcast
+from podex.services.account_saves import save_media
+from podex.services.notification_delivery import (
+    SmtpDigestSender,
+    build_digest_sender,
+)
+from tests.conftest import SeededGraph, seed_catalog_graph
+
+_NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+
+
+class RecordingDigestSender:
+    """In-memory digest delivery for tests."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, str]] = []
+
+    def send_digest(self, *, email: str, subject: str, body_text: str) -> None:
+        """Record one delivered digest."""
+        self.sent.append((email, subject, body_text))
+
+
+def _create_linked_user(db_session: Session, graph: SeededGraph) -> AccountUser:
+    user = AccountUser(email="reader@example.com")
+    db_session.add(user)
+    db_session.flush()
+    save_media(db=db_session, user_id=user.id, media_id=graph.media_id)
+    follow_podcast(db=db_session, user_id=user.id, podcast_id=graph.podcast_id)
+    return user
+
+
+def test_create_alert_rule_requires_linked_target(db_session: Session) -> None:
+    """Rules exist only for saved media or followed podcasts."""
+    graph = seed_catalog_graph(db_session)
+    user = AccountUser(email="reader@example.com")
+    db_session.add(user)
+    db_session.flush()
+
+    orphan = create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="media",
+        target_id=graph.media_id,
+        event_type="new_mention",
+    )
+    assert_that(orphan).is_none()
+
+    save_media(db=db_session, user_id=user.id, media_id=graph.media_id)
+    rule = create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="media",
+        target_id=graph.media_id,
+        event_type="new_mention",
+    )
+    duplicate = create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="media",
+        target_id=graph.media_id,
+        event_type="new_mention",
+    )
+    db_session.commit()
+
+    assert_that(rule).is_not_none()
+    if rule is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(rule.baseline_count).is_equal_to(1)
+    assert_that(duplicate).is_same_as(rule)
+    mismatched = create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="media",
+        target_id=graph.media_id,
+        event_type="new_episode",
+    )
+    assert_that(mismatched).is_none()
+
+
+def test_evaluate_alert_rules_generates_events_on_growth(
+    db_session: Session,
+) -> None:
+    """Evaluation emits one event per rule whose observed count grew."""
+    graph = seed_catalog_graph(db_session)
+    user = _create_linked_user(db_session, graph)
+    create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="media",
+        target_id=graph.media_id,
+        event_type="new_mention",
+    )
+    create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="podcast",
+        target_id=graph.podcast_id,
+        event_type="new_episode",
+    )
+    db_session.commit()
+
+    quiet = evaluate_alert_rules(db=db_session, user_id=user.id, now=_NOW)
+    assert_that(quiet).is_empty()
+
+    episode = Episode(podcast_id=graph.podcast_id, title="Pilot II", episode_number=2)
+    db_session.add(episode)
+    db_session.flush()
+    db_session.add(
+        Mention(
+            episode_id=episode.id,
+            media_id=graph.media_id,
+            context="mentioned again",
+        ),
+    )
+    db_session.commit()
+
+    generated = evaluate_alert_rules(db=db_session, user_id=user.id, now=_NOW)
+    db_session.commit()
+
+    assert_that(generated).is_length(2)
+    repeat = evaluate_alert_rules(db=db_session, user_id=user.id, now=_NOW)
+    assert_that(repeat).is_empty()
+
+
+def test_alert_rule_enable_and_delete(db_session: Session) -> None:
+    """Rules can be paused, resumed, and removed by their owner only."""
+    graph = seed_catalog_graph(db_session)
+    user = _create_linked_user(db_session, graph)
+    rule = create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="media",
+        target_id=graph.media_id,
+        event_type="new_mention",
+    )
+    if rule is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    db_session.commit()
+
+    paused = set_alert_rule_enabled(
+        db=db_session,
+        user_id=user.id,
+        rule_id=rule.id,
+        enabled=False,
+    )
+    assert_that(paused).is_not_none()
+    if paused is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(paused.enabled).is_false()
+    assert_that(
+        set_alert_rule_enabled(
+            db=db_session,
+            user_id=user.id + 1,
+            rule_id=rule.id,
+            enabled=True,
+        ),
+    ).is_none()
+    assert_that(list_alert_rules(db=db_session, user_id=user.id)).is_length(1)
+    assert_that(
+        delete_alert_rule(db=db_session, user_id=user.id, rule_id=rule.id),
+    ).is_true()
+    db_session.commit()
+    assert_that(
+        delete_alert_rule(db=db_session, user_id=user.id, rule_id=rule.id),
+    ).is_false()
+
+
+def test_send_pending_digest_delivers_once(db_session: Session) -> None:
+    """Undigested events deliver as one digest and never redeliver."""
+    graph = seed_catalog_graph(db_session)
+    user = _create_linked_user(db_session, graph)
+    create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="podcast",
+        target_id=graph.podcast_id,
+        event_type="new_episode",
+    )
+    db_session.add(
+        Episode(podcast_id=graph.podcast_id, title="Pilot II", episode_number=2),
+    )
+    db_session.commit()
+    evaluate_alert_rules(db=db_session, user_id=user.id, now=_NOW)
+    db_session.commit()
+    sender = RecordingDigestSender()
+
+    empty_before_events = send_pending_digest(
+        db=db_session,
+        user=user,
+        sender=sender,
+        now=_NOW,
+    )
+    db_session.commit()
+
+    assert_that(empty_before_events).is_not_none()
+    if empty_before_events is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(sender.sent).is_length(1)
+    email, subject, body = sender.sent[0]
+    assert_that(email).is_equal_to("reader@example.com")
+    assert_that(subject).contains("1 new update")
+    assert_that(body).contains("1 new episode from The Example Show")
+    assert_that(empty_before_events.delivered_at).is_not_none()
+
+    event = db_session.query(AccountAlertEvent).one()
+    assert_that(event.digest_id).is_equal_to(empty_before_events.id)
+    assert_that(
+        send_pending_digest(db=db_session, user=user, sender=sender, now=_NOW),
+    ).is_none()
+    assert_that(list_account_digests(db=db_session, user_id=user.id)).is_length(1)
+
+
+def test_digest_summarizes_media_mentions(db_session: Session) -> None:
+    """Media-mention events render the media title in the digest body."""
+    graph = seed_catalog_graph(db_session)
+    user = _create_linked_user(db_session, graph)
+    create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="media",
+        target_id=graph.media_id,
+        event_type="new_mention",
+    )
+    db_session.add(
+        Mention(
+            episode_id=graph.episode_id,
+            media_id=graph.media_id,
+            context="mentioned again",
+        ),
+    )
+    db_session.commit()
+    evaluate_alert_rules(db=db_session, user_id=user.id, now=_NOW)
+    sender = RecordingDigestSender()
+
+    digest = send_pending_digest(db=db_session, user=user, sender=sender, now=_NOW)
+    db_session.commit()
+
+    assert_that(digest).is_not_none()
+    if digest is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(digest.body_text).contains("1 new mention of Dune")
+
+
+def test_build_digest_sender_requires_smtp_configuration() -> None:
+    """No digest sender is built until SMTP settings are present."""
+    assert_that(build_digest_sender(settings=Settings())).is_none()
+    sender = build_digest_sender(
+        settings=Settings(
+            smtp_host="smtp.example.com",
+            smtp_from_email="digests@example.com",
+        ),
+    )
+    assert_that(sender).is_instance_of(SmtpDigestSender)


### PR DESCRIPTION
## Summary

Second accounts slice of the #108 split stack: alert rules over saved media and followed podcasts, deterministic evaluation against public catalog counts, and one-shot email digest delivery of generated events. The API endpoints for these features land in the next slice, which closes #75–#79.

## Type

- [x] `feat` — New feature

## Changes Made

- Add `AccountAlertRule`, `AccountAlertEvent`, and `AccountDigest` models with migration `0013_add_account_alert_and_digest_models`
- Add `account_alerts` service: rules are creatable only over account-linked resources (saved media → `new_mention`, followed podcast → `new_episode`), deduplicated per target/event, with baseline-count evaluation that emits one event per observed increase and advances the baseline
- Add `account_digests` service: assembles undigested events into one human-readable digest, delivers via the sender boundary, stamps `delivered_at`, and marks events digested so they never redeliver
- Add `notification_delivery`: SMTP digest sender built only when SMTP settings are configured
- Add alerts/digests test suite (6 tests) covering eligibility, idempotency, growth detection, pause/delete, one-shot delivery, and rendering

## Closes

- Relates to #78
- Relates to #79
- Relates to #108

## Testing

- [x] Added alerts and digest service tests
- [x] Full backend suite passes with coverage ≥85%
- [x] Migration replay + schema-drift guard passes

## Quality Checks

- [x] `lintro chk` (ruff, mypy, bandit, pydoclint) clean — health 100/100
- [x] `ruff format` applied

## Checklist

- [x] Code follows repo conventions
- [x] No real hostnames or secrets; SMTP settings default empty (#108 boundary)