### PR TITLE
feat(api): add account auth, personalization, and billing endpoints

### DIFF
--- a/backend/alembic/versions/0014_add_billing_models.py
+++ b/backend/alembic/versions/0014_add_billing_models.py
@@ -1,0 +1,92 @@
+"""Add account subscription and quota models.
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-07-19 00:51:00.325288
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0014"
+down_revision: str | None = "0013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.create_table(
+        "account_quota_usage",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("period", sa.String(length=7), nullable=False),
+        sa.Column("feature", sa.String(length=40), nullable=False),
+        sa.Column("units", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["account_users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "period",
+            "feature",
+            name="uq_account_quota_usage_user_period_feature",
+        ),
+    )
+    op.create_index(
+        op.f("ix_account_quota_usage_period"),
+        "account_quota_usage",
+        ["period"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_account_quota_usage_user_id"),
+        "account_quota_usage",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_table(
+        "account_subscriptions",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("tier", sa.String(length=20), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("billing_provider", sa.String(length=40), nullable=True),
+        sa.Column("provider_customer_id", sa.String(length=255), nullable=True),
+        sa.Column("provider_subscription_id", sa.String(length=255), nullable=True),
+        sa.Column("current_period_ends_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["account_users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_account_subscriptions_user_id"),
+        "account_subscriptions",
+        ["user_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    op.drop_index(
+        op.f("ix_account_subscriptions_user_id"), table_name="account_subscriptions"
+    )
+    op.drop_table("account_subscriptions")
+    op.drop_index(
+        op.f("ix_account_quota_usage_user_id"), table_name="account_quota_usage"
+    )
+    op.drop_index(
+        op.f("ix_account_quota_usage_period"), table_name="account_quota_usage"
+    )
+    op.drop_table("account_quota_usage")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "anthropic>=0.40",
   "cryptography>=48.0.0",
   "boto3>=1.43.14",
+  "email-validator>=2.0.0",
 ]
 
 [project.urls]

--- a/backend/src/podex/api/v2/auth.py
+++ b/backend/src/podex/api/v2/auth.py
@@ -192,11 +192,6 @@ def _to_saved_media_read(*, saved: SavedMediaData) -> SavedMediaRead:
     )
 
 
-@router.post(
-    "/auth/magic-link/request",
-    response_model=AuthMagicLinkRequestResponse,
-    status_code=status.HTTP_202_ACCEPTED,
-)
 def request_auth_magic_link(
     payload: AuthMagicLinkRequest,
     db: DbSession,
@@ -234,7 +229,6 @@ def request_auth_magic_link(
     return AuthMagicLinkRequestResponse()
 
 
-@router.post("/auth/magic-link/verify", response_model=AuthSessionRead)
 def verify_auth_magic_link(
     payload: AuthMagicLinkVerifyRequest,
     response: Response,
@@ -264,7 +258,6 @@ def verify_auth_magic_link(
     )
 
 
-@router.post("/auth/logout", response_model=AuthLogoutResponse)
 def logout_account_session(
     request: Request,
     response: Response,
@@ -281,7 +274,6 @@ def logout_account_session(
     return AuthLogoutResponse(signed_out=signed_out)
 
 
-@router.get("/me", response_model=AccountUserRead)
 def get_current_account(
     request: Request,
     db: DbSession,
@@ -293,7 +285,6 @@ def get_current_account(
     return AccountUserRead.model_validate(user)
 
 
-@router.get("/me/saves", response_model=SavedMediaListRead)
 def list_account_saved_media(
     request: Request,
     db: DbSession,
@@ -309,7 +300,6 @@ def list_account_saved_media(
     )
 
 
-@router.put("/me/saves/{media_id}", response_model=SavedMediaRead)
 def put_account_saved_media(
     media_id: int,
     request: Request,
@@ -326,7 +316,6 @@ def put_account_saved_media(
     return _to_saved_media_read(saved=saved)
 
 
-@router.delete("/me/saves/{media_id}", response_model=SavedMediaDeleteResponse)
 def delete_account_saved_media(
     media_id: int,
     request: Request,
@@ -340,7 +329,6 @@ def delete_account_saved_media(
     return SavedMediaDeleteResponse(deleted=deleted)
 
 
-@router.get("/me/follows", response_model=FollowedPodcastListRead)
 def list_account_followed_podcasts(
     request: Request,
     db: DbSession,
@@ -362,7 +350,6 @@ def list_account_followed_podcasts(
     )
 
 
-@router.put("/me/follows/{podcast_id}", response_model=FollowedPodcastRead)
 def put_account_followed_podcast(
     podcast_id: int,
     request: Request,
@@ -382,10 +369,6 @@ def put_account_followed_podcast(
     )
 
 
-@router.delete(
-    "/me/follows/{podcast_id}",
-    response_model=FollowedPodcastDeleteResponse,
-)
 def delete_account_followed_podcast(
     podcast_id: int,
     request: Request,
@@ -399,7 +382,6 @@ def delete_account_followed_podcast(
     return FollowedPodcastDeleteResponse(deleted=deleted)
 
 
-@router.get("/me/alerts", response_model=AlertRuleListRead)
 def list_account_alert_rules(
     request: Request,
     db: DbSession,
@@ -415,7 +397,6 @@ def list_account_alert_rules(
     )
 
 
-@router.post("/me/alerts", response_model=AlertRuleRead)
 def create_account_alert_rule(
     payload: AlertRuleCreateRequest,
     request: Request,
@@ -441,7 +422,6 @@ def create_account_alert_rule(
     return AlertRuleRead.model_validate(rule)
 
 
-@router.patch("/me/alerts/{rule_id}", response_model=AlertRuleRead)
 def update_account_alert_rule(
     rule_id: int,
     payload: AlertRuleUpdateRequest,
@@ -463,7 +443,6 @@ def update_account_alert_rule(
     return AlertRuleRead.model_validate(rule)
 
 
-@router.delete("/me/alerts/{rule_id}", response_model=AlertRuleDeleteResponse)
 def delete_account_alert_rule(
     rule_id: int,
     request: Request,
@@ -477,7 +456,6 @@ def delete_account_alert_rule(
     return AlertRuleDeleteResponse(deleted=deleted)
 
 
-@router.post("/me/alerts/evaluate", response_model=AlertEvaluationRead)
 def evaluate_account_alert_rules(
     request: Request,
     db: DbSession,
@@ -500,7 +478,6 @@ def evaluate_account_alert_rules(
     )
 
 
-@router.get("/me/digests", response_model=DigestListRead)
 def list_current_account_digests(
     request: Request,
     db: DbSession,
@@ -516,7 +493,6 @@ def list_current_account_digests(
     )
 
 
-@router.post("/me/digests/send", response_model=DigestSendResponse)
 def send_current_account_digest(
     request: Request,
     db: DbSession,
@@ -552,7 +528,6 @@ def send_current_account_digest(
     )
 
 
-@router.get("/me/preferences", response_model=PreferenceRead)
 def get_current_account_preferences(
     request: Request,
     db: DbSession,
@@ -565,7 +540,6 @@ def get_current_account_preferences(
     return PreferenceRead.model_validate(preferences)
 
 
-@router.patch("/me/preferences", response_model=PreferenceRead)
 def update_current_account_preferences(
     payload: PreferenceUpdateRequest,
     request: Request,
@@ -584,7 +558,6 @@ def update_current_account_preferences(
     return PreferenceRead.model_validate(preferences)
 
 
-@router.get("/me/subscription", response_model=SubscriptionRead)
 def get_current_account_subscription(
     request: Request,
     db: DbSession,
@@ -616,7 +589,6 @@ def get_current_account_subscription(
     )
 
 
-@router.post("/me/subscription/checkout", response_model=SubscriptionCheckoutRead)
 def begin_current_account_checkout(
     request: Request,
     db: DbSession,
@@ -645,3 +617,152 @@ def begin_current_account_checkout(
         provider=checkout.provider,
         checkout_url=checkout.checkout_url,
     )
+
+
+router.add_api_route(
+    "/auth/magic-link/request",
+    request_auth_magic_link,
+    methods=["POST"],
+    response_model=AuthMagicLinkRequestResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+
+router.add_api_route(
+    "/auth/magic-link/verify",
+    verify_auth_magic_link,
+    methods=["POST"],
+    response_model=AuthSessionRead,
+)
+
+router.add_api_route(
+    "/auth/logout",
+    logout_account_session,
+    methods=["POST"],
+    response_model=AuthLogoutResponse,
+)
+
+router.add_api_route(
+    "/me",
+    get_current_account,
+    methods=["GET"],
+    response_model=AccountUserRead,
+)
+
+router.add_api_route(
+    "/me/saves",
+    list_account_saved_media,
+    methods=["GET"],
+    response_model=SavedMediaListRead,
+)
+
+router.add_api_route(
+    "/me/saves/{media_id}",
+    put_account_saved_media,
+    methods=["PUT"],
+    response_model=SavedMediaRead,
+)
+
+router.add_api_route(
+    "/me/saves/{media_id}",
+    delete_account_saved_media,
+    methods=["DELETE"],
+    response_model=SavedMediaDeleteResponse,
+)
+
+router.add_api_route(
+    "/me/follows",
+    list_account_followed_podcasts,
+    methods=["GET"],
+    response_model=FollowedPodcastListRead,
+)
+
+router.add_api_route(
+    "/me/follows/{podcast_id}",
+    put_account_followed_podcast,
+    methods=["PUT"],
+    response_model=FollowedPodcastRead,
+)
+
+router.add_api_route(
+    "/me/follows/{podcast_id}",
+    delete_account_followed_podcast,
+    methods=["DELETE"],
+    response_model=FollowedPodcastDeleteResponse,
+)
+
+router.add_api_route(
+    "/me/alerts",
+    list_account_alert_rules,
+    methods=["GET"],
+    response_model=AlertRuleListRead,
+)
+
+router.add_api_route(
+    "/me/alerts",
+    create_account_alert_rule,
+    methods=["POST"],
+    response_model=AlertRuleRead,
+)
+
+router.add_api_route(
+    "/me/alerts/{rule_id}",
+    update_account_alert_rule,
+    methods=["PATCH"],
+    response_model=AlertRuleRead,
+)
+
+router.add_api_route(
+    "/me/alerts/{rule_id}",
+    delete_account_alert_rule,
+    methods=["DELETE"],
+    response_model=AlertRuleDeleteResponse,
+)
+
+router.add_api_route(
+    "/me/alerts/evaluate",
+    evaluate_account_alert_rules,
+    methods=["POST"],
+    response_model=AlertEvaluationRead,
+)
+
+router.add_api_route(
+    "/me/digests",
+    list_current_account_digests,
+    methods=["GET"],
+    response_model=DigestListRead,
+)
+
+router.add_api_route(
+    "/me/digests/send",
+    send_current_account_digest,
+    methods=["POST"],
+    response_model=DigestSendResponse,
+)
+
+router.add_api_route(
+    "/me/preferences",
+    get_current_account_preferences,
+    methods=["GET"],
+    response_model=PreferenceRead,
+)
+
+router.add_api_route(
+    "/me/preferences",
+    update_current_account_preferences,
+    methods=["PATCH"],
+    response_model=PreferenceRead,
+)
+
+router.add_api_route(
+    "/me/subscription",
+    get_current_account_subscription,
+    methods=["GET"],
+    response_model=SubscriptionRead,
+)
+
+router.add_api_route(
+    "/me/subscription/checkout",
+    begin_current_account_checkout,
+    methods=["POST"],
+    response_model=SubscriptionCheckoutRead,
+)

--- a/backend/src/podex/api/v2/auth.py
+++ b/backend/src/podex/api/v2/auth.py
@@ -1,0 +1,647 @@
+"""Passwordless account authentication and personalization endpoints.
+
+Route handlers stay thin: they resolve the authenticated account from the
+session cookie, delegate to the account services, and commit the unit of
+work. Magic-link and digest email delivery go through injectable sender
+boundaries so tests and deployments without SMTP stay deterministic.
+"""
+
+from typing import Annotated
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+
+from podex.api.deps import AppSettings, DbSession
+from podex.config import Settings, get_settings
+from podex.logging_config import get_logger
+from podex.models import AccountUser
+from podex.schemas.account import (
+    AccountUserRead,
+    AlertEvaluationRead,
+    AlertEventRead,
+    AlertRuleCreateRequest,
+    AlertRuleDeleteResponse,
+    AlertRuleListRead,
+    AlertRuleRead,
+    AlertRuleUpdateRequest,
+    AuthLogoutResponse,
+    AuthMagicLinkRequest,
+    AuthMagicLinkRequestResponse,
+    AuthMagicLinkVerifyRequest,
+    AuthSessionRead,
+    DigestListRead,
+    DigestRead,
+    DigestSendResponse,
+    FollowedPodcastDeleteResponse,
+    FollowedPodcastListRead,
+    FollowedPodcastRead,
+    PreferenceRead,
+    PreferenceUpdateRequest,
+    QuotaRead,
+    SavedMediaDeleteResponse,
+    SavedMediaListRead,
+    SavedMediaRead,
+    SubscriptionCheckoutRead,
+    SubscriptionRead,
+)
+from podex.schemas.media import MediaRead
+from podex.schemas.podcast import PodcastRead
+from podex.services.account_alerts import (
+    create_alert_rule,
+    delete_alert_rule,
+    evaluate_alert_rules,
+    list_alert_rules,
+    set_alert_rule_enabled,
+)
+from podex.services.account_auth import (
+    authenticate_magic_link,
+    get_authenticated_user,
+    issue_magic_link,
+    revoke_user_session,
+)
+from podex.services.account_digests import list_account_digests, send_pending_digest
+from podex.services.account_follows import (
+    follow_podcast,
+    list_followed_podcasts,
+    unfollow_podcast,
+)
+from podex.services.account_preferences import (
+    get_account_preferences,
+    update_account_preferences,
+)
+from podex.services.account_saves import (
+    SavedMediaData,
+    list_saved_media,
+    remove_saved_media,
+    save_media,
+)
+from podex.services.account_subscriptions import (
+    API_REQUESTS,
+    LLM_REQUESTS,
+    AccountQuotaExceededError,
+    PaidSubscriptionRequiredError,
+    consume_paid_api_request,
+    get_account_subscription,
+    get_quota_snapshot,
+)
+from podex.services.billing_checkout import (
+    BillingCheckoutProvider,
+    build_billing_checkout_provider,
+)
+from podex.services.magic_link_delivery import (
+    MagicLinkSender,
+    build_magic_link_sender,
+)
+from podex.services.notification_delivery import DigestSender, build_digest_sender
+
+router = APIRouter(tags=["auth"])
+logger = get_logger(__name__)
+
+
+def get_auth_magic_link_sender() -> MagicLinkSender | None:
+    """Build the configured sign-in link sender, if SMTP is available."""
+    return build_magic_link_sender(settings=get_settings())
+
+
+def get_digest_sender() -> DigestSender | None:
+    """Build the configured digest sender, if SMTP is available."""
+    return build_digest_sender(settings=get_settings())
+
+
+def get_billing_provider() -> BillingCheckoutProvider | None:
+    """Build the configured checkout provider bridge, if billing is set up."""
+    return build_billing_checkout_provider(settings=get_settings())
+
+
+MagicLinkSenderDep = Annotated[
+    MagicLinkSender | None,
+    Depends(get_auth_magic_link_sender),
+]
+DigestSenderDep = Annotated[DigestSender | None, Depends(get_digest_sender)]
+BillingProviderDep = Annotated[
+    BillingCheckoutProvider | None,
+    Depends(get_billing_provider),
+]
+
+
+def _require_authenticated_account(
+    *,
+    request: Request,
+    db: DbSession,
+    settings: Settings,
+) -> AccountUser:
+    """Resolve the authenticated account or reject the request."""
+    user = get_authenticated_user(
+        db=db,
+        session_token=request.cookies.get(settings.auth_session_cookie_name),
+    )
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+    return user
+
+
+def _set_session_cookie(
+    *,
+    response: Response,
+    token: str,
+    settings: Settings,
+) -> None:
+    """Set the secure, http-only account session cookie."""
+    response.set_cookie(
+        key=settings.auth_session_cookie_name,
+        value=token,
+        max_age=settings.auth_session_ttl_days * 24 * 60 * 60,
+        path="/",
+        secure=settings.auth_session_cookie_secure,
+        httponly=True,
+        samesite="lax",
+    )
+
+
+def _consume_paid_personalization_action(
+    *,
+    db: DbSession,
+    user_id: int,
+    settings: Settings,
+) -> None:
+    """Apply paid-feature enforcement and translate quota failures to HTTP."""
+    try:
+        consume_paid_api_request(db=db, user_id=user_id, settings=settings)
+    except PaidSubscriptionRequiredError as error:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail="A paid subscription is required for this feature",
+        ) from error
+    except AccountQuotaExceededError as error:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Monthly personalization quota exceeded",
+        ) from error
+
+
+def _to_saved_media_read(*, saved: SavedMediaData) -> SavedMediaRead:
+    """Convert a saved-media service result to its API schema."""
+    return SavedMediaRead(
+        media=MediaRead.model_validate(saved.media),
+        saved_at=saved.saved_at,
+    )
+
+
+@router.post(
+    "/auth/magic-link/request",
+    response_model=AuthMagicLinkRequestResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def request_auth_magic_link(
+    payload: AuthMagicLinkRequest,
+    db: DbSession,
+    settings: AppSettings,
+    sender: MagicLinkSenderDep,
+) -> AuthMagicLinkRequestResponse:
+    """Request delivery of a short-lived, single-use email sign-in link."""
+    if sender is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Email sign-in is not configured",
+        )
+    issued = issue_magic_link(
+        db=db,
+        email=payload.email,
+        redirect_path=payload.redirect_path,
+        ttl_minutes=settings.auth_magic_link_ttl_minutes,
+    )
+    query = {"token": issued.token}
+    if issued.redirect_path is not None:
+        query["redirect_path"] = issued.redirect_path
+    verification_url = (
+        f"{settings.public_web_url.rstrip('/')}/auth/verify?{urlencode(query)}"
+    )
+    try:
+        sender.send_magic_link(email=issued.email, verification_url=verification_url)
+    except Exception as error:
+        db.rollback()
+        logger.warning("magic_link_delivery_failed: %s", error)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to deliver sign-in link",
+        ) from error
+    db.commit()
+    return AuthMagicLinkRequestResponse()
+
+
+@router.post("/auth/magic-link/verify", response_model=AuthSessionRead)
+def verify_auth_magic_link(
+    payload: AuthMagicLinkVerifyRequest,
+    response: Response,
+    db: DbSession,
+    settings: AppSettings,
+) -> AuthSessionRead:
+    """Verify a one-time link token and begin an authenticated session."""
+    authenticated = authenticate_magic_link(
+        db=db,
+        token=payload.token,
+        session_ttl_days=settings.auth_session_ttl_days,
+    )
+    if authenticated is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Sign-in link is invalid or expired",
+        )
+    _set_session_cookie(
+        response=response,
+        token=authenticated.token,
+        settings=settings,
+    )
+    db.commit()
+    return AuthSessionRead(
+        user=AccountUserRead.model_validate(authenticated.user),
+        expires_at=authenticated.expires_at,
+    )
+
+
+@router.post("/auth/logout", response_model=AuthLogoutResponse)
+def logout_account_session(
+    request: Request,
+    response: Response,
+    db: DbSession,
+    settings: AppSettings,
+) -> AuthLogoutResponse:
+    """Revoke the current account session and expire its browser cookie."""
+    signed_out = revoke_user_session(
+        db=db,
+        session_token=request.cookies.get(settings.auth_session_cookie_name),
+    )
+    response.delete_cookie(key=settings.auth_session_cookie_name, path="/")
+    db.commit()
+    return AuthLogoutResponse(signed_out=signed_out)
+
+
+@router.get("/me", response_model=AccountUserRead)
+def get_current_account(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> AccountUserRead:
+    """Return the account represented by the current browser session."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    db.commit()
+    return AccountUserRead.model_validate(user)
+
+
+@router.get("/me/saves", response_model=SavedMediaListRead)
+def list_account_saved_media(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> SavedMediaListRead:
+    """List saved public catalog media for the current account."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    saved = list_saved_media(db=db, user_id=user.id)
+    db.commit()
+    return SavedMediaListRead(
+        items=[_to_saved_media_read(saved=item) for item in saved],
+        total=len(saved),
+    )
+
+
+@router.put("/me/saves/{media_id}", response_model=SavedMediaRead)
+def put_account_saved_media(
+    media_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> SavedMediaRead:
+    """Idempotently save a public catalog media record."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    saved = save_media(db=db, user_id=user.id, media_id=media_id)
+    if saved is None:
+        raise HTTPException(status_code=404, detail="Media not found")
+    _consume_paid_personalization_action(db=db, user_id=user.id, settings=settings)
+    db.commit()
+    return _to_saved_media_read(saved=saved)
+
+
+@router.delete("/me/saves/{media_id}", response_model=SavedMediaDeleteResponse)
+def delete_account_saved_media(
+    media_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> SavedMediaDeleteResponse:
+    """Remove a public catalog media record from the current account's saves."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    deleted = remove_saved_media(db=db, user_id=user.id, media_id=media_id)
+    db.commit()
+    return SavedMediaDeleteResponse(deleted=deleted)
+
+
+@router.get("/me/follows", response_model=FollowedPodcastListRead)
+def list_account_followed_podcasts(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> FollowedPodcastListRead:
+    """List followed public podcast sources for the current account."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    followed = list_followed_podcasts(db=db, user_id=user.id)
+    db.commit()
+    return FollowedPodcastListRead(
+        items=[
+            FollowedPodcastRead(
+                podcast=PodcastRead.model_validate(item.podcast),
+                followed_at=item.followed_at,
+            )
+            for item in followed
+        ],
+        total=len(followed),
+    )
+
+
+@router.put("/me/follows/{podcast_id}", response_model=FollowedPodcastRead)
+def put_account_followed_podcast(
+    podcast_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> FollowedPodcastRead:
+    """Idempotently follow a public podcast source."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    followed = follow_podcast(db=db, user_id=user.id, podcast_id=podcast_id)
+    if followed is None:
+        raise HTTPException(status_code=404, detail="Podcast not found")
+    _consume_paid_personalization_action(db=db, user_id=user.id, settings=settings)
+    db.commit()
+    return FollowedPodcastRead(
+        podcast=PodcastRead.model_validate(followed.podcast),
+        followed_at=followed.followed_at,
+    )
+
+
+@router.delete(
+    "/me/follows/{podcast_id}",
+    response_model=FollowedPodcastDeleteResponse,
+)
+def delete_account_followed_podcast(
+    podcast_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> FollowedPodcastDeleteResponse:
+    """Remove a public podcast source from the current account's follows."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    deleted = unfollow_podcast(db=db, user_id=user.id, podcast_id=podcast_id)
+    db.commit()
+    return FollowedPodcastDeleteResponse(deleted=deleted)
+
+
+@router.get("/me/alerts", response_model=AlertRuleListRead)
+def list_account_alert_rules(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> AlertRuleListRead:
+    """List alert rules belonging to the authenticated account."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    rules = list_alert_rules(db=db, user_id=user.id)
+    db.commit()
+    return AlertRuleListRead(
+        items=[AlertRuleRead.model_validate(rule) for rule in rules],
+        total=len(rules),
+    )
+
+
+@router.post("/me/alerts", response_model=AlertRuleRead)
+def create_account_alert_rule(
+    payload: AlertRuleCreateRequest,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> AlertRuleRead:
+    """Create an alert rule for a saved media or followed podcast resource."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    rule = create_alert_rule(
+        db=db,
+        user_id=user.id,
+        target_type=payload.target_type,
+        target_id=payload.target_id,
+        event_type=payload.event_type,
+    )
+    if rule is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Alert target must be a saved reference or followed source",
+        )
+    _consume_paid_personalization_action(db=db, user_id=user.id, settings=settings)
+    db.commit()
+    return AlertRuleRead.model_validate(rule)
+
+
+@router.patch("/me/alerts/{rule_id}", response_model=AlertRuleRead)
+def update_account_alert_rule(
+    rule_id: int,
+    payload: AlertRuleUpdateRequest,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> AlertRuleRead:
+    """Pause or resume an account alert rule."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    rule = set_alert_rule_enabled(
+        db=db,
+        user_id=user.id,
+        rule_id=rule_id,
+        enabled=payload.enabled,
+    )
+    if rule is None:
+        raise HTTPException(status_code=404, detail="Alert rule not found")
+    db.commit()
+    return AlertRuleRead.model_validate(rule)
+
+
+@router.delete("/me/alerts/{rule_id}", response_model=AlertRuleDeleteResponse)
+def delete_account_alert_rule(
+    rule_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> AlertRuleDeleteResponse:
+    """Remove an alert rule belonging to the authenticated account."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    deleted = delete_alert_rule(db=db, user_id=user.id, rule_id=rule_id)
+    db.commit()
+    return AlertRuleDeleteResponse(deleted=deleted)
+
+
+@router.post("/me/alerts/evaluate", response_model=AlertEvaluationRead)
+def evaluate_account_alert_rules(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> AlertEvaluationRead:
+    """Evaluate alert rules and generate events for new published activity."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    generated = evaluate_alert_rules(db=db, user_id=user.id)
+    db.commit()
+    return AlertEvaluationRead(
+        items=[
+            AlertEventRead(
+                rule=AlertRuleRead.model_validate(item.rule),
+                previous_count=item.event.previous_count,
+                observed_count=item.event.observed_count,
+            )
+            for item in generated
+        ],
+        generated=len(generated),
+    )
+
+
+@router.get("/me/digests", response_model=DigestListRead)
+def list_current_account_digests(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> DigestListRead:
+    """List delivered notification digests for the current account."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    digests = list_account_digests(db=db, user_id=user.id)
+    db.commit()
+    return DigestListRead(
+        items=[DigestRead.model_validate(digest) for digest in digests],
+        total=len(digests),
+    )
+
+
+@router.post("/me/digests/send", response_model=DigestSendResponse)
+def send_current_account_digest(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+    sender: DigestSenderDep,
+) -> DigestSendResponse:
+    """Evaluate alert rules and deliver pending activity by email."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    preferences = get_account_preferences(db=db, user_id=user.id)
+    if not preferences.digest_enabled:
+        db.commit()
+        return DigestSendResponse(delivered=False)
+    _consume_paid_personalization_action(db=db, user_id=user.id, settings=settings)
+    if sender is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Digest delivery is not configured",
+        )
+    evaluate_alert_rules(db=db, user_id=user.id)
+    try:
+        digest = send_pending_digest(db=db, user=user, sender=sender)
+    except Exception as error:
+        db.rollback()
+        logger.warning("digest_delivery_failed: %s", error)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to deliver digest",
+        ) from error
+    db.commit()
+    return DigestSendResponse(
+        digest=DigestRead.model_validate(digest) if digest is not None else None,
+        delivered=digest is not None,
+    )
+
+
+@router.get("/me/preferences", response_model=PreferenceRead)
+def get_current_account_preferences(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> PreferenceRead:
+    """Return persisted notification preferences for the signed-in account."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    preferences = get_account_preferences(db=db, user_id=user.id)
+    db.commit()
+    return PreferenceRead.model_validate(preferences)
+
+
+@router.patch("/me/preferences", response_model=PreferenceRead)
+def update_current_account_preferences(
+    payload: PreferenceUpdateRequest,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> PreferenceRead:
+    """Update notification preferences for the signed-in account."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    preferences = update_account_preferences(
+        db=db,
+        user_id=user.id,
+        digest_enabled=payload.digest_enabled,
+        digest_frequency=payload.digest_frequency,
+    )
+    db.commit()
+    return PreferenceRead.model_validate(preferences)
+
+
+@router.get("/me/subscription", response_model=SubscriptionRead)
+def get_current_account_subscription(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> SubscriptionRead:
+    """Return hosted plan entitlement and current monthly usage."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    subscription = get_account_subscription(db=db, user_id=user.id)
+    quotas = [
+        get_quota_snapshot(db=db, user_id=user.id, settings=settings, feature=feature)
+        for feature in (API_REQUESTS, LLM_REQUESTS)
+    ]
+    db.commit()
+    return SubscriptionRead(
+        tier=subscription.tier,
+        status=subscription.status,
+        paid_features_enforced=settings.paid_tier_enforced,
+        current_period_ends_at=subscription.current_period_ends_at,
+        quotas=[
+            QuotaRead(
+                period=quota.period,
+                feature=quota.feature,
+                limit=quota.limit,
+                used=quota.used,
+                remaining=quota.remaining,
+            )
+            for quota in quotas
+        ],
+    )
+
+
+@router.post("/me/subscription/checkout", response_model=SubscriptionCheckoutRead)
+def begin_current_account_checkout(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+    provider: BillingProviderDep,
+) -> SubscriptionCheckoutRead:
+    """Start provider-hosted paid-tier checkout once launch gates are enabled."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    if not settings.paid_tier_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Paid upgrades are not available until launch review is complete",
+        )
+    if provider is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Billing checkout is not configured",
+        )
+    get_account_subscription(db=db, user_id=user.id)
+    checkout = provider.create_checkout(
+        email=user.email,
+        account_reference=str(user.id),
+    )
+    db.commit()
+    return SubscriptionCheckoutRead(
+        provider=checkout.provider,
+        checkout_url=checkout.checkout_url,
+    )

--- a/backend/src/podex/api/v2/router.py
+++ b/backend/src/podex/api/v2/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from podex.api.v2 import episodes, media, podcasts, stats
+from podex.api.v2 import auth, episodes, media, podcasts, stats
 
 api_v2_router = APIRouter(tags=["v2"])
 
@@ -17,3 +17,4 @@ api_v2_router.include_router(podcasts.router)
 api_v2_router.include_router(episodes.router)
 api_v2_router.include_router(media.router)
 api_v2_router.include_router(stats.router)
+api_v2_router.include_router(auth.router)

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     debug: bool = False
     api_v2_prefix: str = "/api/v2"
     cors_origins: list[str] = ["http://localhost:4321"]
+    public_web_url: str = "http://localhost:4321"
     database_url: str = "sqlite:///./podex.db"
 
     # Rate limiting. Defaults are deliberately generous so ordinary traffic
@@ -70,6 +71,17 @@ class Settings(BaseSettings):
     smtp_password: str = ""
     smtp_from_email: str = ""
     smtp_starttls: bool = True
+
+    # Paid tier and billing. Both gates default off: ``paid_tier_enabled``
+    # controls whether checkout can begin, ``paid_tier_enforced`` controls
+    # whether personalization writes require entitlement. The checkout URL
+    # and provider name come from the deployment environment.
+    paid_tier_enabled: bool = False
+    paid_tier_enforced: bool = False
+    paid_api_requests_per_month: int = 500
+    paid_llm_requests_per_month: int = 25
+    billing_provider_name: str = ""
+    billing_checkout_url: str = ""
 
 
 @lru_cache

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -9,7 +9,9 @@ from podex.models.account_alert_rule import AccountAlertRule
 from podex.models.account_digest import AccountDigest
 from podex.models.account_followed_podcast import AccountFollowedPodcast
 from podex.models.account_preference import AccountPreference
+from podex.models.account_quota_usage import AccountQuotaUsage
 from podex.models.account_saved_media import AccountSavedMedia
+from podex.models.account_subscription import AccountSubscription
 from podex.models.account_user import AccountUser
 from podex.models.base import Base
 from podex.models.derivative_generation_run import (
@@ -61,7 +63,9 @@ __all__ = [
     "AccountDigest",
     "AccountFollowedPodcast",
     "AccountPreference",
+    "AccountQuotaUsage",
     "AccountSavedMedia",
+    "AccountSubscription",
     "AccountUser",
     "Base",
     "DerivativeGenerationRun",

--- a/backend/src/podex/models/account_quota_usage.py
+++ b/backend/src/podex/models/account_quota_usage.py
@@ -1,0 +1,32 @@
+"""Monthly per-account feature quota usage."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AccountQuotaUsage(Base):
+    """Consumed quota units for one feature in one UTC billing month."""
+
+    __tablename__ = "account_quota_usage"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "period",
+            "feature",
+            name="uq_account_quota_usage_user_period_feature",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("account_users.id"), index=True)
+    period: Mapped[str] = mapped_column(String(7), index=True)
+    feature: Mapped[str] = mapped_column(String(40))
+    units: Mapped[int] = mapped_column(default=0)
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/backend/src/podex/models/account_subscription.py
+++ b/backend/src/podex/models/account_subscription.py
@@ -1,0 +1,34 @@
+"""Hosted account subscription state."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AccountSubscription(Base):
+    """Subscription entitlement attached to one public account."""
+
+    __tablename__ = "account_subscriptions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("account_users.id"),
+        unique=True,
+        index=True,
+    )
+    tier: Mapped[str] = mapped_column(String(20), default="free")
+    status: Mapped[str] = mapped_column(String(20), default="active")
+    billing_provider: Mapped[str | None] = mapped_column(String(40))
+    provider_customer_id: Mapped[str | None] = mapped_column(String(255))
+    provider_subscription_id: Mapped[str | None] = mapped_column(String(255))
+    current_period_ends_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+    )
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/backend/src/podex/schemas/account.py
+++ b/backend/src/podex/schemas/account.py
@@ -1,0 +1,221 @@
+"""Account and authentication API schemas."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+from podex.schemas.media import MediaRead
+from podex.schemas.podcast import PodcastRead
+
+
+class AccountUserRead(BaseModel):
+    """Public representation of the signed-in account."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    email: str
+    created_at: datetime
+    last_signed_in_at: datetime | None
+
+
+class AuthMagicLinkRequest(BaseModel):
+    """Request delivery of a one-time email sign-in link."""
+
+    email: EmailStr
+    redirect_path: str | None = Field(default=None, max_length=300)
+
+
+class AuthMagicLinkRequestResponse(BaseModel):
+    """Acknowledgement that a sign-in link was accepted for delivery."""
+
+    accepted: bool = True
+
+
+class AuthMagicLinkVerifyRequest(BaseModel):
+    """Redeem a one-time sign-in token."""
+
+    token: str = Field(min_length=1, max_length=128)
+
+
+class AuthSessionRead(BaseModel):
+    """Authenticated session summary returned after verification."""
+
+    user: AccountUserRead
+    expires_at: datetime
+
+
+class AuthLogoutResponse(BaseModel):
+    """Result of revoking the current browser session."""
+
+    signed_out: bool
+
+
+class SavedMediaRead(BaseModel):
+    """A saved public media record and when it was saved."""
+
+    media: MediaRead
+    saved_at: datetime
+
+
+class SavedMediaListRead(BaseModel):
+    """Saved media collection for the current account."""
+
+    items: list[SavedMediaRead]
+    total: int
+
+
+class SavedMediaDeleteResponse(BaseModel):
+    """Result of removing a saved media record."""
+
+    deleted: bool
+
+
+class FollowedPodcastRead(BaseModel):
+    """A followed public podcast source and when it was followed."""
+
+    podcast: PodcastRead
+    followed_at: datetime
+
+
+class FollowedPodcastListRead(BaseModel):
+    """Followed podcast collection for the current account."""
+
+    items: list[FollowedPodcastRead]
+    total: int
+
+
+class FollowedPodcastDeleteResponse(BaseModel):
+    """Result of removing a followed podcast."""
+
+    deleted: bool
+
+
+class AlertRuleRead(BaseModel):
+    """Public representation of one account alert rule."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    target_type: str
+    target_id: int
+    event_type: str
+    enabled: bool
+    baseline_count: int
+    last_evaluated_at: datetime | None
+    created_at: datetime
+
+
+class AlertRuleListRead(BaseModel):
+    """Alert rule collection for the current account."""
+
+    items: list[AlertRuleRead]
+    total: int
+
+
+class AlertRuleCreateRequest(BaseModel):
+    """Create an alert rule over a linked public resource."""
+
+    target_type: Literal["media", "podcast"]
+    target_id: int
+    event_type: Literal["new_mention", "new_episode"]
+
+
+class AlertRuleUpdateRequest(BaseModel):
+    """Pause or resume an alert rule."""
+
+    enabled: bool
+
+
+class AlertRuleDeleteResponse(BaseModel):
+    """Result of removing an alert rule."""
+
+    deleted: bool
+
+
+class AlertEventRead(BaseModel):
+    """A generated alert event and its owning rule."""
+
+    rule: AlertRuleRead
+    previous_count: int
+    observed_count: int
+
+
+class AlertEvaluationRead(BaseModel):
+    """Result of evaluating the account's alert rules."""
+
+    items: list[AlertEventRead]
+    generated: int
+
+
+class DigestRead(BaseModel):
+    """Public representation of a delivered notification digest."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    channel: str
+    subject: str
+    body_text: str
+    event_count: int
+    created_at: datetime
+    delivered_at: datetime | None
+
+
+class DigestListRead(BaseModel):
+    """Delivered digest collection for the current account."""
+
+    items: list[DigestRead]
+    total: int
+
+
+class DigestSendResponse(BaseModel):
+    """Result of an on-demand digest delivery attempt."""
+
+    digest: DigestRead | None = None
+    delivered: bool
+
+
+class PreferenceRead(BaseModel):
+    """Notification preferences for the current account."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    digest_enabled: bool
+    digest_frequency: str
+    updated_at: datetime
+
+
+class PreferenceUpdateRequest(BaseModel):
+    """Update notification preferences."""
+
+    digest_enabled: bool
+    digest_frequency: Literal["immediate", "daily", "weekly"]
+
+
+class QuotaRead(BaseModel):
+    """One monthly feature quota and its current consumption."""
+
+    period: str
+    feature: str
+    limit: int
+    used: int
+    remaining: int
+
+
+class SubscriptionRead(BaseModel):
+    """Hosted plan entitlement and current monthly usage."""
+
+    tier: str
+    status: str
+    paid_features_enforced: bool
+    current_period_ends_at: datetime | None
+    quotas: list[QuotaRead]
+
+
+class SubscriptionCheckoutRead(BaseModel):
+    """External provider-hosted checkout destination."""
+
+    provider: str
+    checkout_url: str

--- a/backend/src/podex/services/account_subscriptions.py
+++ b/backend/src/podex/services/account_subscriptions.py
@@ -1,0 +1,137 @@
+"""Hosted subscription entitlement and quota policy."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from sqlalchemy.orm import Session
+
+from podex.config import Settings
+from podex.models import AccountQuotaUsage, AccountSubscription
+
+QuotaFeature = Literal["api_requests", "llm_requests"]
+API_REQUESTS: QuotaFeature = "api_requests"
+LLM_REQUESTS: QuotaFeature = "llm_requests"
+
+
+class PaidSubscriptionRequiredError(Exception):
+    """Raised when a protected paid feature is unavailable to an account."""
+
+
+class AccountQuotaExceededError(Exception):
+    """Raised when an account has consumed its monthly paid feature allocation."""
+
+
+@dataclass(frozen=True)
+class QuotaSnapshot:
+    """Current month's quota totals for personalized write actions."""
+
+    period: str
+    feature: str
+    limit: int
+    used: int
+
+    @property
+    def remaining(self) -> int:
+        """Return units remaining without exposing a negative value."""
+        return max(self.limit - self.used, 0)
+
+
+def get_account_subscription(*, db: Session, user_id: int) -> AccountSubscription:
+    """Return an account's entitlement, creating its free default when absent."""
+    subscription = (
+        db.query(AccountSubscription)
+        .filter(AccountSubscription.user_id == user_id)
+        .first()
+    )
+    if subscription is not None:
+        return subscription
+    subscription = AccountSubscription(user_id=user_id)
+    db.add(subscription)
+    db.flush()
+    return subscription
+
+
+def has_paid_access(*, subscription: AccountSubscription) -> bool:
+    """Return whether the entitlement permits paid account features."""
+    return bool(subscription.tier == "paid" and subscription.status == "active")
+
+
+def get_quota_snapshot(
+    *,
+    db: Session,
+    user_id: int,
+    settings: Settings,
+    feature: QuotaFeature,
+    now: datetime | None = None,
+) -> QuotaSnapshot:
+    """Load current usage for a monthly paid-feature allocation."""
+    period = (now or datetime.now(UTC)).strftime("%Y-%m")
+    usage = (
+        db.query(AccountQuotaUsage)
+        .filter(
+            AccountQuotaUsage.user_id == user_id,
+            AccountQuotaUsage.period == period,
+            AccountQuotaUsage.feature == feature,
+        )
+        .first()
+    )
+    return QuotaSnapshot(
+        period=period,
+        feature=feature,
+        limit=(
+            settings.paid_api_requests_per_month
+            if feature == API_REQUESTS
+            else settings.paid_llm_requests_per_month
+        ),
+        used=usage.units if usage is not None else 0,
+    )
+
+
+def consume_paid_api_request(
+    *,
+    db: Session,
+    user_id: int,
+    settings: Settings,
+    now: datetime | None = None,
+) -> QuotaSnapshot | None:
+    """Enforce paid access and record one personalized API mutation."""
+    if not settings.paid_tier_enforced:
+        return None
+    subscription = get_account_subscription(db=db, user_id=user_id)
+    if not has_paid_access(subscription=subscription):
+        raise PaidSubscriptionRequiredError
+    snapshot = get_quota_snapshot(
+        db=db,
+        user_id=user_id,
+        settings=settings,
+        feature=API_REQUESTS,
+        now=now,
+    )
+    if snapshot.used >= snapshot.limit:
+        raise AccountQuotaExceededError
+    usage = (
+        db.query(AccountQuotaUsage)
+        .filter(
+            AccountQuotaUsage.user_id == user_id,
+            AccountQuotaUsage.period == snapshot.period,
+            AccountQuotaUsage.feature == snapshot.feature,
+        )
+        .first()
+    )
+    if usage is None:
+        usage = AccountQuotaUsage(
+            user_id=user_id,
+            period=snapshot.period,
+            feature=snapshot.feature,
+            units=0,
+        )
+        db.add(usage)
+    usage.units += 1
+    db.flush()
+    return QuotaSnapshot(
+        period=snapshot.period,
+        feature=snapshot.feature,
+        limit=snapshot.limit,
+        used=snapshot.used + 1,
+    )

--- a/backend/src/podex/services/billing_checkout.py
+++ b/backend/src/podex/services/billing_checkout.py
@@ -1,0 +1,62 @@
+"""Provider boundary for hosted paid-tier checkout."""
+
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.parse import urlencode
+
+from podex.config import Settings
+
+
+@dataclass(frozen=True)
+class BillingCheckout:
+    """External checkout destination produced by a billing adapter."""
+
+    provider: str
+    checkout_url: str
+
+
+class BillingCheckoutProvider(Protocol):
+    """Boundary implemented by the eventual payment-provider adapter."""
+
+    def create_checkout(
+        self,
+        *,
+        email: str,
+        account_reference: str,
+    ) -> BillingCheckout:
+        """Create or link an external checkout session."""
+
+
+class HostedBillingCheckoutProvider:
+    """Config-backed hosted checkout bridge used until provider SDK selection."""
+
+    def __init__(self, *, provider: str, checkout_url: str) -> None:
+        self.provider = provider
+        self.checkout_url = checkout_url
+
+    def create_checkout(
+        self,
+        *,
+        email: str,
+        account_reference: str,
+    ) -> BillingCheckout:
+        """Build a hosted checkout link with non-secret account context."""
+        separator = "&" if "?" in self.checkout_url else "?"
+        query = urlencode({"prefilled_email": email, "reference": account_reference})
+        return BillingCheckout(
+            provider=self.provider,
+            checkout_url=f"{self.checkout_url}{separator}{query}",
+        )
+
+
+def build_billing_checkout_provider(
+    *,
+    settings: Settings,
+) -> BillingCheckoutProvider | None:
+    """Build the configured provider bridge only when checkout is configured."""
+    if not settings.billing_provider_name or not settings.billing_checkout_url:
+        return None
+    return HostedBillingCheckoutProvider(
+        provider=settings.billing_provider_name,
+        checkout_url=settings.billing_checkout_url,
+    )

--- a/backend/tests/test_acceptance_catalog.py
+++ b/backend/tests/test_acceptance_catalog.py
@@ -204,12 +204,19 @@ def test_not_found_responses_use_error_envelope(client: TestClient) -> None:
 
 
 def test_openapi_surface_is_read_only_get() -> None:
-    """The v2 catalog contract exposes only GET handlers (no writes yet)."""
+    """The v2 public catalog contract exposes only GET handlers.
+
+    Account endpoints (``/api/v2/auth/*`` and ``/api/v2/me*``) are the
+    authenticated write surface and are exempt from this invariant.
+    """
     schema = build_openapi_schema()
     catalog_prefix = "/api/v2/"
+    account_prefixes = ("/api/v2/auth", "/api/v2/me")
 
     for path, operations in schema["paths"].items():
         if not path.startswith(catalog_prefix):
+            continue
+        if path.startswith(account_prefixes):
             continue
         assert_that(set(operations)).is_equal_to({"get"})
 
@@ -226,6 +233,8 @@ def test_openapi_response_schemas_reference_read_dtos() -> None:
 
     for path, operations in schema["paths"].items():
         if not path.startswith("/api/v2/") or path.endswith("/status"):
+            continue
+        if path.startswith(("/api/v2/auth", "/api/v2/me")):
             continue
         success = operations["get"]["responses"]["200"]["content"]["application/json"][
             "schema"

--- a/backend/tests/test_api_auth.py
+++ b/backend/tests/test_api_auth.py
@@ -1,0 +1,271 @@
+"""Tests for passwordless v2 account authentication endpoints."""
+
+from http.cookies import SimpleCookie
+from urllib.parse import parse_qs, urlparse
+
+from assertpy import assert_that
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import Response
+from sqlalchemy.orm import Session
+
+from podex.api.v2 import auth as v2_auth_api
+from podex.models import Episode, MagicLinkToken, UserSession
+from tests.conftest import seed_catalog_graph
+
+
+class CapturingMagicLinkSender:
+    """Capture delivered sign-in links for deterministic API tests."""
+
+    def __init__(self) -> None:
+        self.deliveries: list[tuple[str, str]] = []
+
+    def send_magic_link(self, *, email: str, verification_url: str) -> None:
+        """Store an outgoing sign-in message."""
+        self.deliveries.append((email, verification_url))
+
+
+class CapturingDigestSender:
+    """Capture delivered notification digests for deterministic API tests."""
+
+    def __init__(self) -> None:
+        self.deliveries: list[tuple[str, str, str]] = []
+
+    def send_digest(self, *, email: str, subject: str, body_text: str) -> None:
+        """Store an outgoing digest message."""
+        self.deliveries.append((email, subject, body_text))
+
+
+def _sign_in(client: TestClient) -> str:
+    """Complete the magic-link flow and return the session cookie value."""
+    sender = CapturingMagicLinkSender()
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    app.dependency_overrides[v2_auth_api.get_auth_magic_link_sender] = lambda: sender
+    requested = client.post(
+        "/api/v2/auth/magic-link/request",
+        json={"email": "reader@example.com"},
+    )
+    if requested.status_code != 202:  # pragma: no cover - guard
+        raise AssertionError(requested.text)
+    token = parse_qs(urlparse(sender.deliveries[-1][1]).query)["token"][0]
+    verified = client.post("/api/v2/auth/magic-link/verify", json={"token": token})
+    if verified.status_code != 200:  # pragma: no cover - guard
+        raise AssertionError(verified.text)
+    return _extract_session_cookie(verified)
+
+
+def _extract_session_cookie(response: Response) -> str:
+    """Read the opaque session credential from a TestClient response."""
+    cookie = SimpleCookie()
+    cookie.load(response.headers["set-cookie"])
+    return cookie["podex_session"].value
+
+
+def test_magic_link_session_lifecycle_uses_hashed_credentials(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Sign-in delivery, session use, and logout revoke hashed tokens."""
+    sender = CapturingMagicLinkSender()
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    app.dependency_overrides[v2_auth_api.get_auth_magic_link_sender] = lambda: sender
+
+    requested = client.post(
+        "/api/v2/auth/magic-link/request",
+        json={"email": " Reader@Example.com ", "redirect_path": "/account/saved"},
+    )
+
+    assert_that(requested.status_code).is_equal_to(202)
+    assert_that(sender.deliveries[0][0]).is_equal_to("reader@example.com")
+    assert_that(sender.deliveries[0][1]).contains("redirect_path=%2Faccount%2Fsaved")
+    token = parse_qs(urlparse(sender.deliveries[0][1]).query)["token"][0]
+    challenge = db_session.query(MagicLinkToken).one()
+    assert_that(challenge.token_digest).is_not_equal_to(token)
+
+    verified = client.post("/api/v2/auth/magic-link/verify", json={"token": token})
+
+    assert_that(verified.status_code).is_equal_to(200)
+    assert_that(verified.json()["user"]["email"]).is_equal_to("reader@example.com")
+    assert_that(verified.headers["set-cookie"]).contains("HttpOnly", "Secure")
+    session_token = _extract_session_cookie(verified)
+    session = db_session.query(UserSession).one()
+    assert_that(session.token_digest).is_not_equal_to(session_token)
+
+    current = client.get(
+        "/api/v2/me",
+        headers={"Cookie": f"podex_session={session_token}"},
+    )
+    assert_that(current.status_code).is_equal_to(200)
+    assert_that(current.json()["email"]).is_equal_to("reader@example.com")
+
+    replay = client.post("/api/v2/auth/magic-link/verify", json={"token": token})
+    assert_that(replay.status_code).is_equal_to(401)
+
+    logout = client.post(
+        "/api/v2/auth/logout",
+        headers={"Cookie": f"podex_session={session_token}"},
+    )
+    assert_that(logout.status_code).is_equal_to(200)
+    assert_that(logout.json()["signed_out"]).is_true()
+    after = client.get(
+        "/api/v2/me",
+        headers={"Cookie": f"podex_session={session_token}"},
+    )
+    assert_that(after.status_code).is_equal_to(401)
+
+
+def test_magic_link_request_requires_configured_delivery(
+    client: TestClient,
+) -> None:
+    """Without SMTP configuration the sign-in endpoint reports 503."""
+    response = client.post(
+        "/api/v2/auth/magic-link/request",
+        json={"email": "reader@example.com"},
+    )
+    assert_that(response.status_code).is_equal_to(503)
+
+
+def test_me_requires_authentication(client: TestClient) -> None:
+    """Account endpoints reject anonymous requests."""
+    assert_that(client.get("/api/v2/me").status_code).is_equal_to(401)
+    assert_that(client.get("/api/v2/me/saves").status_code).is_equal_to(401)
+    assert_that(client.get("/api/v2/me/alerts").status_code).is_equal_to(401)
+
+
+def test_saves_and_follows_round_trip(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Saves and follows persist, list, and delete through the API."""
+    graph = seed_catalog_graph(db_session)
+    cookie = {"Cookie": f"podex_session={_sign_in(client)}"}
+
+    saved = client.put(f"/api/v2/me/saves/{graph.media_id}", headers=cookie)
+    assert_that(saved.status_code).is_equal_to(200)
+    assert_that(saved.json()["media"]["title"]).is_equal_to("Dune")
+    missing = client.put("/api/v2/me/saves/999999", headers=cookie)
+    assert_that(missing.status_code).is_equal_to(404)
+    listed = client.get("/api/v2/me/saves", headers=cookie)
+    assert_that(listed.json()["total"]).is_equal_to(1)
+    removed = client.delete(f"/api/v2/me/saves/{graph.media_id}", headers=cookie)
+    assert_that(removed.json()["deleted"]).is_true()
+
+    followed = client.put(f"/api/v2/me/follows/{graph.podcast_id}", headers=cookie)
+    assert_that(followed.status_code).is_equal_to(200)
+    assert_that(followed.json()["podcast"]["slug"]).is_equal_to("example-show")
+    follows = client.get("/api/v2/me/follows", headers=cookie)
+    assert_that(follows.json()["total"]).is_equal_to(1)
+    unfollowed = client.delete(
+        f"/api/v2/me/follows/{graph.podcast_id}",
+        headers=cookie,
+    )
+    assert_that(unfollowed.json()["deleted"]).is_true()
+
+
+def test_alert_rule_crud_and_evaluation(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Alert rules require linked targets and generate events on growth."""
+    graph = seed_catalog_graph(db_session)
+    cookie = {"Cookie": f"podex_session={_sign_in(client)}"}
+
+    unlinked = client.post(
+        "/api/v2/me/alerts",
+        json={
+            "target_type": "podcast",
+            "target_id": graph.podcast_id,
+            "event_type": "new_episode",
+        },
+        headers=cookie,
+    )
+    assert_that(unlinked.status_code).is_equal_to(400)
+
+    client.put(f"/api/v2/me/follows/{graph.podcast_id}", headers=cookie)
+    created = client.post(
+        "/api/v2/me/alerts",
+        json={
+            "target_type": "podcast",
+            "target_id": graph.podcast_id,
+            "event_type": "new_episode",
+        },
+        headers=cookie,
+    )
+    assert_that(created.status_code).is_equal_to(200)
+    rule_id = created.json()["id"]
+
+    db_session.add(
+        Episode(podcast_id=graph.podcast_id, title="Pilot II", episode_number=2),
+    )
+    db_session.commit()
+    evaluated = client.post("/api/v2/me/alerts/evaluate", headers=cookie)
+    assert_that(evaluated.json()["generated"]).is_equal_to(1)
+
+    paused = client.patch(
+        f"/api/v2/me/alerts/{rule_id}",
+        json={"enabled": False},
+        headers=cookie,
+    )
+    assert_that(paused.json()["enabled"]).is_false()
+    assert_that(
+        client.patch(
+            "/api/v2/me/alerts/999999",
+            json={"enabled": True},
+            headers=cookie,
+        ).status_code,
+    ).is_equal_to(404)
+    deleted = client.delete(f"/api/v2/me/alerts/{rule_id}", headers=cookie)
+    assert_that(deleted.json()["deleted"]).is_true()
+    rules = client.get("/api/v2/me/alerts", headers=cookie)
+    assert_that(rules.json()["total"]).is_equal_to(0)
+
+
+def test_digest_send_and_preferences(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Digest delivery honors preferences and lists delivered digests."""
+    graph = seed_catalog_graph(db_session)
+    cookie = {"Cookie": f"podex_session={_sign_in(client)}"}
+    digest_sender = CapturingDigestSender()
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    app.dependency_overrides[v2_auth_api.get_digest_sender] = lambda: digest_sender
+    client.put(f"/api/v2/me/follows/{graph.podcast_id}", headers=cookie)
+    client.post(
+        "/api/v2/me/alerts",
+        json={
+            "target_type": "podcast",
+            "target_id": graph.podcast_id,
+            "event_type": "new_episode",
+        },
+        headers=cookie,
+    )
+    db_session.add(
+        Episode(podcast_id=graph.podcast_id, title="Pilot II", episode_number=2),
+    )
+    db_session.commit()
+
+    sent = client.post("/api/v2/me/digests/send", headers=cookie)
+    assert_that(sent.status_code).is_equal_to(200)
+    assert_that(sent.json()["delivered"]).is_true()
+    assert_that(digest_sender.deliveries).is_length(1)
+    listed = client.get("/api/v2/me/digests", headers=cookie)
+    assert_that(listed.json()["total"]).is_equal_to(1)
+
+    prefs = client.get("/api/v2/me/preferences", headers=cookie)
+    assert_that(prefs.json()["digest_enabled"]).is_true()
+    updated = client.patch(
+        "/api/v2/me/preferences",
+        json={"digest_enabled": False, "digest_frequency": "weekly"},
+        headers=cookie,
+    )
+    assert_that(updated.json()["digest_frequency"]).is_equal_to("weekly")
+
+    disabled = client.post("/api/v2/me/digests/send", headers=cookie)
+    assert_that(disabled.json()["delivered"]).is_false()

--- a/backend/tests/test_billing_subscriptions.py
+++ b/backend/tests/test_billing_subscriptions.py
@@ -1,0 +1,184 @@
+"""Tests for subscription entitlement, quotas, and checkout endpoints."""
+
+from datetime import UTC, datetime
+
+import pytest
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.config import Settings
+from podex.models import AccountSubscription, AccountUser
+from podex.services.account_subscriptions import (
+    API_REQUESTS,
+    AccountQuotaExceededError,
+    PaidSubscriptionRequiredError,
+    consume_paid_api_request,
+    get_account_subscription,
+    get_quota_snapshot,
+    has_paid_access,
+)
+from podex.services.billing_checkout import (
+    BillingCheckout,
+    HostedBillingCheckoutProvider,
+    build_billing_checkout_provider,
+)
+from tests.test_api_auth import _sign_in
+
+_NOW = datetime(2026, 7, 19, tzinfo=UTC)
+
+
+def _create_user(db_session: Session) -> AccountUser:
+    user = AccountUser(email="reader@example.com")
+    db_session.add(user)
+    db_session.flush()
+    return user
+
+
+def test_subscription_defaults_to_free(db_session: Session) -> None:
+    """First entitlement lookup creates an active free subscription."""
+    user = _create_user(db_session)
+
+    subscription = get_account_subscription(db=db_session, user_id=user.id)
+    db_session.commit()
+
+    assert_that(subscription.tier).is_equal_to("free")
+    assert_that(subscription.status).is_equal_to("active")
+    assert_that(has_paid_access(subscription=subscription)).is_false()
+    again = get_account_subscription(db=db_session, user_id=user.id)
+    assert_that(again.id).is_equal_to(subscription.id)
+
+
+def test_consume_paid_api_request_enforcement(db_session: Session) -> None:
+    """Enforcement requires paid entitlement and honors monthly limits."""
+    user = _create_user(db_session)
+    relaxed = Settings(paid_tier_enforced=False)
+    assert_that(
+        consume_paid_api_request(db=db_session, user_id=user.id, settings=relaxed),
+    ).is_none()
+
+    enforced = Settings(paid_tier_enforced=True, paid_api_requests_per_month=2)
+    with pytest.raises(PaidSubscriptionRequiredError):
+        consume_paid_api_request(db=db_session, user_id=user.id, settings=enforced)
+
+    subscription = get_account_subscription(db=db_session, user_id=user.id)
+    subscription.tier = "paid"
+    db_session.flush()
+
+    first = consume_paid_api_request(
+        db=db_session,
+        user_id=user.id,
+        settings=enforced,
+        now=_NOW,
+    )
+    second = consume_paid_api_request(
+        db=db_session,
+        user_id=user.id,
+        settings=enforced,
+        now=_NOW,
+    )
+    db_session.commit()
+
+    assert_that(first).is_not_none()
+    if first is None or second is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(first.used).is_equal_to(1)
+    assert_that(second.used).is_equal_to(2)
+    assert_that(second.remaining).is_equal_to(0)
+    with pytest.raises(AccountQuotaExceededError):
+        consume_paid_api_request(
+            db=db_session,
+            user_id=user.id,
+            settings=enforced,
+            now=_NOW,
+        )
+    snapshot = get_quota_snapshot(
+        db=db_session,
+        user_id=user.id,
+        settings=enforced,
+        feature=API_REQUESTS,
+        now=_NOW,
+    )
+    assert_that(snapshot.used).is_equal_to(2)
+
+
+def test_checkout_provider_builds_prefilled_url() -> None:
+    """The hosted bridge appends non-secret context to the checkout URL."""
+    assert_that(build_billing_checkout_provider(settings=Settings())).is_none()
+    provider = build_billing_checkout_provider(
+        settings=Settings(
+            billing_provider_name="hosted-test",
+            billing_checkout_url="https://billing.example/upgrade",
+        ),
+    )
+    assert_that(provider).is_instance_of(HostedBillingCheckoutProvider)
+    if provider is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+
+    checkout = provider.create_checkout(
+        email="reader@example.com",
+        account_reference="7",
+    )
+
+    assert_that(checkout).is_instance_of(BillingCheckout)
+    assert_that(checkout.provider).is_equal_to("hosted-test")
+    assert_that(checkout.checkout_url).contains(
+        "prefilled_email=reader%40example.com",
+        "reference=7",
+    )
+
+
+def test_subscription_endpoint_reports_quotas(client: TestClient) -> None:
+    """The subscription endpoint returns tier and both feature quotas."""
+    cookie = {"Cookie": f"podex_session={_sign_in(client)}"}
+
+    response = client.get("/api/v2/me/subscription", headers=cookie)
+
+    assert_that(response.status_code).is_equal_to(200)
+    body = response.json()
+    assert_that(body["tier"]).is_equal_to("free")
+    assert_that(body["paid_features_enforced"]).is_false()
+    features = {quota["feature"] for quota in body["quotas"]}
+    assert_that(features).is_equal_to({"api_requests", "llm_requests"})
+
+
+def test_checkout_endpoint_requires_launch_gate(client: TestClient) -> None:
+    """Checkout stays unavailable until the paid tier launch gate opens."""
+    cookie = {"Cookie": f"podex_session={_sign_in(client)}"}
+
+    response = client.post("/api/v2/me/subscription/checkout", headers=cookie)
+
+    assert_that(response.status_code).is_equal_to(503)
+
+
+def test_paid_enforcement_blocks_personalization_writes(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """With enforcement on, free accounts get 402 and paid accounts proceed."""
+    from tests.conftest import seed_catalog_graph
+
+    graph = seed_catalog_graph(db_session)
+    cookie = {"Cookie": f"podex_session={_sign_in(client)}"}
+    app = client.app
+    from fastapi import FastAPI
+
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    from podex.api.deps import get_app_settings
+
+    app.dependency_overrides[get_app_settings] = lambda: Settings(
+        paid_tier_enforced=True,
+    )
+
+    blocked = client.put(f"/api/v2/me/saves/{graph.media_id}", headers=cookie)
+    assert_that(blocked.status_code).is_equal_to(402)
+
+    user = db_session.query(AccountUser).one()
+    subscription = get_account_subscription(db=db_session, user_id=user.id)
+    subscription.tier = "paid"
+    db_session.commit()
+    assert_that(db_session.query(AccountSubscription).one().tier).is_equal_to("paid")
+
+    allowed = client.put(f"/api/v2/me/saves/{graph.media_id}", headers=cookie)
+    assert_that(allowed.status_code).is_equal_to(200)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -533,12 +533,34 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -1226,6 +1248,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "cryptography" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "feedparser" },
     { name = "httpx" },
@@ -1258,6 +1281,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "boto3", specifier = ">=1.43.14" },
     { name = "cryptography", specifier = ">=48.0.0" },
+    { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "feedparser", specifier = ">=6.0" },
     { name = "httpx", specifier = ">=0.28" },

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1,6 +1,317 @@
 {
   "components": {
     "schemas": {
+      "AccountUserRead": {
+        "description": "Public representation of the signed-in account.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_signed_in_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Signed In At"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "created_at",
+          "last_signed_in_at"
+        ],
+        "title": "AccountUserRead",
+        "type": "object"
+      },
+      "AlertEvaluationRead": {
+        "description": "Result of evaluating the account's alert rules.",
+        "properties": {
+          "generated": {
+            "title": "Generated",
+            "type": "integer"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AlertEventRead"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items",
+          "generated"
+        ],
+        "title": "AlertEvaluationRead",
+        "type": "object"
+      },
+      "AlertEventRead": {
+        "description": "A generated alert event and its owning rule.",
+        "properties": {
+          "observed_count": {
+            "title": "Observed Count",
+            "type": "integer"
+          },
+          "previous_count": {
+            "title": "Previous Count",
+            "type": "integer"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/AlertRuleRead"
+          }
+        },
+        "required": [
+          "rule",
+          "previous_count",
+          "observed_count"
+        ],
+        "title": "AlertEventRead",
+        "type": "object"
+      },
+      "AlertRuleCreateRequest": {
+        "description": "Create an alert rule over a linked public resource.",
+        "properties": {
+          "event_type": {
+            "enum": [
+              "new_mention",
+              "new_episode"
+            ],
+            "title": "Event Type",
+            "type": "string"
+          },
+          "target_id": {
+            "title": "Target Id",
+            "type": "integer"
+          },
+          "target_type": {
+            "enum": [
+              "media",
+              "podcast"
+            ],
+            "title": "Target Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_type",
+          "target_id",
+          "event_type"
+        ],
+        "title": "AlertRuleCreateRequest",
+        "type": "object"
+      },
+      "AlertRuleDeleteResponse": {
+        "description": "Result of removing an alert rule.",
+        "properties": {
+          "deleted": {
+            "title": "Deleted",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "title": "AlertRuleDeleteResponse",
+        "type": "object"
+      },
+      "AlertRuleListRead": {
+        "description": "Alert rule collection for the current account.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AlertRuleRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "AlertRuleListRead",
+        "type": "object"
+      },
+      "AlertRuleRead": {
+        "description": "Public representation of one account alert rule.",
+        "properties": {
+          "baseline_count": {
+            "title": "Baseline Count",
+            "type": "integer"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "event_type": {
+            "title": "Event Type",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_evaluated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Evaluated At"
+          },
+          "target_id": {
+            "title": "Target Id",
+            "type": "integer"
+          },
+          "target_type": {
+            "title": "Target Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "target_type",
+          "target_id",
+          "event_type",
+          "enabled",
+          "baseline_count",
+          "last_evaluated_at",
+          "created_at"
+        ],
+        "title": "AlertRuleRead",
+        "type": "object"
+      },
+      "AlertRuleUpdateRequest": {
+        "description": "Pause or resume an alert rule.",
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "title": "AlertRuleUpdateRequest",
+        "type": "object"
+      },
+      "AuthLogoutResponse": {
+        "description": "Result of revoking the current browser session.",
+        "properties": {
+          "signed_out": {
+            "title": "Signed Out",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "signed_out"
+        ],
+        "title": "AuthLogoutResponse",
+        "type": "object"
+      },
+      "AuthMagicLinkRequest": {
+        "description": "Request delivery of a one-time email sign-in link.",
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "redirect_path": {
+            "anyOf": [
+              {
+                "maxLength": 300,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Redirect Path"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "title": "AuthMagicLinkRequest",
+        "type": "object"
+      },
+      "AuthMagicLinkRequestResponse": {
+        "description": "Acknowledgement that a sign-in link was accepted for delivery.",
+        "properties": {
+          "accepted": {
+            "default": true,
+            "title": "Accepted",
+            "type": "boolean"
+          }
+        },
+        "title": "AuthMagicLinkRequestResponse",
+        "type": "object"
+      },
+      "AuthMagicLinkVerifyRequest": {
+        "description": "Redeem a one-time sign-in token.",
+        "properties": {
+          "token": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "title": "AuthMagicLinkVerifyRequest",
+        "type": "object"
+      },
+      "AuthSessionRead": {
+        "description": "Authenticated session summary returned after verification.",
+        "properties": {
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/AccountUserRead"
+          }
+        },
+        "required": [
+          "user",
+          "expires_at"
+        ],
+        "title": "AuthSessionRead",
+        "type": "object"
+      },
       "CatalogStats": {
         "description": "Top-level catalog counters plus a small top-list breakdown.\n\nAttributes:\n    podcasts: Total podcast sources in the catalog.\n    episodes: Total episodes across all sources.\n    media: Total canonical media items in the catalog. Counts every\n        ``Media`` row, not just those referenced by a mention.\n    mentions: Total episode<->media mention links.\n    top_media_types: Up to five media types ordered by descending count,\n        with ties broken alphabetically by type name for stability.",
         "properties": {
@@ -43,6 +354,105 @@
           "top_media_types"
         ],
         "title": "CatalogStats",
+        "type": "object"
+      },
+      "DigestListRead": {
+        "description": "Delivered digest collection for the current account.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/DigestRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "DigestListRead",
+        "type": "object"
+      },
+      "DigestRead": {
+        "description": "Public representation of a delivered notification digest.",
+        "properties": {
+          "body_text": {
+            "title": "Body Text",
+            "type": "string"
+          },
+          "channel": {
+            "title": "Channel",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "delivered_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delivered At"
+          },
+          "event_count": {
+            "title": "Event Count",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "subject": {
+            "title": "Subject",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "channel",
+          "subject",
+          "body_text",
+          "event_count",
+          "created_at",
+          "delivered_at"
+        ],
+        "title": "DigestRead",
+        "type": "object"
+      },
+      "DigestSendResponse": {
+        "description": "Result of an on-demand digest delivery attempt.",
+        "properties": {
+          "delivered": {
+            "title": "Delivered",
+            "type": "boolean"
+          },
+          "digest": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DigestRead"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "delivered"
+        ],
+        "title": "DigestSendResponse",
         "type": "object"
       },
       "EpisodeRead": {
@@ -112,6 +522,61 @@
           "podcast_public_id"
         ],
         "title": "EpisodeRead",
+        "type": "object"
+      },
+      "FollowedPodcastDeleteResponse": {
+        "description": "Result of removing a followed podcast.",
+        "properties": {
+          "deleted": {
+            "title": "Deleted",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "title": "FollowedPodcastDeleteResponse",
+        "type": "object"
+      },
+      "FollowedPodcastListRead": {
+        "description": "Followed podcast collection for the current account.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FollowedPodcastRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "FollowedPodcastListRead",
+        "type": "object"
+      },
+      "FollowedPodcastRead": {
+        "description": "A followed public podcast source and when it was followed.",
+        "properties": {
+          "followed_at": {
+            "format": "date-time",
+            "title": "Followed At",
+            "type": "string"
+          },
+          "podcast": {
+            "$ref": "#/components/schemas/PodcastRead"
+          }
+        },
+        "required": [
+          "podcast",
+          "followed_at"
+        ],
+        "title": "FollowedPodcastRead",
         "type": "object"
       },
       "HTTPValidationError": {
@@ -521,6 +986,208 @@
         "title": "PodcastRead",
         "type": "object"
       },
+      "PreferenceRead": {
+        "description": "Notification preferences for the current account.",
+        "properties": {
+          "digest_enabled": {
+            "title": "Digest Enabled",
+            "type": "boolean"
+          },
+          "digest_frequency": {
+            "title": "Digest Frequency",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "digest_enabled",
+          "digest_frequency",
+          "updated_at"
+        ],
+        "title": "PreferenceRead",
+        "type": "object"
+      },
+      "PreferenceUpdateRequest": {
+        "description": "Update notification preferences.",
+        "properties": {
+          "digest_enabled": {
+            "title": "Digest Enabled",
+            "type": "boolean"
+          },
+          "digest_frequency": {
+            "enum": [
+              "immediate",
+              "daily",
+              "weekly"
+            ],
+            "title": "Digest Frequency",
+            "type": "string"
+          }
+        },
+        "required": [
+          "digest_enabled",
+          "digest_frequency"
+        ],
+        "title": "PreferenceUpdateRequest",
+        "type": "object"
+      },
+      "QuotaRead": {
+        "description": "One monthly feature quota and its current consumption.",
+        "properties": {
+          "feature": {
+            "title": "Feature",
+            "type": "string"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "period": {
+            "title": "Period",
+            "type": "string"
+          },
+          "remaining": {
+            "title": "Remaining",
+            "type": "integer"
+          },
+          "used": {
+            "title": "Used",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "period",
+          "feature",
+          "limit",
+          "used",
+          "remaining"
+        ],
+        "title": "QuotaRead",
+        "type": "object"
+      },
+      "SavedMediaDeleteResponse": {
+        "description": "Result of removing a saved media record.",
+        "properties": {
+          "deleted": {
+            "title": "Deleted",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "title": "SavedMediaDeleteResponse",
+        "type": "object"
+      },
+      "SavedMediaListRead": {
+        "description": "Saved media collection for the current account.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SavedMediaRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "SavedMediaListRead",
+        "type": "object"
+      },
+      "SavedMediaRead": {
+        "description": "A saved public media record and when it was saved.",
+        "properties": {
+          "media": {
+            "$ref": "#/components/schemas/MediaRead"
+          },
+          "saved_at": {
+            "format": "date-time",
+            "title": "Saved At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "media",
+          "saved_at"
+        ],
+        "title": "SavedMediaRead",
+        "type": "object"
+      },
+      "SubscriptionCheckoutRead": {
+        "description": "External provider-hosted checkout destination.",
+        "properties": {
+          "checkout_url": {
+            "title": "Checkout Url",
+            "type": "string"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "checkout_url"
+        ],
+        "title": "SubscriptionCheckoutRead",
+        "type": "object"
+      },
+      "SubscriptionRead": {
+        "description": "Hosted plan entitlement and current monthly usage.",
+        "properties": {
+          "current_period_ends_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Period Ends At"
+          },
+          "paid_features_enforced": {
+            "title": "Paid Features Enforced",
+            "type": "boolean"
+          },
+          "quotas": {
+            "items": {
+              "$ref": "#/components/schemas/QuotaRead"
+            },
+            "title": "Quotas",
+            "type": "array"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "tier": {
+            "title": "Tier",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tier",
+          "status",
+          "paid_features_enforced",
+          "current_period_ends_at",
+          "quotas"
+        ],
+        "title": "SubscriptionRead",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "ctx": {
@@ -569,6 +1236,115 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v2/auth/logout": {
+      "post": {
+        "description": "Revoke the current account session and expire its browser cookie.",
+        "operationId": "logout_account_session_api_v2_auth_logout_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthLogoutResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Logout Account Session",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/auth/magic-link/request": {
+      "post": {
+        "description": "Request delivery of a short-lived, single-use email sign-in link.",
+        "operationId": "request_auth_magic_link_api_v2_auth_magic_link_request_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthMagicLinkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthMagicLinkRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Request Auth Magic Link",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/auth/magic-link/verify": {
+      "post": {
+        "description": "Verify a one-time link token and begin an authenticated session.",
+        "operationId": "verify_auth_magic_link_api_v2_auth_magic_link_verify_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthMagicLinkVerifyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthSessionRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Verify Auth Magic Link",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
     "/api/v2/episodes": {
       "get": {
         "description": "List episodes, optionally filtered by podcast, paginated.",
@@ -759,6 +1535,586 @@
         "tags": [
           "v2",
           "episodes"
+        ]
+      }
+    },
+    "/api/v2/me": {
+      "get": {
+        "description": "Return the account represented by the current browser session.",
+        "operationId": "get_current_account_api_v2_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountUserRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Current Account",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/alerts": {
+      "get": {
+        "description": "List alert rules belonging to the authenticated account.",
+        "operationId": "list_account_alert_rules_api_v2_me_alerts_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleListRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Account Alert Rules",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      },
+      "post": {
+        "description": "Create an alert rule for a saved media or followed podcast resource.",
+        "operationId": "create_account_alert_rule_api_v2_me_alerts_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlertRuleCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Account Alert Rule",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/alerts/evaluate": {
+      "post": {
+        "description": "Evaluate alert rules and generate events for new published activity.",
+        "operationId": "evaluate_account_alert_rules_api_v2_me_alerts_evaluate_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertEvaluationRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Evaluate Account Alert Rules",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/alerts/{rule_id}": {
+      "delete": {
+        "description": "Remove an alert rule belonging to the authenticated account.",
+        "operationId": "delete_account_alert_rule_api_v2_me_alerts__rule_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "title": "Rule Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Account Alert Rule",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      },
+      "patch": {
+        "description": "Pause or resume an account alert rule.",
+        "operationId": "update_account_alert_rule_api_v2_me_alerts__rule_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "title": "Rule Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlertRuleUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Account Alert Rule",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/digests": {
+      "get": {
+        "description": "List delivered notification digests for the current account.",
+        "operationId": "list_current_account_digests_api_v2_me_digests_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DigestListRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Current Account Digests",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/digests/send": {
+      "post": {
+        "description": "Evaluate alert rules and deliver pending activity by email.",
+        "operationId": "send_current_account_digest_api_v2_me_digests_send_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DigestSendResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Send Current Account Digest",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/follows": {
+      "get": {
+        "description": "List followed public podcast sources for the current account.",
+        "operationId": "list_account_followed_podcasts_api_v2_me_follows_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FollowedPodcastListRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Account Followed Podcasts",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/follows/{podcast_id}": {
+      "delete": {
+        "description": "Remove a public podcast source from the current account's follows.",
+        "operationId": "delete_account_followed_podcast_api_v2_me_follows__podcast_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "podcast_id",
+            "required": true,
+            "schema": {
+              "title": "Podcast Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FollowedPodcastDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Account Followed Podcast",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      },
+      "put": {
+        "description": "Idempotently follow a public podcast source.",
+        "operationId": "put_account_followed_podcast_api_v2_me_follows__podcast_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "podcast_id",
+            "required": true,
+            "schema": {
+              "title": "Podcast Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FollowedPodcastRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Account Followed Podcast",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/preferences": {
+      "get": {
+        "description": "Return persisted notification preferences for the signed-in account.",
+        "operationId": "get_current_account_preferences_api_v2_me_preferences_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreferenceRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Current Account Preferences",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      },
+      "patch": {
+        "description": "Update notification preferences for the signed-in account.",
+        "operationId": "update_current_account_preferences_api_v2_me_preferences_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreferenceUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreferenceRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Current Account Preferences",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/saves": {
+      "get": {
+        "description": "List saved public catalog media for the current account.",
+        "operationId": "list_account_saved_media_api_v2_me_saves_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SavedMediaListRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Account Saved Media",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/saves/{media_id}": {
+      "delete": {
+        "description": "Remove a public catalog media record from the current account's saves.",
+        "operationId": "delete_account_saved_media_api_v2_me_saves__media_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "media_id",
+            "required": true,
+            "schema": {
+              "title": "Media Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SavedMediaDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Account Saved Media",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      },
+      "put": {
+        "description": "Idempotently save a public catalog media record.",
+        "operationId": "put_account_saved_media_api_v2_me_saves__media_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "media_id",
+            "required": true,
+            "schema": {
+              "title": "Media Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SavedMediaRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Account Saved Media",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/subscription": {
+      "get": {
+        "description": "Return hosted plan entitlement and current monthly usage.",
+        "operationId": "get_current_account_subscription_api_v2_me_subscription_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Current Account Subscription",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/subscription/checkout": {
+      "post": {
+        "description": "Start provider-hosted paid-tier checkout once launch gates are enabled.",
+        "operationId": "begin_current_account_checkout_api_v2_me_subscription_checkout_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionCheckoutRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Begin Current Account Checkout",
+        "tags": [
+          "v2",
+          "auth"
         ]
       }
     },

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -4,6 +4,66 @@
  */
 
 export interface paths {
+    "/api/v2/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Logout Account Session
+         * @description Revoke the current account session and expire its browser cookie.
+         */
+        post: operations["logout_account_session_api_v2_auth_logout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/auth/magic-link/request": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request Auth Magic Link
+         * @description Request delivery of a short-lived, single-use email sign-in link.
+         */
+        post: operations["request_auth_magic_link_api_v2_auth_magic_link_request_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/auth/magic-link/verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Verify Auth Magic Link
+         * @description Verify a one-time link token and begin an authenticated session.
+         */
+        post: operations["verify_auth_magic_link_api_v2_auth_magic_link_verify_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/episodes": {
         parameters: {
             query?: never;
@@ -58,6 +118,286 @@ export interface paths {
         get: operations["list_episode_mentions_api_v2_episodes__episode_id__mentions_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Current Account
+         * @description Return the account represented by the current browser session.
+         */
+        get: operations["get_current_account_api_v2_me_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Account Alert Rules
+         * @description List alert rules belonging to the authenticated account.
+         */
+        get: operations["list_account_alert_rules_api_v2_me_alerts_get"];
+        put?: never;
+        /**
+         * Create Account Alert Rule
+         * @description Create an alert rule for a saved media or followed podcast resource.
+         */
+        post: operations["create_account_alert_rule_api_v2_me_alerts_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/alerts/evaluate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Evaluate Account Alert Rules
+         * @description Evaluate alert rules and generate events for new published activity.
+         */
+        post: operations["evaluate_account_alert_rules_api_v2_me_alerts_evaluate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/alerts/{rule_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Account Alert Rule
+         * @description Remove an alert rule belonging to the authenticated account.
+         */
+        delete: operations["delete_account_alert_rule_api_v2_me_alerts__rule_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Account Alert Rule
+         * @description Pause or resume an account alert rule.
+         */
+        patch: operations["update_account_alert_rule_api_v2_me_alerts__rule_id__patch"];
+        trace?: never;
+    };
+    "/api/v2/me/digests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Current Account Digests
+         * @description List delivered notification digests for the current account.
+         */
+        get: operations["list_current_account_digests_api_v2_me_digests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/digests/send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Send Current Account Digest
+         * @description Evaluate alert rules and deliver pending activity by email.
+         */
+        post: operations["send_current_account_digest_api_v2_me_digests_send_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/follows": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Account Followed Podcasts
+         * @description List followed public podcast sources for the current account.
+         */
+        get: operations["list_account_followed_podcasts_api_v2_me_follows_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/follows/{podcast_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Put Account Followed Podcast
+         * @description Idempotently follow a public podcast source.
+         */
+        put: operations["put_account_followed_podcast_api_v2_me_follows__podcast_id__put"];
+        post?: never;
+        /**
+         * Delete Account Followed Podcast
+         * @description Remove a public podcast source from the current account's follows.
+         */
+        delete: operations["delete_account_followed_podcast_api_v2_me_follows__podcast_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Current Account Preferences
+         * @description Return persisted notification preferences for the signed-in account.
+         */
+        get: operations["get_current_account_preferences_api_v2_me_preferences_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Current Account Preferences
+         * @description Update notification preferences for the signed-in account.
+         */
+        patch: operations["update_current_account_preferences_api_v2_me_preferences_patch"];
+        trace?: never;
+    };
+    "/api/v2/me/saves": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Account Saved Media
+         * @description List saved public catalog media for the current account.
+         */
+        get: operations["list_account_saved_media_api_v2_me_saves_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/saves/{media_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Put Account Saved Media
+         * @description Idempotently save a public catalog media record.
+         */
+        put: operations["put_account_saved_media_api_v2_me_saves__media_id__put"];
+        post?: never;
+        /**
+         * Delete Account Saved Media
+         * @description Remove a public catalog media record from the current account's saves.
+         */
+        delete: operations["delete_account_saved_media_api_v2_me_saves__media_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/subscription": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Current Account Subscription
+         * @description Return hosted plan entitlement and current monthly usage.
+         */
+        get: operations["get_current_account_subscription_api_v2_me_subscription_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/subscription/checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Begin Current Account Checkout
+         * @description Start provider-hosted paid-tier checkout once launch gates are enabled.
+         */
+        post: operations["begin_current_account_checkout_api_v2_me_subscription_checkout_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -234,6 +574,165 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         /**
+         * AccountUserRead
+         * @description Public representation of the signed-in account.
+         */
+        AccountUserRead: {
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Email */
+            email: string;
+            /** Id */
+            id: number;
+            /** Last Signed In At */
+            last_signed_in_at: string | null;
+        };
+        /**
+         * AlertEvaluationRead
+         * @description Result of evaluating the account's alert rules.
+         */
+        AlertEvaluationRead: {
+            /** Generated */
+            generated: number;
+            /** Items */
+            items: components["schemas"]["AlertEventRead"][];
+        };
+        /**
+         * AlertEventRead
+         * @description A generated alert event and its owning rule.
+         */
+        AlertEventRead: {
+            /** Observed Count */
+            observed_count: number;
+            /** Previous Count */
+            previous_count: number;
+            rule: components["schemas"]["AlertRuleRead"];
+        };
+        /**
+         * AlertRuleCreateRequest
+         * @description Create an alert rule over a linked public resource.
+         */
+        AlertRuleCreateRequest: {
+            /**
+             * Event Type
+             * @enum {string}
+             */
+            event_type: "new_mention" | "new_episode";
+            /** Target Id */
+            target_id: number;
+            /**
+             * Target Type
+             * @enum {string}
+             */
+            target_type: "media" | "podcast";
+        };
+        /**
+         * AlertRuleDeleteResponse
+         * @description Result of removing an alert rule.
+         */
+        AlertRuleDeleteResponse: {
+            /** Deleted */
+            deleted: boolean;
+        };
+        /**
+         * AlertRuleListRead
+         * @description Alert rule collection for the current account.
+         */
+        AlertRuleListRead: {
+            /** Items */
+            items: components["schemas"]["AlertRuleRead"][];
+            /** Total */
+            total: number;
+        };
+        /**
+         * AlertRuleRead
+         * @description Public representation of one account alert rule.
+         */
+        AlertRuleRead: {
+            /** Baseline Count */
+            baseline_count: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Enabled */
+            enabled: boolean;
+            /** Event Type */
+            event_type: string;
+            /** Id */
+            id: number;
+            /** Last Evaluated At */
+            last_evaluated_at: string | null;
+            /** Target Id */
+            target_id: number;
+            /** Target Type */
+            target_type: string;
+        };
+        /**
+         * AlertRuleUpdateRequest
+         * @description Pause or resume an alert rule.
+         */
+        AlertRuleUpdateRequest: {
+            /** Enabled */
+            enabled: boolean;
+        };
+        /**
+         * AuthLogoutResponse
+         * @description Result of revoking the current browser session.
+         */
+        AuthLogoutResponse: {
+            /** Signed Out */
+            signed_out: boolean;
+        };
+        /**
+         * AuthMagicLinkRequest
+         * @description Request delivery of a one-time email sign-in link.
+         */
+        AuthMagicLinkRequest: {
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+            /** Redirect Path */
+            redirect_path?: string | null;
+        };
+        /**
+         * AuthMagicLinkRequestResponse
+         * @description Acknowledgement that a sign-in link was accepted for delivery.
+         */
+        AuthMagicLinkRequestResponse: {
+            /**
+             * Accepted
+             * @default true
+             */
+            accepted: boolean;
+        };
+        /**
+         * AuthMagicLinkVerifyRequest
+         * @description Redeem a one-time sign-in token.
+         */
+        AuthMagicLinkVerifyRequest: {
+            /** Token */
+            token: string;
+        };
+        /**
+         * AuthSessionRead
+         * @description Authenticated session summary returned after verification.
+         */
+        AuthSessionRead: {
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+            user: components["schemas"]["AccountUserRead"];
+        };
+        /**
          * CatalogStats
          * @description Top-level catalog counters plus a small top-list breakdown.
          *
@@ -265,6 +764,48 @@ export interface components {
             top_media_types: components["schemas"]["MediaTypeCount"][];
         };
         /**
+         * DigestListRead
+         * @description Delivered digest collection for the current account.
+         */
+        DigestListRead: {
+            /** Items */
+            items: components["schemas"]["DigestRead"][];
+            /** Total */
+            total: number;
+        };
+        /**
+         * DigestRead
+         * @description Public representation of a delivered notification digest.
+         */
+        DigestRead: {
+            /** Body Text */
+            body_text: string;
+            /** Channel */
+            channel: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Delivered At */
+            delivered_at: string | null;
+            /** Event Count */
+            event_count: number;
+            /** Id */
+            id: number;
+            /** Subject */
+            subject: string;
+        };
+        /**
+         * DigestSendResponse
+         * @description Result of an on-demand digest delivery attempt.
+         */
+        DigestSendResponse: {
+            /** Delivered */
+            delivered: boolean;
+            digest?: components["schemas"]["DigestRead"] | null;
+        };
+        /**
          * EpisodeRead
          * @description Public representation of a podcast episode.
          */
@@ -294,6 +835,36 @@ export interface components {
             published_at: string | null;
             /** Title */
             title: string;
+        };
+        /**
+         * FollowedPodcastDeleteResponse
+         * @description Result of removing a followed podcast.
+         */
+        FollowedPodcastDeleteResponse: {
+            /** Deleted */
+            deleted: boolean;
+        };
+        /**
+         * FollowedPodcastListRead
+         * @description Followed podcast collection for the current account.
+         */
+        FollowedPodcastListRead: {
+            /** Items */
+            items: components["schemas"]["FollowedPodcastRead"][];
+            /** Total */
+            total: number;
+        };
+        /**
+         * FollowedPodcastRead
+         * @description A followed public podcast source and when it was followed.
+         */
+        FollowedPodcastRead: {
+            /**
+             * Followed At
+             * Format: date-time
+             */
+            followed_at: string;
+            podcast: components["schemas"]["PodcastRead"];
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -457,6 +1028,106 @@ export interface components {
             /** Slug */
             slug: string;
         };
+        /**
+         * PreferenceRead
+         * @description Notification preferences for the current account.
+         */
+        PreferenceRead: {
+            /** Digest Enabled */
+            digest_enabled: boolean;
+            /** Digest Frequency */
+            digest_frequency: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /**
+         * PreferenceUpdateRequest
+         * @description Update notification preferences.
+         */
+        PreferenceUpdateRequest: {
+            /** Digest Enabled */
+            digest_enabled: boolean;
+            /**
+             * Digest Frequency
+             * @enum {string}
+             */
+            digest_frequency: "immediate" | "daily" | "weekly";
+        };
+        /**
+         * QuotaRead
+         * @description One monthly feature quota and its current consumption.
+         */
+        QuotaRead: {
+            /** Feature */
+            feature: string;
+            /** Limit */
+            limit: number;
+            /** Period */
+            period: string;
+            /** Remaining */
+            remaining: number;
+            /** Used */
+            used: number;
+        };
+        /**
+         * SavedMediaDeleteResponse
+         * @description Result of removing a saved media record.
+         */
+        SavedMediaDeleteResponse: {
+            /** Deleted */
+            deleted: boolean;
+        };
+        /**
+         * SavedMediaListRead
+         * @description Saved media collection for the current account.
+         */
+        SavedMediaListRead: {
+            /** Items */
+            items: components["schemas"]["SavedMediaRead"][];
+            /** Total */
+            total: number;
+        };
+        /**
+         * SavedMediaRead
+         * @description A saved public media record and when it was saved.
+         */
+        SavedMediaRead: {
+            media: components["schemas"]["MediaRead"];
+            /**
+             * Saved At
+             * Format: date-time
+             */
+            saved_at: string;
+        };
+        /**
+         * SubscriptionCheckoutRead
+         * @description External provider-hosted checkout destination.
+         */
+        SubscriptionCheckoutRead: {
+            /** Checkout Url */
+            checkout_url: string;
+            /** Provider */
+            provider: string;
+        };
+        /**
+         * SubscriptionRead
+         * @description Hosted plan entitlement and current monthly usage.
+         */
+        SubscriptionRead: {
+            /** Current Period Ends At */
+            current_period_ends_at: string | null;
+            /** Paid Features Enforced */
+            paid_features_enforced: boolean;
+            /** Quotas */
+            quotas: components["schemas"]["QuotaRead"][];
+            /** Status */
+            status: string;
+            /** Tier */
+            tier: string;
+        };
         /** ValidationError */
         ValidationError: {
             /** Context */
@@ -479,6 +1150,92 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    logout_account_session_api_v2_auth_logout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthLogoutResponse"];
+                };
+            };
+        };
+    };
+    request_auth_magic_link_api_v2_auth_magic_link_request_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthMagicLinkRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthMagicLinkRequestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    verify_auth_magic_link_api_v2_auth_magic_link_verify_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthMagicLinkVerifyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthSessionRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_episodes_api_v2_episodes_get: {
         parameters: {
             query?: {
@@ -577,6 +1334,462 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_current_account_api_v2_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountUserRead"];
+                };
+            };
+        };
+    };
+    list_account_alert_rules_api_v2_me_alerts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertRuleListRead"];
+                };
+            };
+        };
+    };
+    create_account_alert_rule_api_v2_me_alerts_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AlertRuleCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertRuleRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    evaluate_account_alert_rules_api_v2_me_alerts_evaluate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertEvaluationRead"];
+                };
+            };
+        };
+    };
+    delete_account_alert_rule_api_v2_me_alerts__rule_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                rule_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertRuleDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_account_alert_rule_api_v2_me_alerts__rule_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                rule_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AlertRuleUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertRuleRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_current_account_digests_api_v2_me_digests_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DigestListRead"];
+                };
+            };
+        };
+    };
+    send_current_account_digest_api_v2_me_digests_send_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DigestSendResponse"];
+                };
+            };
+        };
+    };
+    list_account_followed_podcasts_api_v2_me_follows_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FollowedPodcastListRead"];
+                };
+            };
+        };
+    };
+    put_account_followed_podcast_api_v2_me_follows__podcast_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                podcast_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FollowedPodcastRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_account_followed_podcast_api_v2_me_follows__podcast_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                podcast_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FollowedPodcastDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_current_account_preferences_api_v2_me_preferences_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PreferenceRead"];
+                };
+            };
+        };
+    };
+    update_current_account_preferences_api_v2_me_preferences_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PreferenceUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PreferenceRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_account_saved_media_api_v2_me_saves_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedMediaListRead"];
+                };
+            };
+        };
+    };
+    put_account_saved_media_api_v2_me_saves__media_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                media_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedMediaRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_account_saved_media_api_v2_me_saves__media_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                media_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedMediaDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_current_account_subscription_api_v2_me_subscription_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionRead"];
+                };
+            };
+        };
+    };
+    begin_current_account_checkout_api_v2_me_subscription_checkout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionCheckoutRead"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Completes the accounts and billing themes of the #108 split stack by exposing the account vertical over `/api/v2`. Builds on the models and services from #277 and #279: passwordless sign-in, saves/follows/alerts/digests/preferences endpoints, and subscription entitlement with monthly quotas and a hosted checkout bridge behind launch gates that default off.

## Type

- [x] `feat` — New feature

## Changes Made

- Add `/api/v2/auth/magic-link/request|verify` and `/auth/logout` with secure http-only session cookies; tokens only ever stored as SHA-256 digests
- Add `/api/v2/me` plus saves, follows, alert rules (CRUD + evaluate), digests (list + on-demand send), and preferences endpoints, all delegating to the existing account services
- Add `AccountSubscription` and `AccountQuotaUsage` models with migration `0014_add_billing_models`; free-tier default entitlement, monthly per-feature quota snapshots, and `consume_paid_api_request` enforcement (402 without entitlement, 429 over quota) wired into personalization writes — enforcement and checkout are both gated off by default (`paid_tier_enforced` / `paid_tier_enabled`)
- Add `billing_checkout` provider boundary with a config-backed hosted checkout bridge (no payment SDK yet); `/me/subscription` and `/me/subscription/checkout` endpoints
- Add account API schemas; restrict the read-only OpenAPI acceptance invariant to the public catalog surface; regenerate `frontend/openapi.json`
- Add API and billing test suites (12 tests): session lifecycle with hashed credentials, 401/503 paths, CRUD round-trips, evaluation, digest delivery, quota enforcement, and checkout gating

## Closes

- Closes #75
- Closes #76
- Closes #77
- Closes #78
- Closes #79
- Closes #30
- Closes #106
- Relates to #108

## Testing

- [x] Added endpoint and billing test suites
- [x] Full backend suite passes with coverage ≥85% (86.07%)
- [x] Migration replay + schema-drift guard passes
- [x] Committed OpenAPI artifact regenerated and verified against the app

## Quality Checks

- [x] `lintro chk` (ruff, mypy, bandit, pydoclint) clean — health 100/100
- [x] `ruff format` applied

## Checklist

- [x] Code follows repo conventions
- [x] No provider accounts, real hostnames, or secrets; billing/paid gates default off (#108 boundary)