### PR TITLE
feat(ops): add audit log, podcast management, and guarded ops API

### DIFF
--- a/backend/alembic/versions/0015_add_audit_log_and_cover_url.py
+++ b/backend/alembic/versions/0015_add_audit_log_and_cover_url.py
@@ -1,0 +1,58 @@
+"""Add audit log and podcast cover url.
+
+Revision ID: 0015
+Revises: 0013
+Create Date: 2026-07-19 00:59:25.071943
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0015"
+down_revision: str | None = "0013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("resource_type", sa.String(length=64), nullable=False),
+        sa.Column("resource_id", sa.Integer(), nullable=True),
+        sa.Column("resource_identifier", sa.String(length=120), nullable=True),
+        sa.Column("actor_name", sa.String(length=100), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_audit_logs_action"), "audit_logs", ["action"], unique=False
+    )
+    op.create_index(
+        op.f("ix_audit_logs_resource_id"), "audit_logs", ["resource_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_audit_logs_resource_type"),
+        "audit_logs",
+        ["resource_type"],
+        unique=False,
+    )
+    op.add_column(
+        "podcasts", sa.Column("cover_url", sa.String(length=500), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    op.drop_column("podcasts", "cover_url")
+    op.drop_index(op.f("ix_audit_logs_resource_type"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_resource_id"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_action"), table_name="audit_logs")
+    op.drop_table("audit_logs")

--- a/backend/alembic/versions/0015_add_audit_log_and_cover_url.py
+++ b/backend/alembic/versions/0015_add_audit_log_and_cover_url.py
@@ -1,7 +1,7 @@
 """Add audit log and podcast cover url.
 
 Revision ID: 0015
-Revises: 0013
+Revises: 0014
 Create Date: 2026-07-19 00:59:25.071943
 """
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
 
 revision: str = "0015"
-down_revision: str | None = "0013"
+down_revision: str | None = "0014"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/podex/api/v2/ops.py
+++ b/backend/src/podex/api/v2/ops.py
@@ -1,0 +1,475 @@
+"""Ops console endpoints for operators.
+
+The whole surface is disabled until ``PODEX_OPS_API_KEY`` is configured;
+requests must present the key in the ``X-Ops-Key`` header. Mutations are
+recorded in the immutable audit log.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from sqlalchemy.exc import IntegrityError
+
+from podex.api.deps import AppSettings, DbSession
+from podex.models import AuditAction, PodcastStatus
+from podex.schemas.ops import (
+    OpsAuditLogEntryRead,
+    OpsAuditLogListRead,
+    OpsMetricsRead,
+    OpsPipelineActivityRead,
+    OpsPodcastCreateRequest,
+    OpsPodcastListRead,
+    OpsPodcastRead,
+    OpsPodcastSortField,
+    OpsPodcastUpdateRequest,
+    OpsRetentionPreviewRead,
+    OpsSortOrder,
+    OpsTranscriptPurgeRead,
+    OpsTranscriptRetentionRead,
+    PodcastSourceType,
+)
+from podex.services.audit_log import list_audit_logs, record_audit_log
+from podex.services.ops_metrics import get_operational_metrics
+from podex.services.ops_podcast_commands import (
+    CreateOpsPodcastInputData,
+    OpsPodcastSourceInputData,
+    UpdateOpsPodcastInputData,
+    archive_ops_podcast,
+    create_ops_podcast,
+    update_ops_podcast,
+)
+from podex.services.ops_podcast_queries import get_ops_podcast_by_id, list_ops_podcasts
+from podex.services.ops_retention_commands import (
+    OpsTranscriptRetentionPreviewData,
+    apply_ops_transcript_retention,
+    list_ops_transcript_retention,
+    preview_ops_transcript_retention,
+    purge_ops_transcript,
+)
+from podex.services.pipeline_queries import list_recent_ingestion_runs
+from podex.services.transcript_artifacts import build_transcript_artifact_store
+from podex.services.transcript_retention import TranscriptRetentionPolicy
+
+router = APIRouter(prefix="/ops", tags=["ops"])
+
+
+def _require_ops_access(*, request: Request, settings: AppSettings) -> None:
+    """Reject the request unless the configured ops key is presented."""
+    if not settings.ops_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Ops console is not configured",
+        )
+    if request.headers.get("X-Ops-Key") != settings.ops_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Ops authentication required",
+        )
+
+
+def _to_retention_preview_read(
+    *,
+    preview: OpsTranscriptRetentionPreviewData,
+) -> OpsRetentionPreviewRead:
+    """Convert a retention preview service payload to its API schema."""
+    return OpsRetentionPreviewRead(
+        transcript=OpsTranscriptRetentionRead.model_validate(preview.transcript),
+        decision={
+            "tier": preview.decision.tier.value,
+            "purge_eligible": preview.decision.purge_eligible,
+            "purge_blockers": [
+                blocker.value for blocker in preview.decision.purge_blockers
+            ],
+            "retention_suppressed": preview.decision.retention_suppressed,
+            "age_days": preview.decision.age.days,
+        },
+        extraction_confidence=preview.extraction_confidence,
+        derivative_coverage_ready=preview.derivative_coverage_ready,
+        missing_query_classes=list(preview.missing_query_classes),
+    )
+
+
+def get_ops_metrics(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsMetricsRead:
+    """Return operational dashboard metrics."""
+    _require_ops_access(request=request, settings=settings)
+    metrics = get_operational_metrics(db=db)
+    db.commit()
+    return OpsMetricsRead.model_validate(metrics, from_attributes=True)
+
+
+def list_ops_podcasts_endpoint(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+    page: Annotated[int, Query(ge=1)] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100)] = 25,
+    status_filter: Annotated[
+        PodcastStatus | None,
+        Query(alias="status"),
+    ] = None,
+    source: PodcastSourceType | None = None,
+    sort: OpsPodcastSortField = "created_at",
+    order: OpsSortOrder = "desc",
+) -> OpsPodcastListRead:
+    """List managed podcasts with filters and count sorting."""
+    _require_ops_access(request=request, settings=settings)
+    listed = list_ops_podcasts(
+        db=db,
+        page=page,
+        per_page=per_page,
+        status=status_filter,
+        source=source,
+        sort=sort,
+        order=order,
+    )
+    db.commit()
+    return OpsPodcastListRead.model_validate(listed, from_attributes=True)
+
+
+def create_ops_podcast_endpoint(
+    payload: OpsPodcastCreateRequest,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsPodcastRead:
+    """Create a managed podcast and record the action."""
+    _require_ops_access(request=request, settings=settings)
+    try:
+        created = create_ops_podcast(
+            db=db,
+            payload=CreateOpsPodcastInputData(
+                name=payload.name,
+                slug=payload.slug,
+                status=payload.status,
+                description=payload.description,
+                cover_url=payload.cover_url,
+                discovery_source=payload.discovery_source,
+                sources=OpsPodcastSourceInputData(
+                    **payload.sources.model_dump(),
+                ),
+            ),
+        )
+    except IntegrityError as error:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Podcast slug already exists",
+        ) from error
+    record_audit_log(
+        db=db,
+        action=AuditAction.CREATE_PODCAST,
+        resource_type="podcast",
+        resource_id=created.id,
+        resource_identifier=created.slug,
+        summary=f"Created podcast {created.slug}",
+    )
+    db.commit()
+    return OpsPodcastRead.model_validate(created, from_attributes=True)
+
+
+def update_ops_podcast_endpoint(
+    podcast_id: int,
+    payload: OpsPodcastUpdateRequest,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsPodcastRead:
+    """Partially update a managed podcast and record the action."""
+    _require_ops_access(request=request, settings=settings)
+    provided = frozenset(payload.model_dump(exclude_unset=True)) - {"sources"}
+    source_fields = (
+        frozenset(payload.sources.model_dump(exclude_unset=True))
+        if payload.sources is not None
+        else frozenset()
+    )
+    try:
+        updated = update_ops_podcast(
+            db=db,
+            podcast_id=podcast_id,
+            payload=UpdateOpsPodcastInputData(
+                provided_fields=provided,
+                source_fields=source_fields,
+                name=payload.name,
+                slug=payload.slug,
+                status=payload.status,
+                description=payload.description,
+                cover_url=payload.cover_url,
+                discovery_source=payload.discovery_source,
+                sources=(
+                    OpsPodcastSourceInputData(**payload.sources.model_dump())
+                    if payload.sources is not None
+                    else None
+                ),
+            ),
+        )
+    except ValueError as error:
+        db.rollback()
+        raise HTTPException(status_code=422, detail=str(error)) from error
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Podcast not found")
+    record_audit_log(
+        db=db,
+        action=AuditAction.UPDATE_PODCAST,
+        resource_type="podcast",
+        resource_id=updated.id,
+        resource_identifier=updated.slug,
+        summary=f"Updated podcast {updated.slug}",
+        metadata_json={"fields": sorted(provided | source_fields)},
+    )
+    db.commit()
+    return OpsPodcastRead.model_validate(updated, from_attributes=True)
+
+
+def archive_ops_podcast_endpoint(
+    podcast_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsPodcastRead:
+    """Pause a managed podcast and record the action."""
+    _require_ops_access(request=request, settings=settings)
+    archived = archive_ops_podcast(db=db, podcast_id=podcast_id)
+    if archived is None:
+        raise HTTPException(status_code=404, detail="Podcast not found")
+    record_audit_log(
+        db=db,
+        action=AuditAction.ARCHIVE_PODCAST,
+        resource_type="podcast",
+        resource_id=archived.id,
+        resource_identifier=archived.slug,
+        summary=f"Archived podcast {archived.slug}",
+    )
+    db.commit()
+    return OpsPodcastRead.model_validate(archived, from_attributes=True)
+
+
+def get_ops_podcast_endpoint(
+    podcast_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsPodcastRead:
+    """Return one managed podcast summary."""
+    _require_ops_access(request=request, settings=settings)
+    podcast = get_ops_podcast_by_id(db=db, podcast_id=podcast_id)
+    if podcast is None:
+        raise HTTPException(status_code=404, detail="Podcast not found")
+    db.commit()
+    return OpsPodcastRead.model_validate(podcast, from_attributes=True)
+
+
+def get_ops_pipelines(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> OpsPipelineActivityRead:
+    """Return recent ingestion run activity."""
+    _require_ops_access(request=request, settings=settings)
+    runs = list_recent_ingestion_runs(db=db, limit=limit)
+    db.commit()
+    return OpsPipelineActivityRead.model_validate(
+        {"runs": runs},
+        from_attributes=True,
+    )
+
+
+def list_ops_retention(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+    limit: Annotated[int, Query(ge=1, le=200)] = 40,
+) -> list[OpsTranscriptRetentionRead]:
+    """List recent transcript assets for retention review."""
+    _require_ops_access(request=request, settings=settings)
+    listed = list_ops_transcript_retention(db=db, limit=limit)
+    db.commit()
+    return [
+        OpsTranscriptRetentionRead.model_validate(item, from_attributes=True)
+        for item in listed
+    ]
+
+
+def preview_ops_retention(
+    transcript_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsRetentionPreviewRead:
+    """Dry-run the retention policy for one transcript."""
+    _require_ops_access(request=request, settings=settings)
+    preview = preview_ops_transcript_retention(
+        db=db,
+        transcript_id=transcript_id,
+        policy=TranscriptRetentionPolicy(),
+    )
+    if preview is None:
+        raise HTTPException(status_code=404, detail="Transcript not found")
+    db.commit()
+    return _to_retention_preview_read(preview=preview)
+
+
+def apply_ops_retention(
+    transcript_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsRetentionPreviewRead:
+    """Persist a retention evaluation and record the action."""
+    _require_ops_access(request=request, settings=settings)
+    applied = apply_ops_transcript_retention(
+        db=db,
+        transcript_id=transcript_id,
+        policy=TranscriptRetentionPolicy(),
+    )
+    if applied is None:
+        raise HTTPException(status_code=404, detail="Transcript not found")
+    record_audit_log(
+        db=db,
+        action=AuditAction.EVALUATE_TRANSCRIPT_RETENTION,
+        resource_type="transcript",
+        resource_id=transcript_id,
+        summary=f"Evaluated retention for transcript {transcript_id}",
+        metadata_json={"tier": applied.transcript.tier},
+    )
+    db.commit()
+    return _to_retention_preview_read(preview=applied)
+
+
+def purge_ops_transcript_endpoint(
+    transcript_id: int,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsTranscriptPurgeRead:
+    """Purge an eligible transcript and record the action."""
+    _require_ops_access(request=request, settings=settings)
+    try:
+        purged = purge_ops_transcript(
+            db=db,
+            transcript_id=transcript_id,
+            artifact_store=build_transcript_artifact_store(settings=settings),
+        )
+    except ValueError as error:
+        db.rollback()
+        raise HTTPException(status_code=409, detail=str(error)) from error
+    if purged is None:
+        raise HTTPException(status_code=404, detail="Transcript not found")
+    record_audit_log(
+        db=db,
+        action=AuditAction.PURGE_TRANSCRIPT,
+        resource_type="transcript",
+        resource_id=transcript_id,
+        summary=f"Purged transcript {transcript_id}",
+        metadata_json={"digest_id": purged.digest.id},
+    )
+    db.commit()
+    return OpsTranscriptPurgeRead(
+        transcript=OpsTranscriptRetentionRead.model_validate(
+            purged.transcript,
+            from_attributes=True,
+        ),
+        digest_id=purged.digest.id,
+    )
+
+
+def get_ops_audit_log(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+    page: Annotated[int, Query(ge=1)] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100)] = 25,
+    resource_type: str | None = None,
+) -> OpsAuditLogListRead:
+    """List immutable audit records, newest first."""
+    _require_ops_access(request=request, settings=settings)
+    listed = list_audit_logs(
+        db=db,
+        page=page,
+        per_page=per_page,
+        resource_type=resource_type,
+    )
+    db.commit()
+    return OpsAuditLogListRead(
+        items=[
+            OpsAuditLogEntryRead.model_validate(item, from_attributes=True)
+            for item in listed.items
+        ],
+        total=listed.total,
+        page=listed.page,
+        per_page=listed.per_page,
+    )
+
+
+router.add_api_route("/metrics", get_ops_metrics, methods=["GET"])
+router.add_api_route(
+    "/podcasts",
+    list_ops_podcasts_endpoint,
+    methods=["GET"],
+    response_model=OpsPodcastListRead,
+)
+router.add_api_route(
+    "/podcasts",
+    create_ops_podcast_endpoint,
+    methods=["POST"],
+    response_model=OpsPodcastRead,
+    status_code=status.HTTP_201_CREATED,
+)
+router.add_api_route(
+    "/podcasts/{podcast_id}",
+    get_ops_podcast_endpoint,
+    methods=["GET"],
+    response_model=OpsPodcastRead,
+)
+router.add_api_route(
+    "/podcasts/{podcast_id}",
+    update_ops_podcast_endpoint,
+    methods=["PATCH"],
+    response_model=OpsPodcastRead,
+)
+router.add_api_route(
+    "/podcasts/{podcast_id}/archive",
+    archive_ops_podcast_endpoint,
+    methods=["POST"],
+    response_model=OpsPodcastRead,
+)
+router.add_api_route(
+    "/pipelines",
+    get_ops_pipelines,
+    methods=["GET"],
+    response_model=OpsPipelineActivityRead,
+)
+router.add_api_route(
+    "/retention",
+    list_ops_retention,
+    methods=["GET"],
+    response_model=list[OpsTranscriptRetentionRead],
+)
+router.add_api_route(
+    "/retention/{transcript_id}/preview",
+    preview_ops_retention,
+    methods=["GET"],
+    response_model=OpsRetentionPreviewRead,
+)
+router.add_api_route(
+    "/retention/{transcript_id}/apply",
+    apply_ops_retention,
+    methods=["POST"],
+    response_model=OpsRetentionPreviewRead,
+)
+router.add_api_route(
+    "/retention/{transcript_id}/purge",
+    purge_ops_transcript_endpoint,
+    methods=["POST"],
+    response_model=OpsTranscriptPurgeRead,
+)
+router.add_api_route(
+    "/audit-log",
+    get_ops_audit_log,
+    methods=["GET"],
+    response_model=OpsAuditLogListRead,
+)

--- a/backend/src/podex/api/v2/router.py
+++ b/backend/src/podex/api/v2/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from podex.api.v2 import auth, episodes, media, podcasts, stats
+from podex.api.v2 import auth, episodes, media, ops, podcasts, stats
 
 api_v2_router = APIRouter(tags=["v2"])
 
@@ -18,3 +18,4 @@ api_v2_router.include_router(episodes.router)
 api_v2_router.include_router(media.router)
 api_v2_router.include_router(stats.router)
 api_v2_router.include_router(auth.router)
+api_v2_router.include_router(ops.router)

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -83,6 +83,11 @@ class Settings(BaseSettings):
     billing_provider_name: str = ""
     billing_checkout_url: str = ""
 
+    # Ops console API. The ops surface stays disabled until a key is
+    # configured by the deployment environment; requests must present it in
+    # the X-Ops-Key header.
+    ops_api_key: str = ""
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -13,6 +13,7 @@ from podex.models.account_quota_usage import AccountQuotaUsage
 from podex.models.account_saved_media import AccountSavedMedia
 from podex.models.account_subscription import AccountSubscription
 from podex.models.account_user import AccountUser
+from podex.models.audit_log import AuditAction, AuditLog
 from podex.models.base import Base
 from podex.models.derivative_generation_run import (
     DerivativeGenerationRun,
@@ -67,6 +68,8 @@ __all__ = [
     "AccountSavedMedia",
     "AccountSubscription",
     "AccountUser",
+    "AuditAction",
+    "AuditLog",
     "Base",
     "DerivativeGenerationRun",
     "DerivativeGenerationRunStatus",

--- a/backend/src/podex/models/audit_log.py
+++ b/backend/src/podex/models/audit_log.py
@@ -1,0 +1,56 @@
+"""Audit log model."""
+
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from typing import Any
+
+from sqlalchemy import JSON, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class AuditAction(StrEnum):
+    """Privileged actions that are recorded in the audit log."""
+
+    APPROVE_REVIEW_ITEM = auto()
+    ARCHIVE_PODCAST = auto()
+    CREATE_PODCAST = auto()
+    EVALUATE_TRANSCRIPT_RETENTION = auto()
+    ADD_MEDIA_ALIAS = auto()
+    MERGE_MEDIA = auto()
+    MERGE_REVIEW_ITEM = auto()
+    RECLASSIFY_REVIEW_ITEM = auto()
+    REJECT_REVIEW_ITEM = auto()
+    REINDEX_SEARCH = auto()
+    PURGE_TRANSCRIPT = auto()
+    REACQUIRE_TRANSCRIPT = auto()
+    SUBMIT_TAKEDOWN_REQUEST = auto()
+    SPLIT_MEDIA = auto()
+    SPLIT_REVIEW_ITEM = auto()
+    RERUN_EPISODE = auto()
+    RUN_PIPELINE = auto()
+    UPDATE_MEDIA = auto()
+    UPDATE_PODCAST = auto()
+    UPDATE_SEARCH_TUNING = auto()
+    UPDATE_SETTINGS = auto()
+    UPDATE_RETENTION_SAMPLING = auto()
+    UPDATE_TRANSCRIPT_RETENTION_POLICY = auto()
+    DECIDE_TAKEDOWN_REQUEST = auto()
+    UPSERT_MEDIA_EXTERNAL_REF = auto()
+
+
+class AuditLog(Base):
+    """Immutable audit record for privileged and content-affecting actions."""
+
+    __tablename__ = "audit_logs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    action: Mapped[str] = mapped_column(String(64), index=True)
+    resource_type: Mapped[str] = mapped_column(String(64), index=True)
+    resource_id: Mapped[int | None] = mapped_column(index=True)
+    resource_identifier: Mapped[str | None] = mapped_column(String(120))
+    actor_name: Mapped[str | None] = mapped_column(String(100))
+    summary: Mapped[str] = mapped_column(Text)
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))

--- a/backend/src/podex/models/podcast.py
+++ b/backend/src/podex/models/podcast.py
@@ -32,6 +32,7 @@ class Podcast(Base):
     name: Mapped[str] = mapped_column(String(255), index=True)
     slug: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     description: Mapped[str | None] = mapped_column(String(2000), default=None)
+    cover_url: Mapped[str | None] = mapped_column(String(500), default=None)
     status: Mapped[PodcastStatus] = mapped_column(
         SAEnum(PodcastStatus, native_enum=False, length=20),
         default=PodcastStatus.WATCHLIST,

--- a/backend/src/podex/schemas/ops.py
+++ b/backend/src/podex/schemas/ops.py
@@ -1,0 +1,232 @@
+"""Ops console API schemas."""
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from podex.models import PodcastStatus
+from podex.services.ops_podcast_queries import PodcastSourceType
+
+
+class OpsPodcastSourcesRead(BaseModel):
+    """Source identifiers associated with a managed podcast."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    rss_url: str | None
+    spotify_id: str | None
+    apple_id: str | None
+    youtube_channel_id: str | None
+    podscripts_slug: str | None
+
+
+class OpsPodcastRead(BaseModel):
+    """Podcast summary for ops catalog management views."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    slug: str
+    status: PodcastStatus
+    description: str | None
+    cover_url: str | None
+    created_at: datetime
+    discovery_source: str | None
+    episode_count: int
+    mention_count: int
+    sources: OpsPodcastSourcesRead
+
+
+class OpsPodcastListRead(BaseModel):
+    """Paginated podcast management payload."""
+
+    items: list[OpsPodcastRead]
+    total: int
+    page: int
+    per_page: int
+
+
+class OpsPodcastSourcesInput(BaseModel):
+    """Source identifiers accepted on podcast mutations."""
+
+    rss_url: str | None = Field(default=None, max_length=500)
+    spotify_id: str | None = Field(default=None, max_length=50)
+    apple_id: str | None = Field(default=None, max_length=50)
+    youtube_channel_id: str | None = Field(default=None, max_length=30)
+    podscripts_slug: str | None = Field(default=None, max_length=100)
+
+
+class OpsPodcastCreateRequest(BaseModel):
+    """Create a managed podcast."""
+
+    name: str = Field(min_length=1, max_length=255)
+    slug: str = Field(min_length=1, max_length=255)
+    status: PodcastStatus = PodcastStatus.WATCHLIST
+    description: str | None = Field(default=None, max_length=2000)
+    cover_url: str | None = Field(default=None, max_length=500)
+    discovery_source: str | None = None
+    sources: OpsPodcastSourcesInput = OpsPodcastSourcesInput()
+
+
+class OpsPodcastUpdateRequest(BaseModel):
+    """Partially update a managed podcast; only provided fields change."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    slug: str | None = Field(default=None, min_length=1, max_length=255)
+    status: PodcastStatus | None = None
+    description: str | None = None
+    cover_url: str | None = None
+    discovery_source: str | None = None
+    sources: OpsPodcastSourcesInput | None = None
+
+
+class OpsIngestionRunRead(BaseModel):
+    """Ingestion run summary for pipeline views."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    status: str
+    error_summary: str | None
+    started_at: datetime | None
+    completed_at: datetime | None
+    created_at: datetime
+    duration_seconds: int | None
+
+
+class OpsPipelineActivityRead(BaseModel):
+    """Recent pipeline activity."""
+
+    runs: list[OpsIngestionRunRead]
+
+
+class OpsReviewThroughputRead(BaseModel):
+    """Review decision activity and outstanding pressure."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    pending_items: int
+    decisions_last_24h: int
+    median_decision_minutes_last_24h: float | None
+
+
+class OpsAlertDeliveryRead(BaseModel):
+    """Generated and delivered account notification health."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    generated_events_last_24h: int
+    delivered_digests_last_24h: int
+    delivered_events_last_24h: int
+    pending_events: int
+
+
+class OpsMetricsRead(BaseModel):
+    """Combined operational metrics for the ops dashboard."""
+
+    measured_at: datetime
+    review: OpsReviewThroughputRead
+    alerts: OpsAlertDeliveryRead
+
+
+class OpsTranscriptRetentionRead(BaseModel):
+    """Operator-facing state for one raw transcript asset."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    episode_id: int
+    episode_title: str
+    podcast_name: str
+    provider: str
+    fetched_at: datetime | None
+    tier: str
+    policy_version: str | None
+    retention_exempt_sample: bool
+    source_retention_opt_out: bool
+    purge_eligible_at: datetime | None
+    purged_at: datetime | None
+    has_raw_payload: bool
+    has_stored_artifact: bool
+    digest_id: int | None
+
+
+class OpsRetentionDecisionRead(BaseModel):
+    """Lifecycle decision produced by a retention evaluation."""
+
+    tier: str
+    purge_eligible: bool
+    purge_blockers: list[str]
+    retention_suppressed: bool
+    age_days: int
+
+
+class OpsRetentionPreviewRead(BaseModel):
+    """Dry-run lifecycle result plus derivative safety gate."""
+
+    transcript: OpsTranscriptRetentionRead
+    decision: OpsRetentionDecisionRead
+    extraction_confidence: float | None
+    derivative_coverage_ready: bool
+    missing_query_classes: list[str]
+
+
+class OpsTranscriptPurgeRead(BaseModel):
+    """Result of an operator-approved transcript purge."""
+
+    transcript: OpsTranscriptRetentionRead
+    digest_id: int
+
+
+class OpsAuditLogEntryRead(BaseModel):
+    """One immutable audit record."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    action: str
+    resource_type: str
+    resource_id: int | None
+    resource_identifier: str | None
+    actor_name: str | None
+    summary: str
+    metadata_json: dict[str, Any] | None
+    created_at: datetime
+
+
+class OpsAuditLogListRead(BaseModel):
+    """Paginated audit log payload."""
+
+    items: list[OpsAuditLogEntryRead]
+    total: int
+    page: int
+    per_page: int
+
+
+OpsPodcastSortField = Literal["created_at", "name", "episode_count", "mention_count"]
+OpsSortOrder = Literal["asc", "desc"]
+
+__all__ = [
+    "OpsAuditLogEntryRead",
+    "OpsAuditLogListRead",
+    "OpsAlertDeliveryRead",
+    "OpsIngestionRunRead",
+    "OpsMetricsRead",
+    "OpsPipelineActivityRead",
+    "OpsPodcastCreateRequest",
+    "OpsPodcastListRead",
+    "OpsPodcastRead",
+    "OpsPodcastSortField",
+    "OpsPodcastSourcesInput",
+    "OpsPodcastSourcesRead",
+    "OpsPodcastUpdateRequest",
+    "OpsRetentionDecisionRead",
+    "OpsRetentionPreviewRead",
+    "OpsReviewThroughputRead",
+    "OpsSortOrder",
+    "OpsTranscriptPurgeRead",
+    "OpsTranscriptRetentionRead",
+    "PodcastSourceType",
+]

--- a/backend/src/podex/services/audit_log.py
+++ b/backend/src/podex/services/audit_log.py
@@ -1,0 +1,139 @@
+"""Shared audit log services for ops and admin surfaces."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from podex.models import AuditAction, AuditLog
+
+
+@dataclass(frozen=True, slots=True)
+class AuditLogEntryData:
+    """Audit log entry exposed to shared services and API layers."""
+
+    id: int
+    action: AuditAction
+    resource_type: str
+    resource_id: int | None
+    resource_identifier: str | None
+    actor_name: str | None
+    summary: str
+    metadata_json: dict[str, Any] | None
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class AuditLogListData:
+    """Paginated audit log payload."""
+
+    items: list[AuditLogEntryData]
+    total: int
+    page: int
+    per_page: int
+
+
+def _to_audit_log_entry_data(*, entry: AuditLog) -> AuditLogEntryData:
+    """Convert a persisted audit log entry into shared data.
+
+    Args:
+        entry: Persisted audit log row.
+
+    Returns:
+        Shared audit log payload.
+    """
+    return AuditLogEntryData(
+        id=entry.id,
+        action=AuditAction(entry.action),
+        resource_type=entry.resource_type,
+        resource_id=entry.resource_id,
+        resource_identifier=entry.resource_identifier,
+        actor_name=entry.actor_name,
+        summary=entry.summary,
+        metadata_json=entry.metadata_json,
+        created_at=entry.created_at,
+    )
+
+
+def record_audit_log(
+    *,
+    db: Session,
+    action: AuditAction,
+    resource_type: str,
+    summary: str,
+    resource_id: int | None = None,
+    resource_identifier: str | None = None,
+    actor_name: str | None = None,
+    metadata_json: dict[str, Any] | None = None,
+) -> AuditLogEntryData:
+    """Persist an audit log entry for a privileged or content-affecting action.
+
+    Args:
+        db: Database session.
+        action: Audit action enum.
+        resource_type: Resource type that was affected.
+        summary: Human-readable action summary.
+        resource_id: Optional internal resource identifier.
+        resource_identifier: Optional non-numeric resource identifier.
+        actor_name: Optional actor name.
+        metadata_json: Optional structured metadata.
+
+    Returns:
+        Persisted audit log entry data.
+    """
+    entry = AuditLog(
+        action=action.value,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        resource_identifier=resource_identifier,
+        actor_name=actor_name,
+        summary=summary,
+        metadata_json=metadata_json,
+    )
+    db.add(entry)
+    db.flush()
+    return _to_audit_log_entry_data(entry=entry)
+
+
+def list_audit_logs(
+    *,
+    db: Session,
+    page: int,
+    per_page: int,
+    action: AuditAction | None = None,
+    resource_type: str | None = None,
+) -> AuditLogListData:
+    """List audit log entries for ops and admin views.
+
+    Args:
+        db: Database session.
+        page: Requested page number.
+        per_page: Number of entries per page.
+        action: Optional audit action filter.
+        resource_type: Optional resource type filter.
+
+    Returns:
+        Paginated audit log payload ordered by recency.
+    """
+    query = db.query(AuditLog)
+
+    if action is not None:
+        query = query.filter(AuditLog.action == action.value)
+    if resource_type is not None:
+        query = query.filter(AuditLog.resource_type == resource_type)
+
+    total = query.count()
+    entries = (
+        query.order_by(AuditLog.created_at.desc(), AuditLog.id.desc())
+        .offset((page - 1) * per_page)
+        .limit(per_page)
+        .all()
+    )
+
+    return AuditLogListData(
+        items=[_to_audit_log_entry_data(entry=entry) for entry in entries],
+        total=total,
+        page=page,
+        per_page=per_page,
+    )

--- a/backend/src/podex/services/ops_metrics.py
+++ b/backend/src/podex/services/ops_metrics.py
@@ -1,0 +1,97 @@
+"""Operational health metrics for the private dashboard."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from statistics import median
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    AccountAlertEvent,
+    AccountDigest,
+    ReviewItem,
+    ReviewItemStatus,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewThroughputData:
+    """Review decision activity and outstanding pressure."""
+
+    pending_items: int
+    decisions_last_24h: int
+    median_decision_minutes_last_24h: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class AlertDeliveryData:
+    """Generated and delivered account notification health."""
+
+    generated_events_last_24h: int
+    delivered_digests_last_24h: int
+    delivered_events_last_24h: int
+    pending_events: int
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalMetricsData:
+    """Combined stabilization metrics for operator visibility."""
+
+    measured_at: datetime
+    review: ReviewThroughputData
+    alerts: AlertDeliveryData
+
+
+def get_operational_metrics(
+    *,
+    db: Session,
+    now: datetime | None = None,
+) -> OperationalMetricsData:
+    """Calculate dashboard health metrics from authoritative operational records."""
+    measured_at = now or datetime.now(UTC)
+    cutoff = measured_at - timedelta(hours=24)
+    pending_statuses = [
+        ReviewItemStatus.PENDING.value,
+        ReviewItemStatus.IN_REVIEW.value,
+    ]
+    decided_items = (
+        db.query(ReviewItem)
+        .filter(ReviewItem.decided_at.isnot(None))
+        .filter(ReviewItem.decided_at >= cutoff)
+        .all()
+    )
+    decision_minutes = [
+        (item.decided_at - item.created_at).total_seconds() / 60
+        for item in decided_items
+        if item.decided_at is not None
+    ]
+    delivered_digests = (
+        db.query(AccountDigest)
+        .filter(AccountDigest.delivered_at.isnot(None))
+        .filter(AccountDigest.delivered_at >= cutoff)
+        .all()
+    )
+    return OperationalMetricsData(
+        measured_at=measured_at,
+        review=ReviewThroughputData(
+            pending_items=db.query(ReviewItem)
+            .filter(ReviewItem.status.in_(pending_statuses))
+            .count(),
+            decisions_last_24h=len(decided_items),
+            median_decision_minutes_last_24h=(
+                round(median(decision_minutes), 2) if decision_minutes else None
+            ),
+        ),
+        alerts=AlertDeliveryData(
+            generated_events_last_24h=db.query(AccountAlertEvent)
+            .filter(AccountAlertEvent.created_at >= cutoff)
+            .count(),
+            delivered_digests_last_24h=len(delivered_digests),
+            delivered_events_last_24h=sum(
+                digest.event_count for digest in delivered_digests
+            ),
+            pending_events=db.query(AccountAlertEvent)
+            .filter(AccountAlertEvent.digest_id.is_(None))
+            .count(),
+        ),
+    )

--- a/backend/src/podex/services/ops_podcast_commands.py
+++ b/backend/src/podex/services/ops_podcast_commands.py
@@ -1,0 +1,189 @@
+"""Shared podcast management mutation services for ops surfaces."""
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from podex.models import DiscoverySource, Podcast, PodcastStatus
+from podex.services.ops_podcast_queries import (
+    OpsPodcastSummaryData,
+    get_ops_podcast_by_id,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OpsPodcastSourceInputData:
+    """Source fields provided for ops podcast mutations."""
+
+    rss_url: str | None = None
+    spotify_id: str | None = None
+    apple_id: str | None = None
+    youtube_channel_id: str | None = None
+    podscripts_slug: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CreateOpsPodcastInputData:
+    """Required and optional fields for podcast creation."""
+
+    name: str
+    slug: str
+    status: PodcastStatus
+    description: str | None = None
+    cover_url: str | None = None
+    discovery_source: str | None = None
+    sources: OpsPodcastSourceInputData = OpsPodcastSourceInputData()
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateOpsPodcastInputData:
+    """Partial fields accepted for podcast updates."""
+
+    provided_fields: frozenset[str] = frozenset()
+    source_fields: frozenset[str] = frozenset()
+    name: str | None = None
+    slug: str | None = None
+    status: PodcastStatus | None = None
+    description: str | None = None
+    cover_url: str | None = None
+    discovery_source: str | None = None
+    sources: OpsPodcastSourceInputData | None = None
+
+
+def create_ops_podcast(
+    *,
+    db: Session,
+    payload: CreateOpsPodcastInputData,
+) -> OpsPodcastSummaryData:
+    """Create a podcast for ops catalog management.
+
+    Args:
+        db: Database session.
+        payload: Podcast creation payload.
+
+    Returns:
+        Created podcast summary.
+
+    Raises:
+        RuntimeError: If the created podcast cannot be reloaded.
+    """
+    podcast = Podcast(
+        name=payload.name,
+        slug=payload.slug,
+        status=payload.status.value,
+        description=payload.description,
+        cover_url=payload.cover_url,
+        discovery_source=(
+            DiscoverySource(payload.discovery_source)
+            if payload.discovery_source is not None
+            else None
+        ),
+        rss_url=payload.sources.rss_url,
+        spotify_id=payload.sources.spotify_id,
+        apple_id=payload.sources.apple_id,
+        youtube_channel_id=payload.sources.youtube_channel_id,
+        podscripts_slug=payload.sources.podscripts_slug,
+    )
+    db.add(podcast)
+    db.flush()
+
+    created_podcast = get_ops_podcast_by_id(db=db, podcast_id=podcast.id)
+    if created_podcast is None:
+        raise RuntimeError("Created podcast could not be reloaded")
+    return created_podcast
+
+
+def update_ops_podcast(
+    *,
+    db: Session,
+    podcast_id: int,
+    payload: UpdateOpsPodcastInputData,
+) -> OpsPodcastSummaryData | None:
+    """Update a podcast for ops catalog management.
+
+    Args:
+        db: Database session.
+        podcast_id: Internal podcast identifier.
+        payload: Partial update payload.
+
+    Returns:
+        Updated podcast summary when found, otherwise ``None``.
+
+    Raises:
+        RuntimeError: If the updated podcast cannot be reloaded.
+    """
+    podcast = db.query(Podcast).filter(Podcast.id == podcast_id).first()
+    if podcast is None:
+        return None
+
+    if "name" in payload.provided_fields:
+        if payload.name is None:
+            raise ValueError("name cannot be cleared")
+        podcast.name = payload.name
+    if "slug" in payload.provided_fields:
+        if payload.slug is None:
+            raise ValueError("slug cannot be cleared")
+        podcast.slug = payload.slug
+    if "status" in payload.provided_fields:
+        if payload.status is None:
+            raise ValueError("status cannot be cleared")
+        podcast.status = payload.status.value
+    if "description" in payload.provided_fields:
+        podcast.description = payload.description
+    if "cover_url" in payload.provided_fields:
+        podcast.cover_url = payload.cover_url
+    if "discovery_source" in payload.provided_fields:
+        podcast.discovery_source = (
+            DiscoverySource(payload.discovery_source)
+            if payload.discovery_source is not None
+            else None
+        )
+
+    if payload.sources is not None:
+        if "rss_url" in payload.source_fields:
+            podcast.rss_url = payload.sources.rss_url
+        if "spotify_id" in payload.source_fields:
+            podcast.spotify_id = payload.sources.spotify_id
+        if "apple_id" in payload.source_fields:
+            podcast.apple_id = payload.sources.apple_id
+        if "youtube_channel_id" in payload.source_fields:
+            podcast.youtube_channel_id = payload.sources.youtube_channel_id
+        if "podscripts_slug" in payload.source_fields:
+            podcast.podscripts_slug = payload.sources.podscripts_slug
+
+    db.flush()
+
+    updated_podcast = get_ops_podcast_by_id(db=db, podcast_id=podcast.id)
+    if updated_podcast is None:
+        raise RuntimeError("Updated podcast could not be reloaded")
+    return updated_podcast
+
+
+def archive_ops_podcast(
+    *,
+    db: Session,
+    podcast_id: int,
+) -> OpsPodcastSummaryData | None:
+    """Archive a podcast for ops catalog management.
+
+    Args:
+        db: Database session.
+        podcast_id: Internal podcast identifier.
+
+    Returns:
+        Archived podcast summary when found, otherwise ``None``.
+
+    Raises:
+        RuntimeError: If the archived podcast cannot be reloaded.
+    """
+    podcast = db.query(Podcast).filter(Podcast.id == podcast_id).first()
+    if podcast is None:
+        return None
+
+    podcast.status = PodcastStatus.PAUSED.value
+    db.flush()
+
+    archived_podcast = get_ops_podcast_by_id(db=db, podcast_id=podcast.id)
+    if archived_podcast is None:
+        raise RuntimeError("Archived podcast could not be reloaded")
+    return archived_podcast

--- a/backend/src/podex/services/ops_podcast_queries.py
+++ b/backend/src/podex/services/ops_podcast_queries.py
@@ -1,0 +1,244 @@
+"""Shared podcast management query services for ops surfaces."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum, auto
+from typing import Any, Literal
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from podex.api.query_helpers import (
+    episode_count_by_podcast_subquery,
+    mention_count_by_podcast_subquery,
+)
+from podex.models import Podcast, PodcastStatus
+
+
+class PodcastSourceType(StrEnum):
+    """Supported source filters for ops podcast management views."""
+
+    RSS = auto()
+    SPOTIFY = auto()
+    APPLE = auto()
+    YOUTUBE = auto()
+    PODSCRIPTS = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class OpsPodcastSourceData:
+    """Source identifiers associated with a managed podcast."""
+
+    rss_url: str | None
+    spotify_id: str | None
+    apple_id: str | None
+    youtube_channel_id: str | None
+    podscripts_slug: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class OpsPodcastSummaryData:
+    """Podcast summary for ops catalog management views."""
+
+    id: int
+    name: str
+    slug: str
+    status: PodcastStatus
+    description: str | None
+    cover_url: str | None
+    created_at: datetime
+    discovery_source: str | None
+    episode_count: int
+    mention_count: int
+    sources: OpsPodcastSourceData
+
+
+@dataclass(frozen=True, slots=True)
+class OpsPodcastListData:
+    """Paginated podcast management payload for ops surfaces."""
+
+    items: list[OpsPodcastSummaryData]
+    total: int
+    page: int
+    per_page: int
+
+
+def _build_ops_podcast_summary(
+    *,
+    podcast: Podcast,
+    episode_count: int,
+    mention_count: int,
+) -> OpsPodcastSummaryData:
+    """Build an ops podcast summary with aggregated counts.
+
+    Args:
+        podcast: Podcast model instance.
+        episode_count: Number of episodes in the podcast.
+        mention_count: Number of mentions across the podcast.
+
+    Returns:
+        Ops podcast summary payload.
+    """
+    return OpsPodcastSummaryData(
+        id=podcast.id,
+        name=podcast.name,
+        slug=podcast.slug,
+        status=PodcastStatus(podcast.status),
+        description=podcast.description,
+        cover_url=podcast.cover_url,
+        created_at=podcast.created_at,
+        discovery_source=(
+            podcast.discovery_source.value
+            if podcast.discovery_source is not None
+            else None
+        ),
+        episode_count=episode_count,
+        mention_count=mention_count,
+        sources=OpsPodcastSourceData(
+            rss_url=podcast.rss_url,
+            spotify_id=podcast.spotify_id,
+            apple_id=podcast.apple_id,
+            youtube_channel_id=podcast.youtube_channel_id,
+            podscripts_slug=podcast.podscripts_slug,
+        ),
+    )
+
+
+def _apply_source_filter(*, query: Any, source: PodcastSourceType) -> Any:
+    """Apply a source-presence filter to an ops podcast query.
+
+    Args:
+        query: SQLAlchemy query to filter.
+        source: Source type to require.
+
+    Returns:
+        Filtered query.
+    """
+    if source is PodcastSourceType.RSS:
+        return query.filter(Podcast.rss_url.isnot(None))
+    if source is PodcastSourceType.SPOTIFY:
+        return query.filter(Podcast.spotify_id.isnot(None))
+    if source is PodcastSourceType.APPLE:
+        return query.filter(Podcast.apple_id.isnot(None))
+    if source is PodcastSourceType.YOUTUBE:
+        return query.filter(Podcast.youtube_channel_id.isnot(None))
+    return query.filter(Podcast.podscripts_slug.isnot(None))
+
+
+def list_ops_podcasts(
+    *,
+    db: Session,
+    page: int,
+    per_page: int,
+    status: PodcastStatus | None = None,
+    source: PodcastSourceType | None = None,
+    sort: Literal["created_at", "name", "episode_count", "mention_count"] = (
+        "created_at"
+    ),
+    order: Literal["asc", "desc"] = "desc",
+) -> OpsPodcastListData:
+    """List podcasts for ops catalog management surfaces.
+
+    Args:
+        db: Database session.
+        page: Requested page number.
+        per_page: Number of items per page.
+        status: Optional podcast status filter.
+        source: Optional source-presence filter.
+        sort: Sort field.
+        order: Sort direction.
+
+    Returns:
+        Paginated ops podcast response.
+    """
+    episode_counts = episode_count_by_podcast_subquery(db)
+    mention_counts = mention_count_by_podcast_subquery(db)
+
+    query = (
+        db.query(
+            Podcast,
+            func.coalesce(episode_counts.c.episode_count, 0).label("episode_count"),
+            func.coalesce(mention_counts.c.mention_count, 0).label("mention_count"),
+        )
+        .outerjoin(episode_counts, Podcast.id == episode_counts.c.podcast_id)
+        .outerjoin(mention_counts, Podcast.id == mention_counts.c.podcast_id)
+    )
+
+    if status is not None:
+        query = query.filter(Podcast.status == status.value)
+
+    if source is not None:
+        query = _apply_source_filter(query=query, source=source)
+
+    total = query.count()
+
+    sort_column: Any
+    if sort == "name":
+        sort_column = Podcast.name
+    elif sort == "episode_count":
+        sort_column = func.coalesce(episode_counts.c.episode_count, 0)
+    elif sort == "mention_count":
+        sort_column = func.coalesce(mention_counts.c.mention_count, 0)
+    else:
+        sort_column = Podcast.created_at
+
+    sort_expression = sort_column.desc() if order == "desc" else sort_column.asc()
+    podcast_rows = (
+        query.order_by(sort_expression, Podcast.id.asc())
+        .offset((page - 1) * per_page)
+        .limit(per_page)
+        .all()
+    )
+
+    return OpsPodcastListData(
+        items=[
+            _build_ops_podcast_summary(
+                podcast=podcast,
+                episode_count=episode_count,
+                mention_count=mention_count,
+            )
+            for podcast, episode_count, mention_count in podcast_rows
+        ],
+        total=total,
+        page=page,
+        per_page=per_page,
+    )
+
+
+def get_ops_podcast_by_id(
+    *,
+    db: Session,
+    podcast_id: int,
+) -> OpsPodcastSummaryData | None:
+    """Get a single podcast summary for ops catalog management views.
+
+    Args:
+        db: Database session.
+        podcast_id: Internal podcast identifier.
+
+    Returns:
+        Ops podcast summary when found, otherwise ``None``.
+    """
+    episode_counts = episode_count_by_podcast_subquery(db)
+    mention_counts = mention_count_by_podcast_subquery(db)
+
+    podcast_row = (
+        db.query(
+            Podcast,
+            func.coalesce(episode_counts.c.episode_count, 0).label("episode_count"),
+            func.coalesce(mention_counts.c.mention_count, 0).label("mention_count"),
+        )
+        .outerjoin(episode_counts, Podcast.id == episode_counts.c.podcast_id)
+        .outerjoin(mention_counts, Podcast.id == mention_counts.c.podcast_id)
+        .filter(Podcast.id == podcast_id)
+        .first()
+    )
+    if podcast_row is None:
+        return None
+
+    podcast, episode_count, mention_count = podcast_row
+    return _build_ops_podcast_summary(
+        podcast=podcast,
+        episode_count=episode_count,
+        mention_count=mention_count,
+    )

--- a/backend/src/podex/services/ops_retention_commands.py
+++ b/backend/src/podex/services/ops_retention_commands.py
@@ -1,0 +1,276 @@
+"""Operator commands and read models for transcript lifecycle management."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    MentionCandidate,
+    Transcript,
+    TranscriptArtifact,
+    TranscriptDigest,
+)
+from podex.services.derivative_coverage import evaluate_episode_derivative_coverage
+from podex.services.transcript_artifacts import (
+    TranscriptAcquisitionClient,
+    TranscriptArtifactStore,
+    TranscriptReacquisitionData,
+    reacquire_purged_transcript,
+)
+from podex.services.transcript_retention import (
+    TranscriptRetentionDecision,
+    TranscriptRetentionPolicy,
+    TranscriptRetentionService,
+    TranscriptRetentionState,
+)
+from podex.services.transcript_retention_commands import (
+    evaluate_transcript_retention,
+    purge_transcript_if_eligible,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OpsTranscriptRetentionData:
+    """Operator-facing state for one raw transcript asset."""
+
+    id: int
+    episode_id: int
+    episode_title: str
+    podcast_name: str
+    provider: str
+    fetched_at: datetime | None
+    tier: str
+    policy_version: str | None
+    retention_exempt_sample: bool
+    source_retention_opt_out: bool
+    purge_eligible_at: datetime | None
+    purged_at: datetime | None
+    has_raw_payload: bool
+    has_stored_artifact: bool
+    digest_id: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class OpsTranscriptRetentionPreviewData:
+    """Dry-run lifecycle result plus derivative safety gate."""
+
+    transcript: OpsTranscriptRetentionData
+    decision: TranscriptRetentionDecision
+    extraction_confidence: float | None
+    derivative_coverage_ready: bool
+    missing_query_classes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OpsTranscriptPurgeResultData:
+    """Persisted transcript and proof digest after an operator purge."""
+
+    transcript: OpsTranscriptRetentionData
+    digest: TranscriptDigest
+
+
+@dataclass(frozen=True, slots=True)
+class OpsTranscriptReacquisitionResultData:
+    """Fresh transcript asset created for reprocessing after purge."""
+
+    transcript: OpsTranscriptRetentionData
+    artifact: TranscriptArtifact
+    prior_digest: TranscriptDigest
+
+
+def list_ops_transcript_retention(
+    *,
+    db: Session,
+    limit: int = 40,
+) -> list[OpsTranscriptRetentionData]:
+    """List recent transcript assets for operator retention review."""
+    transcripts = db.query(Transcript).order_by(Transcript.id.desc()).limit(limit).all()
+    return [
+        _to_ops_transcript_retention(db=db, transcript=item) for item in transcripts
+    ]
+
+
+def preview_ops_transcript_retention(
+    *,
+    db: Session,
+    transcript_id: int,
+    policy: TranscriptRetentionPolicy,
+    source_retention_opt_out: bool | None = None,
+    now: datetime | None = None,
+) -> OpsTranscriptRetentionPreviewData | None:
+    """Dry-run a lifecycle policy without changing transcript state."""
+    transcript = db.query(Transcript).filter(Transcript.id == transcript_id).first()
+    if transcript is None:
+        return None
+    extraction_confidence = _latest_confidence(db=db, transcript=transcript)
+    service = TranscriptRetentionService(policy=policy)
+    decision = service.evaluate(
+        state=TranscriptRetentionState(
+            acquired_at=transcript.fetched_at or transcript.created_at,
+            extraction_confidence=extraction_confidence,
+            digest_created_at=transcript.digest_created_at,
+            purged_at=transcript.purged_at,
+            retention_exempt_sample=transcript.retention_exempt_sample,
+            source_retention_opt_out=(
+                source_retention_opt_out
+                if source_retention_opt_out is not None
+                else transcript.source_retention_opt_out
+            ),
+        ),
+        now=now or datetime.now(UTC),
+    )
+    coverage = evaluate_episode_derivative_coverage(db=db, episode=transcript.episode)
+    return OpsTranscriptRetentionPreviewData(
+        transcript=_to_ops_transcript_retention(db=db, transcript=transcript),
+        decision=decision,
+        extraction_confidence=extraction_confidence,
+        derivative_coverage_ready=coverage.purge_safe,
+        missing_query_classes=tuple(
+            item.value for item in coverage.missing_query_classes
+        ),
+    )
+
+
+def apply_ops_transcript_retention(
+    *,
+    db: Session,
+    transcript_id: int,
+    policy: TranscriptRetentionPolicy,
+    source_retention_opt_out: bool | None = None,
+    now: datetime | None = None,
+) -> OpsTranscriptRetentionPreviewData | None:
+    """Persist a policy evaluation and return the current purge gate state."""
+    transcript = db.query(Transcript).filter(Transcript.id == transcript_id).first()
+    if transcript is None:
+        return None
+    evaluate_transcript_retention(
+        db=db,
+        transcript=transcript,
+        extraction_confidence=_latest_confidence(db=db, transcript=transcript),
+        source_retention_opt_out=(
+            source_retention_opt_out
+            if source_retention_opt_out is not None
+            else transcript.source_retention_opt_out
+        ),
+        policy=policy,
+        now=now,
+    )
+    return preview_ops_transcript_retention(
+        db=db,
+        transcript_id=transcript_id,
+        policy=policy,
+        source_retention_opt_out=source_retention_opt_out,
+        now=now,
+    )
+
+
+def purge_ops_transcript(
+    *,
+    db: Session,
+    transcript_id: int,
+    artifact_store: TranscriptArtifactStore | None = None,
+    now: datetime | None = None,
+) -> OpsTranscriptPurgeResultData | None:
+    """Purge an eligible transcript after checking public derivative coverage."""
+    transcript = db.query(Transcript).filter(Transcript.id == transcript_id).first()
+    if transcript is None:
+        return None
+    coverage = evaluate_episode_derivative_coverage(db=db, episode=transcript.episode)
+    if not coverage.purge_safe:
+        raise ValueError("Derivative coverage is incomplete for transcript purge")
+    if not purge_transcript_if_eligible(
+        db=db,
+        transcript=transcript,
+        artifact_store=artifact_store,
+        now=now,
+    ):
+        raise ValueError("Transcript is not eligible for purge")
+    digest = (
+        db.query(TranscriptDigest)
+        .filter(TranscriptDigest.transcript_id == transcript.id)
+        .order_by(TranscriptDigest.id.desc())
+        .one()
+    )
+    return OpsTranscriptPurgeResultData(
+        transcript=_to_ops_transcript_retention(db=db, transcript=transcript),
+        digest=digest,
+    )
+
+
+def reacquire_ops_transcript(
+    *,
+    db: Session,
+    transcript_id: int,
+    acquirer: TranscriptAcquisitionClient,
+    artifact_store: TranscriptArtifactStore | None,
+) -> OpsTranscriptReacquisitionResultData | None:
+    """Re-acquire a purged transcript into a fresh hot raw asset."""
+    transcript = db.query(Transcript).filter(Transcript.id == transcript_id).first()
+    if transcript is None:
+        return None
+    result: TranscriptReacquisitionData = reacquire_purged_transcript(
+        db=db,
+        transcript=transcript,
+        acquirer=acquirer,
+        artifact_store=artifact_store,
+    )
+    return OpsTranscriptReacquisitionResultData(
+        transcript=_to_ops_transcript_retention(db=db, transcript=result.transcript),
+        artifact=result.artifact,
+        prior_digest=result.prior_digest,
+    )
+
+
+def _latest_confidence(*, db: Session, transcript: Transcript) -> float | None:
+    """Get the highest candidate confidence for the transcript episode."""
+    row = (
+        db.query(MentionCandidate.confidence)
+        .filter(MentionCandidate.episode_id == transcript.episode_id)
+        .order_by(MentionCandidate.confidence.desc())
+        .first()
+    )
+    return row[0] if row is not None else None
+
+
+def _to_ops_transcript_retention(
+    *,
+    db: Session,
+    transcript: Transcript,
+) -> OpsTranscriptRetentionData:
+    """Convert a transcript model into its ops lifecycle read model."""
+    digest = (
+        db.query(TranscriptDigest)
+        .filter(TranscriptDigest.transcript_id == transcript.id)
+        .order_by(TranscriptDigest.id.desc())
+        .first()
+    )
+    active_artifact = (
+        db.query(TranscriptArtifact)
+        .filter(
+            TranscriptArtifact.transcript_id == transcript.id,
+            TranscriptArtifact.purged_at.is_(None),
+        )
+        .first()
+    )
+    return OpsTranscriptRetentionData(
+        id=transcript.id,
+        episode_id=transcript.episode_id,
+        episode_title=transcript.episode.title,
+        podcast_name=transcript.episode.podcast.name,
+        provider=transcript.provider,
+        fetched_at=transcript.fetched_at,
+        tier=transcript.retention_tier,
+        policy_version=transcript.retention_policy_version,
+        retention_exempt_sample=transcript.retention_exempt_sample,
+        source_retention_opt_out=transcript.source_retention_opt_out,
+        purge_eligible_at=transcript.purge_eligible_at,
+        purged_at=transcript.purged_at,
+        has_raw_payload=(
+            transcript.raw_text is not None
+            or transcript.cleaned_text is not None
+            or active_artifact is not None
+        ),
+        has_stored_artifact=active_artifact is not None,
+        digest_id=digest.id if digest is not None else None,
+    )

--- a/backend/src/podex/services/pipeline_queries.py
+++ b/backend/src/podex/services/pipeline_queries.py
@@ -1,0 +1,110 @@
+"""Shared pipeline and job query services for ops surfaces."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from podex.models import IngestionRun
+
+
+@dataclass(frozen=True, slots=True)
+class IngestionRunSummaryData:
+    """Shared ingestion run summary payload."""
+
+    id: int
+    status: str
+    error_summary: str | None
+    started_at: datetime | None
+    completed_at: datetime | None
+    created_at: datetime
+    duration_seconds: int | None
+
+
+def calculate_duration_seconds(
+    *,
+    started_at: datetime | None,
+    completed_at: datetime | None,
+) -> int | None:
+    """Calculate whole-second duration for a completed run or job.
+
+    Args:
+        started_at: Start timestamp.
+        completed_at: Completion timestamp.
+
+    Returns:
+        Duration in seconds when both timestamps are present.
+    """
+    if started_at is None or completed_at is None:
+        return None
+
+    return int((completed_at - started_at).total_seconds())
+
+
+def _to_ingestion_run_summary_data(
+    *,
+    run: IngestionRun,
+) -> IngestionRunSummaryData:
+    """Build a shared ingestion run summary payload.
+
+    Args:
+        run: Ingestion run model instance.
+
+    Returns:
+        Shared ingestion run summary payload.
+    """
+    return IngestionRunSummaryData(
+        id=run.id,
+        status=run.status,
+        error_summary=run.error_summary,
+        started_at=run.started_at,
+        completed_at=run.completed_at,
+        created_at=run.created_at,
+        duration_seconds=calculate_duration_seconds(
+            started_at=run.started_at,
+            completed_at=run.completed_at,
+        ),
+    )
+
+
+def get_ingestion_run_by_id(
+    *,
+    db: Session,
+    ingestion_run_id: int,
+) -> IngestionRunSummaryData | None:
+    """Get a single ingestion run summary for ops surfaces.
+
+    Args:
+        db: Database session.
+        ingestion_run_id: Internal ingestion run identifier.
+
+    Returns:
+        Ingestion run summary when found, otherwise ``None``.
+    """
+    run = db.query(IngestionRun).filter(IngestionRun.id == ingestion_run_id).first()
+    if run is None:
+        return None
+    return _to_ingestion_run_summary_data(run=run)
+
+
+def list_recent_ingestion_runs(
+    *,
+    db: Session,
+    limit: int,
+) -> list[IngestionRunSummaryData]:
+    """List recent ingestion runs for ops views.
+
+    Args:
+        db: Database session.
+        limit: Maximum number of runs to return.
+
+    Returns:
+        Recent ingestion run summaries ordered by recency.
+    """
+    runs = (
+        db.query(IngestionRun)
+        .order_by(IngestionRun.created_at.desc(), IngestionRun.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return [_to_ingestion_run_summary_data(run=run) for run in runs]

--- a/backend/tests/test_acceptance_catalog.py
+++ b/backend/tests/test_acceptance_catalog.py
@@ -211,7 +211,7 @@ def test_openapi_surface_is_read_only_get() -> None:
     """
     schema = build_openapi_schema()
     catalog_prefix = "/api/v2/"
-    account_prefixes = ("/api/v2/auth", "/api/v2/me")
+    account_prefixes = ("/api/v2/auth", "/api/v2/me", "/api/v2/ops")
 
     for path, operations in schema["paths"].items():
         if not path.startswith(catalog_prefix):
@@ -234,7 +234,7 @@ def test_openapi_response_schemas_reference_read_dtos() -> None:
     for path, operations in schema["paths"].items():
         if not path.startswith("/api/v2/") or path.endswith("/status"):
             continue
-        if path.startswith(("/api/v2/auth", "/api/v2/me")):
+        if path.startswith(("/api/v2/auth", "/api/v2/me", "/api/v2/ops")):
             continue
         success = operations["get"]["responses"]["200"]["content"]["application/json"][
             "schema"

--- a/backend/tests/test_api_ops.py
+++ b/backend/tests/test_api_ops.py
@@ -1,0 +1,162 @@
+"""Tests for the ops console API surface."""
+
+from assertpy import assert_that
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.api.deps import get_app_settings
+from podex.config import Settings
+from podex.models import IngestionRun, IngestionRunStatus, Transcript
+from tests.conftest import seed_catalog_graph
+
+_OPS_KEY = "test-ops-key"
+_HEADERS = {"X-Ops-Key": _OPS_KEY}
+
+
+def _enable_ops(client: TestClient) -> None:
+    """Configure the ops surface for a test app."""
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    app.dependency_overrides[get_app_settings] = lambda: Settings(
+        ops_api_key=_OPS_KEY,
+    )
+
+
+def test_ops_surface_requires_configuration_and_key(client: TestClient) -> None:
+    """Unconfigured ops reports 503; wrong key reports 401."""
+    assert_that(client.get("/api/v2/ops/metrics").status_code).is_equal_to(503)
+
+    _enable_ops(client)
+    unauthenticated = client.get("/api/v2/ops/metrics")
+    assert_that(unauthenticated.status_code).is_equal_to(401)
+    wrong = client.get("/api/v2/ops/metrics", headers={"X-Ops-Key": "wrong"})
+    assert_that(wrong.status_code).is_equal_to(401)
+    ok = client.get("/api/v2/ops/metrics", headers=_HEADERS)
+    assert_that(ok.status_code).is_equal_to(200)
+    assert_that(ok.json()["review"]["pending_items"]).is_equal_to(0)
+
+
+def test_ops_podcast_management_round_trip(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Podcasts create, list, update, and archive with audit records."""
+    _enable_ops(client)
+
+    created = client.post(
+        "/api/v2/ops/podcasts",
+        json={
+            "name": "The Example Show",
+            "slug": "example-show",
+            "status": "active",
+            "sources": {"rss_url": "https://example.com/feed.xml"},
+        },
+        headers=_HEADERS,
+    )
+    assert_that(created.status_code).is_equal_to(201)
+    podcast_id = created.json()["id"]
+    assert_that(created.json()["sources"]["rss_url"]).is_equal_to(
+        "https://example.com/feed.xml",
+    )
+
+    duplicate = client.post(
+        "/api/v2/ops/podcasts",
+        json={"name": "Duplicate", "slug": "example-show"},
+        headers=_HEADERS,
+    )
+    assert_that(duplicate.status_code).is_equal_to(409)
+
+    listed = client.get(
+        "/api/v2/ops/podcasts",
+        params={"status": "active", "source": "rss"},
+        headers=_HEADERS,
+    )
+    assert_that(listed.json()["total"]).is_equal_to(1)
+
+    updated = client.patch(
+        f"/api/v2/ops/podcasts/{podcast_id}",
+        json={"description": "An updated description."},
+        headers=_HEADERS,
+    )
+    assert_that(updated.status_code).is_equal_to(200)
+    assert_that(updated.json()["description"]).is_equal_to(
+        "An updated description.",
+    )
+    assert_that(updated.json()["name"]).is_equal_to("The Example Show")
+
+    archived = client.post(
+        f"/api/v2/ops/podcasts/{podcast_id}/archive",
+        headers=_HEADERS,
+    )
+    assert_that(archived.json()["status"]).is_equal_to("paused")
+    assert_that(
+        client.patch(
+            "/api/v2/ops/podcasts/999999",
+            json={"name": "Nope"},
+            headers=_HEADERS,
+        ).status_code,
+    ).is_equal_to(404)
+
+    audit = client.get("/api/v2/ops/audit-log", headers=_HEADERS)
+    assert_that(audit.json()["total"]).is_equal_to(3)
+    assert_that(audit.json()["items"][0]["action"]).is_equal_to("archive_podcast")
+
+
+def test_ops_pipelines_lists_recent_runs(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Pipeline activity returns recent ingestion runs."""
+    _enable_ops(client)
+    db_session.add(IngestionRun(status=IngestionRunStatus.COMPLETED))
+    db_session.commit()
+
+    response = client.get("/api/v2/ops/pipelines", headers=_HEADERS)
+
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()["runs"]).is_length(1)
+
+
+def test_ops_retention_preview_apply_and_purge_gate(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Retention endpoints preview, apply, and refuse unsafe purges."""
+    _enable_ops(client)
+    graph = seed_catalog_graph(db_session)
+    transcript = Transcript(
+        episode_id=graph.episode_id,
+        provider="podscripts",
+        raw_text="raw text",
+    )
+    db_session.add(transcript)
+    db_session.commit()
+
+    listed = client.get("/api/v2/ops/retention", headers=_HEADERS)
+    assert_that(listed.json()).is_length(1)
+
+    preview = client.get(
+        f"/api/v2/ops/retention/{transcript.id}/preview",
+        headers=_HEADERS,
+    )
+    assert_that(preview.status_code).is_equal_to(200)
+    assert_that(preview.json()["derivative_coverage_ready"]).is_false()
+    assert_that(
+        client.get(
+            "/api/v2/ops/retention/999999/preview", headers=_HEADERS
+        ).status_code,
+    ).is_equal_to(404)
+
+    applied = client.post(
+        f"/api/v2/ops/retention/{transcript.id}/apply",
+        headers=_HEADERS,
+    )
+    assert_that(applied.status_code).is_equal_to(200)
+
+    refused = client.post(
+        f"/api/v2/ops/retention/{transcript.id}/purge",
+        headers=_HEADERS,
+    )
+    assert_that(refused.status_code).is_equal_to(409)

--- a/backend/tests/test_ops_pipeline_metrics.py
+++ b/backend/tests/test_ops_pipeline_metrics.py
@@ -1,0 +1,190 @@
+"""Tests for ops pipeline queries, metrics, and retention commands."""
+
+from datetime import UTC, datetime, timedelta
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    AccountAlertEvent,
+    AccountAlertRule,
+    AccountDigest,
+    AccountUser,
+    IngestionRun,
+    IngestionRunStatus,
+    MentionCandidate,
+    ReviewItem,
+    ReviewItemStatus,
+    Transcript,
+)
+from podex.services.ops_metrics import get_operational_metrics
+from podex.services.ops_retention_commands import (
+    apply_ops_transcript_retention,
+    list_ops_transcript_retention,
+    preview_ops_transcript_retention,
+)
+from podex.services.pipeline_queries import (
+    get_ingestion_run_by_id,
+    list_recent_ingestion_runs,
+)
+from podex.services.transcript_retention import TranscriptRetentionPolicy
+from tests.conftest import seed_catalog_graph
+
+_NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+
+
+def test_ingestion_run_queries_compute_durations(db_session: Session) -> None:
+    """Run summaries include whole-second durations and recency ordering."""
+    done = IngestionRun(
+        status=IngestionRunStatus.COMPLETED,
+        started_at=_NOW - timedelta(minutes=5),
+        completed_at=_NOW,
+    )
+    running = IngestionRun(status=IngestionRunStatus.RUNNING, started_at=_NOW)
+    db_session.add_all([done, running])
+    db_session.commit()
+
+    loaded = get_ingestion_run_by_id(db=db_session, ingestion_run_id=done.id)
+    assert_that(loaded).is_not_none()
+    if loaded is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(loaded.duration_seconds).is_equal_to(300)
+    assert_that(
+        get_ingestion_run_by_id(db=db_session, ingestion_run_id=999_999),
+    ).is_none()
+
+    recent = list_recent_ingestion_runs(db=db_session, limit=10)
+    assert_that(recent).is_length(2)
+    assert_that(recent[0].id).is_equal_to(running.id)
+    assert_that(recent[0].duration_seconds).is_none()
+
+
+def test_operational_metrics_summarize_review_and_alerts(
+    db_session: Session,
+) -> None:
+    """Dashboard metrics compute review throughput and alert delivery."""
+    graph = seed_catalog_graph(db_session)
+    pending_candidate = MentionCandidate(
+        episode_id=graph.episode_id,
+        media_type="book",
+        raw_title="Dune",
+        confidence=0.4,
+        extraction_source="llm",
+    )
+    decided_candidate = MentionCandidate(
+        episode_id=graph.episode_id,
+        media_type="book",
+        raw_title="Dune II",
+        confidence=0.4,
+        extraction_source="llm",
+    )
+    db_session.add_all([pending_candidate, decided_candidate])
+    db_session.flush()
+    db_session.add(ReviewItem(mention_candidate_id=pending_candidate.id))
+    db_session.add(
+        ReviewItem(
+            mention_candidate_id=decided_candidate.id,
+            status=ReviewItemStatus.APPROVED.value,
+            created_at=_NOW - timedelta(hours=2),
+            decided_at=_NOW - timedelta(hours=1),
+        ),
+    )
+    user = AccountUser(email="reader@example.com")
+    db_session.add(user)
+    db_session.flush()
+    rule = AccountAlertRule(
+        user_id=user.id,
+        target_type="podcast",
+        target_id=graph.podcast_id,
+        event_type="new_episode",
+    )
+    db_session.add(rule)
+    db_session.flush()
+    digest = AccountDigest(
+        user_id=user.id,
+        subject="Podex digest: 1 new update",
+        body_text="- 1 new episode",
+        event_count=1,
+        created_at=_NOW - timedelta(hours=1),
+        delivered_at=_NOW - timedelta(hours=1),
+    )
+    db_session.add(digest)
+    db_session.flush()
+    db_session.add_all(
+        [
+            AccountAlertEvent(
+                rule_id=rule.id,
+                previous_count=1,
+                observed_count=2,
+                digest_id=digest.id,
+                created_at=_NOW - timedelta(hours=2),
+            ),
+            AccountAlertEvent(
+                rule_id=rule.id,
+                previous_count=2,
+                observed_count=3,
+                created_at=_NOW - timedelta(minutes=30),
+            ),
+        ],
+    )
+    db_session.commit()
+
+    metrics = get_operational_metrics(db=db_session, now=_NOW)
+
+    assert_that(metrics.review.pending_items).is_equal_to(1)
+    assert_that(metrics.review.decisions_last_24h).is_equal_to(1)
+    assert_that(metrics.review.median_decision_minutes_last_24h).is_equal_to(60.0)
+    assert_that(metrics.alerts.generated_events_last_24h).is_equal_to(2)
+    assert_that(metrics.alerts.delivered_digests_last_24h).is_equal_to(1)
+    assert_that(metrics.alerts.delivered_events_last_24h).is_equal_to(1)
+    assert_that(metrics.alerts.pending_events).is_equal_to(1)
+
+
+def test_ops_retention_preview_and_apply(db_session: Session) -> None:
+    """Retention preview reports the purge gate; apply persists evaluation."""
+    graph = seed_catalog_graph(db_session)
+    transcript = Transcript(
+        episode_id=graph.episode_id,
+        provider="podscripts",
+        raw_text="raw text",
+        fetched_at=_NOW - timedelta(days=400),
+    )
+    db_session.add(transcript)
+    db_session.commit()
+
+    listed = list_ops_transcript_retention(db=db_session)
+    assert_that(listed).is_length(1)
+    assert_that(listed[0].has_raw_payload).is_true()
+    assert_that(listed[0].has_stored_artifact).is_false()
+
+    policy = TranscriptRetentionPolicy()
+    preview = preview_ops_transcript_retention(
+        db=db_session,
+        transcript_id=transcript.id,
+        policy=policy,
+        now=_NOW,
+    )
+    assert_that(preview).is_not_none()
+    if preview is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(preview.derivative_coverage_ready).is_false()
+    assert_that(preview.missing_query_classes).is_not_empty()
+    assert_that(
+        preview_ops_transcript_retention(
+            db=db_session,
+            transcript_id=999_999,
+            policy=policy,
+        ),
+    ).is_none()
+
+    applied = apply_ops_transcript_retention(
+        db=db_session,
+        transcript_id=transcript.id,
+        policy=policy,
+        now=_NOW,
+    )
+    db_session.commit()
+    assert_that(applied).is_not_none()
+    if applied is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(applied.transcript.tier).is_not_equal_to("hot")

--- a/backend/tests/test_ops_podcasts.py
+++ b/backend/tests/test_ops_podcasts.py
@@ -1,0 +1,182 @@
+"""Tests for ops podcast management queries, commands, and audit log."""
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.models import AuditAction, Podcast, PodcastStatus
+from podex.services.audit_log import list_audit_logs, record_audit_log
+from podex.services.ops_podcast_commands import (
+    CreateOpsPodcastInputData,
+    OpsPodcastSourceInputData,
+    UpdateOpsPodcastInputData,
+    archive_ops_podcast,
+    create_ops_podcast,
+    update_ops_podcast,
+)
+from podex.services.ops_podcast_queries import (
+    PodcastSourceType,
+    get_ops_podcast_by_id,
+    list_ops_podcasts,
+)
+from tests.conftest import seed_catalog_graph
+
+
+def test_create_and_get_ops_podcast(db_session: Session) -> None:
+    """Creation persists sources and reload returns aggregated counts."""
+    created = create_ops_podcast(
+        db=db_session,
+        payload=CreateOpsPodcastInputData(
+            name="The Example Show",
+            slug="example-show",
+            status=PodcastStatus.ACTIVE,
+            description="A show about examples.",
+            cover_url="https://cdn.example/cover.jpg",
+            discovery_source="rss",
+            sources=OpsPodcastSourceInputData(rss_url="https://example.com/feed.xml"),
+        ),
+    )
+    db_session.commit()
+
+    assert_that(created.slug).is_equal_to("example-show")
+    assert_that(created.status).is_equal_to(PodcastStatus.ACTIVE)
+    assert_that(created.sources.rss_url).is_equal_to("https://example.com/feed.xml")
+    assert_that(created.episode_count).is_equal_to(0)
+    loaded = get_ops_podcast_by_id(db=db_session, podcast_id=created.id)
+    assert_that(loaded).is_not_none()
+    assert_that(get_ops_podcast_by_id(db=db_session, podcast_id=999_999)).is_none()
+
+
+def test_list_ops_podcasts_filters_and_sorts(db_session: Session) -> None:
+    """Listing supports status filters, source filters, and count sorting."""
+    graph = seed_catalog_graph(db_session)
+    podcast = db_session.query(Podcast).filter(Podcast.id == graph.podcast_id).one()
+    podcast.rss_url = "https://example.com/feed.xml"
+    create_ops_podcast(
+        db=db_session,
+        payload=CreateOpsPodcastInputData(
+            name="Quiet Show",
+            slug="quiet-show",
+            status=PodcastStatus.PAUSED,
+        ),
+    )
+    db_session.commit()
+
+    everything = list_ops_podcasts(db=db_session, page=1, per_page=10)
+    assert_that(everything.total).is_equal_to(2)
+
+    paused = list_ops_podcasts(
+        db=db_session,
+        page=1,
+        per_page=10,
+        status=PodcastStatus.PAUSED,
+    )
+    assert_that(paused.total).is_equal_to(1)
+    assert_that(paused.items[0].slug).is_equal_to("quiet-show")
+
+    rss_only = list_ops_podcasts(
+        db=db_session,
+        page=1,
+        per_page=10,
+        source=PodcastSourceType.RSS,
+    )
+    assert_that(rss_only.total).is_equal_to(1)
+    assert_that(rss_only.items[0].slug).is_equal_to("example-show")
+
+    by_mentions = list_ops_podcasts(
+        db=db_session,
+        page=1,
+        per_page=10,
+        sort="mention_count",
+        order="desc",
+    )
+    assert_that(by_mentions.items[0].slug).is_equal_to("example-show")
+    assert_that(by_mentions.items[0].mention_count).is_equal_to(1)
+
+
+def test_update_and_archive_ops_podcast(db_session: Session) -> None:
+    """Partial updates only touch provided fields; archive pauses processing."""
+    created = create_ops_podcast(
+        db=db_session,
+        payload=CreateOpsPodcastInputData(
+            name="The Example Show",
+            slug="example-show",
+            status=PodcastStatus.ACTIVE,
+            description="Original description.",
+        ),
+    )
+    db_session.commit()
+
+    updated = update_ops_podcast(
+        db=db_session,
+        podcast_id=created.id,
+        payload=UpdateOpsPodcastInputData(
+            provided_fields=frozenset({"name", "description"}),
+            source_fields=frozenset({"spotify_id"}),
+            name="The Example Show — Renamed",
+            description=None,
+            sources=OpsPodcastSourceInputData(spotify_id="abc123"),
+        ),
+    )
+    db_session.commit()
+
+    assert_that(updated).is_not_none()
+    if updated is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(updated.name).is_equal_to("The Example Show — Renamed")
+    assert_that(updated.description).is_none()
+    assert_that(updated.slug).is_equal_to("example-show")
+    assert_that(updated.sources.spotify_id).is_equal_to("abc123")
+    assert_that(
+        update_ops_podcast(
+            db=db_session,
+            podcast_id=999_999,
+            payload=UpdateOpsPodcastInputData(),
+        ),
+    ).is_none()
+
+    archived = archive_ops_podcast(db=db_session, podcast_id=created.id)
+    db_session.commit()
+    assert_that(archived).is_not_none()
+    if archived is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+    assert_that(archived.status).is_equal_to(PodcastStatus.PAUSED)
+    assert_that(archive_ops_podcast(db=db_session, podcast_id=999_999)).is_none()
+
+
+def test_audit_log_records_and_lists(db_session: Session) -> None:
+    """Audit entries persist immutably and list newest first with paging."""
+    record_audit_log(
+        db=db_session,
+        action=AuditAction.CREATE_PODCAST,
+        resource_type="podcast",
+        resource_id=1,
+        resource_identifier="example-show",
+        actor_name="operator",
+        summary="Created podcast example-show",
+        metadata_json={"slug": "example-show"},
+    )
+    record_audit_log(
+        db=db_session,
+        action=AuditAction.ARCHIVE_PODCAST,
+        resource_type="podcast",
+        resource_id=1,
+        summary="Archived podcast example-show",
+    )
+    db_session.commit()
+
+    listed = list_audit_logs(db=db_session, page=1, per_page=10)
+    assert_that(listed.total).is_equal_to(2)
+    assert_that(listed.items[0].action).is_equal_to(AuditAction.ARCHIVE_PODCAST)
+    assert_that(listed.items[1].metadata_json).is_equal_to({"slug": "example-show"})
+
+    filtered = list_audit_logs(
+        db=db_session,
+        page=1,
+        per_page=10,
+        action=AuditAction.CREATE_PODCAST,
+    )
+    assert_that(filtered.total).is_equal_to(1)
+
+    paged = list_audit_logs(db=db_session, page=2, per_page=1)
+    assert_that(paged.items).is_length(1)
+    assert_that(paged.items[0].action).is_equal_to(AuditAction.CREATE_PODCAST)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -801,6 +801,920 @@
         "title": "MentionRead",
         "type": "object"
       },
+      "OpsAlertDeliveryRead": {
+        "description": "Generated and delivered account notification health.",
+        "properties": {
+          "delivered_digests_last_24h": {
+            "title": "Delivered Digests Last 24H",
+            "type": "integer"
+          },
+          "delivered_events_last_24h": {
+            "title": "Delivered Events Last 24H",
+            "type": "integer"
+          },
+          "generated_events_last_24h": {
+            "title": "Generated Events Last 24H",
+            "type": "integer"
+          },
+          "pending_events": {
+            "title": "Pending Events",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "generated_events_last_24h",
+          "delivered_digests_last_24h",
+          "delivered_events_last_24h",
+          "pending_events"
+        ],
+        "title": "OpsAlertDeliveryRead",
+        "type": "object"
+      },
+      "OpsAuditLogEntryRead": {
+        "description": "One immutable audit record.",
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "actor_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor Name"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "metadata_json": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata Json"
+          },
+          "resource_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource Id"
+          },
+          "resource_identifier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource Identifier"
+          },
+          "resource_type": {
+            "title": "Resource Type",
+            "type": "string"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "action",
+          "resource_type",
+          "resource_id",
+          "resource_identifier",
+          "actor_name",
+          "summary",
+          "metadata_json",
+          "created_at"
+        ],
+        "title": "OpsAuditLogEntryRead",
+        "type": "object"
+      },
+      "OpsAuditLogListRead": {
+        "description": "Paginated audit log payload.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OpsAuditLogEntryRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "per_page": {
+            "title": "Per Page",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "per_page"
+        ],
+        "title": "OpsAuditLogListRead",
+        "type": "object"
+      },
+      "OpsIngestionRunRead": {
+        "description": "Ingestion run summary for pipeline views.",
+        "properties": {
+          "completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Seconds"
+          },
+          "error_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Summary"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "error_summary",
+          "started_at",
+          "completed_at",
+          "created_at",
+          "duration_seconds"
+        ],
+        "title": "OpsIngestionRunRead",
+        "type": "object"
+      },
+      "OpsMetricsRead": {
+        "description": "Combined operational metrics for the ops dashboard.",
+        "properties": {
+          "alerts": {
+            "$ref": "#/components/schemas/OpsAlertDeliveryRead"
+          },
+          "measured_at": {
+            "format": "date-time",
+            "title": "Measured At",
+            "type": "string"
+          },
+          "review": {
+            "$ref": "#/components/schemas/OpsReviewThroughputRead"
+          }
+        },
+        "required": [
+          "measured_at",
+          "review",
+          "alerts"
+        ],
+        "title": "OpsMetricsRead",
+        "type": "object"
+      },
+      "OpsPipelineActivityRead": {
+        "description": "Recent pipeline activity.",
+        "properties": {
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/OpsIngestionRunRead"
+            },
+            "title": "Runs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "runs"
+        ],
+        "title": "OpsPipelineActivityRead",
+        "type": "object"
+      },
+      "OpsPodcastCreateRequest": {
+        "description": "Create a managed podcast.",
+        "properties": {
+          "cover_url": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Url"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "discovery_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Discovery Source"
+          },
+          "name": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "slug": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Slug",
+            "type": "string"
+          },
+          "sources": {
+            "$ref": "#/components/schemas/OpsPodcastSourcesInput",
+            "default": {}
+          },
+          "status": {
+            "$ref": "#/components/schemas/PodcastStatus",
+            "default": "watchlist"
+          }
+        },
+        "required": [
+          "name",
+          "slug"
+        ],
+        "title": "OpsPodcastCreateRequest",
+        "type": "object"
+      },
+      "OpsPodcastListRead": {
+        "description": "Paginated podcast management payload.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OpsPodcastRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "per_page": {
+            "title": "Per Page",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "per_page"
+        ],
+        "title": "OpsPodcastListRead",
+        "type": "object"
+      },
+      "OpsPodcastRead": {
+        "description": "Podcast summary for ops catalog management views.",
+        "properties": {
+          "cover_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Url"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "discovery_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Discovery Source"
+          },
+          "episode_count": {
+            "title": "Episode Count",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "mention_count": {
+            "title": "Mention Count",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "sources": {
+            "$ref": "#/components/schemas/OpsPodcastSourcesRead"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PodcastStatus"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "status",
+          "description",
+          "cover_url",
+          "created_at",
+          "discovery_source",
+          "episode_count",
+          "mention_count",
+          "sources"
+        ],
+        "title": "OpsPodcastRead",
+        "type": "object"
+      },
+      "OpsPodcastSourcesInput": {
+        "description": "Source identifiers accepted on podcast mutations.",
+        "properties": {
+          "apple_id": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Apple Id"
+          },
+          "podscripts_slug": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Podscripts Slug"
+          },
+          "rss_url": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rss Url"
+          },
+          "spotify_id": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spotify Id"
+          },
+          "youtube_channel_id": {
+            "anyOf": [
+              {
+                "maxLength": 30,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Youtube Channel Id"
+          }
+        },
+        "title": "OpsPodcastSourcesInput",
+        "type": "object"
+      },
+      "OpsPodcastSourcesRead": {
+        "description": "Source identifiers associated with a managed podcast.",
+        "properties": {
+          "apple_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Apple Id"
+          },
+          "podscripts_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Podscripts Slug"
+          },
+          "rss_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rss Url"
+          },
+          "spotify_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spotify Id"
+          },
+          "youtube_channel_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Youtube Channel Id"
+          }
+        },
+        "required": [
+          "rss_url",
+          "spotify_id",
+          "apple_id",
+          "youtube_channel_id",
+          "podscripts_slug"
+        ],
+        "title": "OpsPodcastSourcesRead",
+        "type": "object"
+      },
+      "OpsPodcastUpdateRequest": {
+        "description": "Partially update a managed podcast; only provided fields change.",
+        "properties": {
+          "cover_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Url"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "discovery_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Discovery Source"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "sources": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpsPodcastSourcesInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PodcastStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "OpsPodcastUpdateRequest",
+        "type": "object"
+      },
+      "OpsRetentionDecisionRead": {
+        "description": "Lifecycle decision produced by a retention evaluation.",
+        "properties": {
+          "age_days": {
+            "title": "Age Days",
+            "type": "integer"
+          },
+          "purge_blockers": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Purge Blockers",
+            "type": "array"
+          },
+          "purge_eligible": {
+            "title": "Purge Eligible",
+            "type": "boolean"
+          },
+          "retention_suppressed": {
+            "title": "Retention Suppressed",
+            "type": "boolean"
+          },
+          "tier": {
+            "title": "Tier",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tier",
+          "purge_eligible",
+          "purge_blockers",
+          "retention_suppressed",
+          "age_days"
+        ],
+        "title": "OpsRetentionDecisionRead",
+        "type": "object"
+      },
+      "OpsRetentionPreviewRead": {
+        "description": "Dry-run lifecycle result plus derivative safety gate.",
+        "properties": {
+          "decision": {
+            "$ref": "#/components/schemas/OpsRetentionDecisionRead"
+          },
+          "derivative_coverage_ready": {
+            "title": "Derivative Coverage Ready",
+            "type": "boolean"
+          },
+          "extraction_confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extraction Confidence"
+          },
+          "missing_query_classes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing Query Classes",
+            "type": "array"
+          },
+          "transcript": {
+            "$ref": "#/components/schemas/OpsTranscriptRetentionRead"
+          }
+        },
+        "required": [
+          "transcript",
+          "decision",
+          "extraction_confidence",
+          "derivative_coverage_ready",
+          "missing_query_classes"
+        ],
+        "title": "OpsRetentionPreviewRead",
+        "type": "object"
+      },
+      "OpsReviewThroughputRead": {
+        "description": "Review decision activity and outstanding pressure.",
+        "properties": {
+          "decisions_last_24h": {
+            "title": "Decisions Last 24H",
+            "type": "integer"
+          },
+          "median_decision_minutes_last_24h": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Median Decision Minutes Last 24H"
+          },
+          "pending_items": {
+            "title": "Pending Items",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "pending_items",
+          "decisions_last_24h",
+          "median_decision_minutes_last_24h"
+        ],
+        "title": "OpsReviewThroughputRead",
+        "type": "object"
+      },
+      "OpsTranscriptPurgeRead": {
+        "description": "Result of an operator-approved transcript purge.",
+        "properties": {
+          "digest_id": {
+            "title": "Digest Id",
+            "type": "integer"
+          },
+          "transcript": {
+            "$ref": "#/components/schemas/OpsTranscriptRetentionRead"
+          }
+        },
+        "required": [
+          "transcript",
+          "digest_id"
+        ],
+        "title": "OpsTranscriptPurgeRead",
+        "type": "object"
+      },
+      "OpsTranscriptRetentionRead": {
+        "description": "Operator-facing state for one raw transcript asset.",
+        "properties": {
+          "digest_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Digest Id"
+          },
+          "episode_id": {
+            "title": "Episode Id",
+            "type": "integer"
+          },
+          "episode_title": {
+            "title": "Episode Title",
+            "type": "string"
+          },
+          "fetched_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fetched At"
+          },
+          "has_raw_payload": {
+            "title": "Has Raw Payload",
+            "type": "boolean"
+          },
+          "has_stored_artifact": {
+            "title": "Has Stored Artifact",
+            "type": "boolean"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "podcast_name": {
+            "title": "Podcast Name",
+            "type": "string"
+          },
+          "policy_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Policy Version"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "purge_eligible_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purge Eligible At"
+          },
+          "purged_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purged At"
+          },
+          "retention_exempt_sample": {
+            "title": "Retention Exempt Sample",
+            "type": "boolean"
+          },
+          "source_retention_opt_out": {
+            "title": "Source Retention Opt Out",
+            "type": "boolean"
+          },
+          "tier": {
+            "title": "Tier",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "episode_id",
+          "episode_title",
+          "podcast_name",
+          "provider",
+          "fetched_at",
+          "tier",
+          "policy_version",
+          "retention_exempt_sample",
+          "source_retention_opt_out",
+          "purge_eligible_at",
+          "purged_at",
+          "has_raw_payload",
+          "has_stored_artifact",
+          "digest_id"
+        ],
+        "title": "OpsTranscriptRetentionRead",
+        "type": "object"
+      },
       "Page_EpisodeRead_": {
         "properties": {
           "items": {
@@ -985,6 +1899,28 @@
         ],
         "title": "PodcastRead",
         "type": "object"
+      },
+      "PodcastSourceType": {
+        "description": "Supported source filters for ops podcast management views.",
+        "enum": [
+          "rss",
+          "spotify",
+          "apple",
+          "youtube",
+          "podscripts"
+        ],
+        "title": "PodcastSourceType",
+        "type": "string"
+      },
+      "PodcastStatus": {
+        "description": "Status of a podcast in the processing workflow.",
+        "enum": [
+          "watchlist",
+          "active",
+          "paused"
+        ],
+        "title": "PodcastStatus",
+        "type": "string"
       },
       "PreferenceRead": {
         "description": "Notification preferences for the current account.",
@@ -2308,6 +3244,634 @@
         "tags": [
           "v2",
           "media"
+        ]
+      }
+    },
+    "/api/v2/ops/audit-log": {
+      "get": {
+        "description": "List immutable audit records, newest first.",
+        "operationId": "get_ops_audit_log_api_v2_ops_audit_log_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Per Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "resource_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Resource Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsAuditLogListRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Ops Audit Log",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/metrics": {
+      "get": {
+        "description": "Return operational dashboard metrics.",
+        "operationId": "get_ops_metrics_api_v2_ops_metrics_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsMetricsRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Ops Metrics",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/pipelines": {
+      "get": {
+        "description": "Return recent ingestion run activity.",
+        "operationId": "get_ops_pipelines_api_v2_ops_pipelines_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsPipelineActivityRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Ops Pipelines",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/podcasts": {
+      "get": {
+        "description": "List managed podcasts with filters and count sorting.",
+        "operationId": "list_ops_podcasts_endpoint_api_v2_ops_podcasts_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Per Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PodcastStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/PodcastSourceType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "created_at",
+              "enum": [
+                "created_at",
+                "name",
+                "episode_count",
+                "mention_count"
+              ],
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "title": "Order",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsPodcastListRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Ops Podcasts Endpoint",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      },
+      "post": {
+        "description": "Create a managed podcast and record the action.",
+        "operationId": "create_ops_podcast_endpoint_api_v2_ops_podcasts_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpsPodcastCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsPodcastRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Ops Podcast Endpoint",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/podcasts/{podcast_id}": {
+      "get": {
+        "description": "Return one managed podcast summary.",
+        "operationId": "get_ops_podcast_endpoint_api_v2_ops_podcasts__podcast_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "podcast_id",
+            "required": true,
+            "schema": {
+              "title": "Podcast Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsPodcastRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Ops Podcast Endpoint",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      },
+      "patch": {
+        "description": "Partially update a managed podcast and record the action.",
+        "operationId": "update_ops_podcast_endpoint_api_v2_ops_podcasts__podcast_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "podcast_id",
+            "required": true,
+            "schema": {
+              "title": "Podcast Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpsPodcastUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsPodcastRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Ops Podcast Endpoint",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/podcasts/{podcast_id}/archive": {
+      "post": {
+        "description": "Pause a managed podcast and record the action.",
+        "operationId": "archive_ops_podcast_endpoint_api_v2_ops_podcasts__podcast_id__archive_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "podcast_id",
+            "required": true,
+            "schema": {
+              "title": "Podcast Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsPodcastRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Archive Ops Podcast Endpoint",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/retention": {
+      "get": {
+        "description": "List recent transcript assets for retention review.",
+        "operationId": "list_ops_retention_api_v2_ops_retention_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 40,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OpsTranscriptRetentionRead"
+                  },
+                  "title": "Response List Ops Retention Api V2 Ops Retention Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Ops Retention",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/retention/{transcript_id}/apply": {
+      "post": {
+        "description": "Persist a retention evaluation and record the action.",
+        "operationId": "apply_ops_retention_api_v2_ops_retention__transcript_id__apply_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "transcript_id",
+            "required": true,
+            "schema": {
+              "title": "Transcript Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsRetentionPreviewRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Apply Ops Retention",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/retention/{transcript_id}/preview": {
+      "get": {
+        "description": "Dry-run the retention policy for one transcript.",
+        "operationId": "preview_ops_retention_api_v2_ops_retention__transcript_id__preview_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "transcript_id",
+            "required": true,
+            "schema": {
+              "title": "Transcript Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsRetentionPreviewRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Preview Ops Retention",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/retention/{transcript_id}/purge": {
+      "post": {
+        "description": "Purge an eligible transcript and record the action.",
+        "operationId": "purge_ops_transcript_endpoint_api_v2_ops_retention__transcript_id__purge_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "transcript_id",
+            "required": true,
+            "schema": {
+              "title": "Transcript Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsTranscriptPurgeRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Purge Ops Transcript Endpoint",
+        "tags": [
+          "v2",
+          "ops"
         ]
       }
     },

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -464,6 +464,214 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/ops/audit-log": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Ops Audit Log
+         * @description List immutable audit records, newest first.
+         */
+        get: operations["get_ops_audit_log_api_v2_ops_audit_log_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/ops/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Ops Metrics
+         * @description Return operational dashboard metrics.
+         */
+        get: operations["get_ops_metrics_api_v2_ops_metrics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/ops/pipelines": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Ops Pipelines
+         * @description Return recent ingestion run activity.
+         */
+        get: operations["get_ops_pipelines_api_v2_ops_pipelines_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/ops/podcasts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Ops Podcasts Endpoint
+         * @description List managed podcasts with filters and count sorting.
+         */
+        get: operations["list_ops_podcasts_endpoint_api_v2_ops_podcasts_get"];
+        put?: never;
+        /**
+         * Create Ops Podcast Endpoint
+         * @description Create a managed podcast and record the action.
+         */
+        post: operations["create_ops_podcast_endpoint_api_v2_ops_podcasts_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/ops/podcasts/{podcast_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Ops Podcast Endpoint
+         * @description Return one managed podcast summary.
+         */
+        get: operations["get_ops_podcast_endpoint_api_v2_ops_podcasts__podcast_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Ops Podcast Endpoint
+         * @description Partially update a managed podcast and record the action.
+         */
+        patch: operations["update_ops_podcast_endpoint_api_v2_ops_podcasts__podcast_id__patch"];
+        trace?: never;
+    };
+    "/api/v2/ops/podcasts/{podcast_id}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Archive Ops Podcast Endpoint
+         * @description Pause a managed podcast and record the action.
+         */
+        post: operations["archive_ops_podcast_endpoint_api_v2_ops_podcasts__podcast_id__archive_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/ops/retention": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Ops Retention
+         * @description List recent transcript assets for retention review.
+         */
+        get: operations["list_ops_retention_api_v2_ops_retention_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/ops/retention/{transcript_id}/apply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Apply Ops Retention
+         * @description Persist a retention evaluation and record the action.
+         */
+        post: operations["apply_ops_retention_api_v2_ops_retention__transcript_id__apply_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/ops/retention/{transcript_id}/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Preview Ops Retention
+         * @description Dry-run the retention policy for one transcript.
+         */
+        get: operations["preview_ops_retention_api_v2_ops_retention__transcript_id__preview_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/ops/retention/{transcript_id}/purge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Purge Ops Transcript Endpoint
+         * @description Purge an eligible transcript and record the action.
+         */
+        post: operations["purge_ops_transcript_endpoint_api_v2_ops_retention__transcript_id__purge_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/podcasts": {
         parameters: {
             query?: never;
@@ -960,6 +1168,307 @@ export interface components {
             /** Timestamp Seconds */
             timestamp_seconds: number | null;
         };
+        /**
+         * OpsAlertDeliveryRead
+         * @description Generated and delivered account notification health.
+         */
+        OpsAlertDeliveryRead: {
+            /** Delivered Digests Last 24H */
+            delivered_digests_last_24h: number;
+            /** Delivered Events Last 24H */
+            delivered_events_last_24h: number;
+            /** Generated Events Last 24H */
+            generated_events_last_24h: number;
+            /** Pending Events */
+            pending_events: number;
+        };
+        /**
+         * OpsAuditLogEntryRead
+         * @description One immutable audit record.
+         */
+        OpsAuditLogEntryRead: {
+            /** Action */
+            action: string;
+            /** Actor Name */
+            actor_name: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Id */
+            id: number;
+            /** Metadata Json */
+            metadata_json: {
+                [key: string]: unknown;
+            } | null;
+            /** Resource Id */
+            resource_id: number | null;
+            /** Resource Identifier */
+            resource_identifier: string | null;
+            /** Resource Type */
+            resource_type: string;
+            /** Summary */
+            summary: string;
+        };
+        /**
+         * OpsAuditLogListRead
+         * @description Paginated audit log payload.
+         */
+        OpsAuditLogListRead: {
+            /** Items */
+            items: components["schemas"]["OpsAuditLogEntryRead"][];
+            /** Page */
+            page: number;
+            /** Per Page */
+            per_page: number;
+            /** Total */
+            total: number;
+        };
+        /**
+         * OpsIngestionRunRead
+         * @description Ingestion run summary for pipeline views.
+         */
+        OpsIngestionRunRead: {
+            /** Completed At */
+            completed_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Duration Seconds */
+            duration_seconds: number | null;
+            /** Error Summary */
+            error_summary: string | null;
+            /** Id */
+            id: number;
+            /** Started At */
+            started_at: string | null;
+            /** Status */
+            status: string;
+        };
+        /**
+         * OpsMetricsRead
+         * @description Combined operational metrics for the ops dashboard.
+         */
+        OpsMetricsRead: {
+            alerts: components["schemas"]["OpsAlertDeliveryRead"];
+            /**
+             * Measured At
+             * Format: date-time
+             */
+            measured_at: string;
+            review: components["schemas"]["OpsReviewThroughputRead"];
+        };
+        /**
+         * OpsPipelineActivityRead
+         * @description Recent pipeline activity.
+         */
+        OpsPipelineActivityRead: {
+            /** Runs */
+            runs: components["schemas"]["OpsIngestionRunRead"][];
+        };
+        /**
+         * OpsPodcastCreateRequest
+         * @description Create a managed podcast.
+         */
+        OpsPodcastCreateRequest: {
+            /** Cover Url */
+            cover_url?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Discovery Source */
+            discovery_source?: string | null;
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
+            /** @default {} */
+            sources: components["schemas"]["OpsPodcastSourcesInput"];
+            /** @default watchlist */
+            status: components["schemas"]["PodcastStatus"];
+        };
+        /**
+         * OpsPodcastListRead
+         * @description Paginated podcast management payload.
+         */
+        OpsPodcastListRead: {
+            /** Items */
+            items: components["schemas"]["OpsPodcastRead"][];
+            /** Page */
+            page: number;
+            /** Per Page */
+            per_page: number;
+            /** Total */
+            total: number;
+        };
+        /**
+         * OpsPodcastRead
+         * @description Podcast summary for ops catalog management views.
+         */
+        OpsPodcastRead: {
+            /** Cover Url */
+            cover_url: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Description */
+            description: string | null;
+            /** Discovery Source */
+            discovery_source: string | null;
+            /** Episode Count */
+            episode_count: number;
+            /** Id */
+            id: number;
+            /** Mention Count */
+            mention_count: number;
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
+            sources: components["schemas"]["OpsPodcastSourcesRead"];
+            status: components["schemas"]["PodcastStatus"];
+        };
+        /**
+         * OpsPodcastSourcesInput
+         * @description Source identifiers accepted on podcast mutations.
+         */
+        OpsPodcastSourcesInput: {
+            /** Apple Id */
+            apple_id?: string | null;
+            /** Podscripts Slug */
+            podscripts_slug?: string | null;
+            /** Rss Url */
+            rss_url?: string | null;
+            /** Spotify Id */
+            spotify_id?: string | null;
+            /** Youtube Channel Id */
+            youtube_channel_id?: string | null;
+        };
+        /**
+         * OpsPodcastSourcesRead
+         * @description Source identifiers associated with a managed podcast.
+         */
+        OpsPodcastSourcesRead: {
+            /** Apple Id */
+            apple_id: string | null;
+            /** Podscripts Slug */
+            podscripts_slug: string | null;
+            /** Rss Url */
+            rss_url: string | null;
+            /** Spotify Id */
+            spotify_id: string | null;
+            /** Youtube Channel Id */
+            youtube_channel_id: string | null;
+        };
+        /**
+         * OpsPodcastUpdateRequest
+         * @description Partially update a managed podcast; only provided fields change.
+         */
+        OpsPodcastUpdateRequest: {
+            /** Cover Url */
+            cover_url?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Discovery Source */
+            discovery_source?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Slug */
+            slug?: string | null;
+            sources?: components["schemas"]["OpsPodcastSourcesInput"] | null;
+            status?: components["schemas"]["PodcastStatus"] | null;
+        };
+        /**
+         * OpsRetentionDecisionRead
+         * @description Lifecycle decision produced by a retention evaluation.
+         */
+        OpsRetentionDecisionRead: {
+            /** Age Days */
+            age_days: number;
+            /** Purge Blockers */
+            purge_blockers: string[];
+            /** Purge Eligible */
+            purge_eligible: boolean;
+            /** Retention Suppressed */
+            retention_suppressed: boolean;
+            /** Tier */
+            tier: string;
+        };
+        /**
+         * OpsRetentionPreviewRead
+         * @description Dry-run lifecycle result plus derivative safety gate.
+         */
+        OpsRetentionPreviewRead: {
+            decision: components["schemas"]["OpsRetentionDecisionRead"];
+            /** Derivative Coverage Ready */
+            derivative_coverage_ready: boolean;
+            /** Extraction Confidence */
+            extraction_confidence: number | null;
+            /** Missing Query Classes */
+            missing_query_classes: string[];
+            transcript: components["schemas"]["OpsTranscriptRetentionRead"];
+        };
+        /**
+         * OpsReviewThroughputRead
+         * @description Review decision activity and outstanding pressure.
+         */
+        OpsReviewThroughputRead: {
+            /** Decisions Last 24H */
+            decisions_last_24h: number;
+            /** Median Decision Minutes Last 24H */
+            median_decision_minutes_last_24h: number | null;
+            /** Pending Items */
+            pending_items: number;
+        };
+        /**
+         * OpsTranscriptPurgeRead
+         * @description Result of an operator-approved transcript purge.
+         */
+        OpsTranscriptPurgeRead: {
+            /** Digest Id */
+            digest_id: number;
+            transcript: components["schemas"]["OpsTranscriptRetentionRead"];
+        };
+        /**
+         * OpsTranscriptRetentionRead
+         * @description Operator-facing state for one raw transcript asset.
+         */
+        OpsTranscriptRetentionRead: {
+            /** Digest Id */
+            digest_id: number | null;
+            /** Episode Id */
+            episode_id: number;
+            /** Episode Title */
+            episode_title: string;
+            /** Fetched At */
+            fetched_at: string | null;
+            /** Has Raw Payload */
+            has_raw_payload: boolean;
+            /** Has Stored Artifact */
+            has_stored_artifact: boolean;
+            /** Id */
+            id: number;
+            /** Podcast Name */
+            podcast_name: string;
+            /** Policy Version */
+            policy_version: string | null;
+            /** Provider */
+            provider: string;
+            /** Purge Eligible At */
+            purge_eligible_at: string | null;
+            /** Purged At */
+            purged_at: string | null;
+            /** Retention Exempt Sample */
+            retention_exempt_sample: boolean;
+            /** Source Retention Opt Out */
+            source_retention_opt_out: boolean;
+            /** Tier */
+            tier: string;
+        };
         /** Page[EpisodeRead] */
         Page_EpisodeRead_: {
             /** Items */
@@ -1028,6 +1537,18 @@ export interface components {
             /** Slug */
             slug: string;
         };
+        /**
+         * PodcastSourceType
+         * @description Supported source filters for ops podcast management views.
+         * @enum {string}
+         */
+        PodcastSourceType: "rss" | "spotify" | "apple" | "youtube" | "podscripts";
+        /**
+         * PodcastStatus
+         * @description Status of a podcast in the processing workflow.
+         * @enum {string}
+         */
+        PodcastStatus: "watchlist" | "active" | "paused";
         /**
          * PreferenceRead
          * @description Notification preferences for the current account.
@@ -1883,6 +2404,380 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Page_MentionRead_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_ops_audit_log_api_v2_ops_audit_log_get: {
+        parameters: {
+            query?: {
+                page?: number;
+                per_page?: number;
+                resource_type?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsAuditLogListRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_ops_metrics_api_v2_ops_metrics_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsMetricsRead"];
+                };
+            };
+        };
+    };
+    get_ops_pipelines_api_v2_ops_pipelines_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsPipelineActivityRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_ops_podcasts_endpoint_api_v2_ops_podcasts_get: {
+        parameters: {
+            query?: {
+                page?: number;
+                per_page?: number;
+                status?: components["schemas"]["PodcastStatus"] | null;
+                source?: components["schemas"]["PodcastSourceType"] | null;
+                sort?: "created_at" | "name" | "episode_count" | "mention_count";
+                order?: "asc" | "desc";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsPodcastListRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_ops_podcast_endpoint_api_v2_ops_podcasts_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OpsPodcastCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsPodcastRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_ops_podcast_endpoint_api_v2_ops_podcasts__podcast_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                podcast_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsPodcastRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_ops_podcast_endpoint_api_v2_ops_podcasts__podcast_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                podcast_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OpsPodcastUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsPodcastRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archive_ops_podcast_endpoint_api_v2_ops_podcasts__podcast_id__archive_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                podcast_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsPodcastRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_ops_retention_api_v2_ops_retention_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsTranscriptRetentionRead"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    apply_ops_retention_api_v2_ops_retention__transcript_id__apply_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                transcript_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsRetentionPreviewRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_ops_retention_api_v2_ops_retention__transcript_id__preview_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                transcript_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsRetentionPreviewRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    purge_ops_transcript_endpoint_api_v2_ops_retention__transcript_id__purge_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                transcript_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsTranscriptPurgeRead"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

First ops-console slices of the #108 split stack: the immutable audit log, podcast manager backend, pipeline/metrics/retention operator services, and a guarded `/api/v2/ops` API. The ops UI follows and is what closes #68–#73; transcription-job and search-projection pieces stay with their own themes.

## Type

- [x] `feat` — New feature

## Changes Made

- Add `AuditLog` model + `audit_log` service (immutable records for privileged actions) and `cover_url` on `Podcast`, migration `0015`
- Add `ops_podcast_queries`/`ops_podcast_commands`: list with status/source filters and count sorting, create, partial update, archive
- Add `pipeline_queries` (ingestion run summaries with computed durations), `ops_metrics` (review throughput + alert delivery), and `ops_retention_commands` (list, dry-run preview with the derivative purge-safety gate, policy apply, coverage-gated purge, re-acquisition)
- Add `/api/v2/ops` endpoints for metrics, podcasts CRUD/archive, pipelines, retention preview/apply/purge, and audit-log listing; mutations record audit entries
- Ops surface is disabled (503) until `PODEX_OPS_API_KEY` is configured; requests authenticate via `X-Ops-Key` (401 otherwise)
- Regenerate OpenAPI artifact and frontend API types; extend the read-only catalog invariant exemption to `/api/v2/ops`
- Add service and API test suites (11 tests)

## Closes

- Relates to #68
- Relates to #69
- Relates to #70
- Relates to #108

## Testing

- [x] Added ops service and API tests
- [x] Full backend suite passes with coverage ≥85% (86.69%)
- [x] Migration replay + schema-drift guard passes

## Quality Checks

- [x] `lintro chk` (ruff, mypy, bandit, pydoclint) clean — health 100/100
- [x] `ruff format` applied

## Checklist

- [x] Code follows repo conventions
- [x] Ops key defaults empty; no real hostnames or secrets (#108 boundary)