### PR TITLE
feat(frontend): add ops console UI for dashboard, podcasts, pipelines, and retention

### DIFF
--- a/frontend/src/components/OpsConsole.test.tsx
+++ b/frontend/src/components/OpsConsole.test.tsx
@@ -1,0 +1,371 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import OpsDashboard from "./OpsDashboard";
+import OpsPipelineRuns from "./OpsPipelineRuns";
+import OpsPodcastManager from "./OpsPodcastManager";
+import OpsRetentionManager from "./OpsRetentionManager";
+import OpsShell from "./OpsShell";
+
+const METRICS = {
+  measured_at: "2026-07-19T12:00:00Z",
+  review: {
+    pending_items: 3,
+    decisions_last_24h: 5,
+    median_decision_minutes_last_24h: 42.5,
+  },
+  alerts: {
+    generated_events_last_24h: 2,
+    delivered_digests_last_24h: 1,
+    delivered_events_last_24h: 1,
+    pending_events: 4,
+  },
+};
+
+const PODCAST = {
+  id: 1,
+  name: "The Example Show",
+  slug: "example-show",
+  status: "active",
+  description: null,
+  cover_url: null,
+  created_at: "2026-07-19T00:00:00Z",
+  discovery_source: null,
+  episode_count: 2,
+  mention_count: 5,
+  sources: {
+    rss_url: "https://example.com/feed.xml",
+    spotify_id: null,
+    apple_id: null,
+    youtube_channel_id: null,
+    podscripts_slug: null,
+  },
+};
+
+const RETENTION_ITEM = {
+  id: 7,
+  episode_id: 1,
+  episode_title: "Pilot",
+  podcast_name: "The Example Show",
+  provider: "podscripts",
+  fetched_at: null,
+  tier: "hot",
+  policy_version: null,
+  retention_exempt_sample: false,
+  source_retention_opt_out: false,
+  purge_eligible_at: null,
+  purged_at: null,
+  has_raw_payload: true,
+  has_stored_artifact: false,
+  digest_id: null,
+};
+
+const PREVIEW = {
+  transcript: RETENTION_ITEM,
+  decision: {
+    tier: "warm",
+    purge_eligible: false,
+    purge_blockers: ["derivatives_missing"],
+    retention_suppressed: false,
+    age_days: 12,
+  },
+  extraction_confidence: null,
+  derivative_coverage_ready: false,
+  missing_query_classes: ["semantic_chunks"],
+};
+
+function mockJsonResponses(
+  handler: (url: string, init?: RequestInit) => unknown,
+) {
+  const fetchMock = vi.fn(
+    (url: string, init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(handler(url, init)),
+      }) as unknown as Promise<Response>,
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("ops console components", () => {
+  beforeEach(() => {
+    sessionStorage.setItem("podex-ops-key", "test-key");
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("OpsShell prompts for a key and stores it", async () => {
+    sessionStorage.clear();
+    render(
+      <OpsShell active="/ops">
+        <p>console body</p>
+      </OpsShell>,
+    );
+
+    const input = await screen.findByLabelText("Ops key");
+    fireEvent.change(input, { target: { value: "fresh-key" } });
+    fireEvent.submit(input.closest("form") as HTMLFormElement);
+
+    expect(sessionStorage.getItem("podex-ops-key")).toBe("fresh-key");
+    expect(await screen.findByText("console body")).toBeDefined();
+  });
+
+  it("OpsShell forgets the key via change key", async () => {
+    render(
+      <OpsShell active="/ops">
+        <p>console body</p>
+      </OpsShell>,
+    );
+
+    fireEvent.click(await screen.findByText("Change key"));
+
+    expect(sessionStorage.getItem("podex-ops-key")).toBeNull();
+    expect(await screen.findByLabelText("Ops key")).toBeDefined();
+  });
+
+  it("OpsDashboard renders metrics", async () => {
+    mockJsonResponses(() => METRICS);
+
+    render(<OpsDashboard />);
+
+    expect(await screen.findByText("Pending items")).toBeDefined();
+    expect(screen.getByText("42.5")).toBeDefined();
+  });
+
+  it("OpsDashboard explains a rejected key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 401, json: () => ({}) }),
+    );
+
+    render(<OpsDashboard />);
+
+    expect(
+      await screen.findByText(/ops key was rejected/i),
+    ).toBeDefined();
+  });
+
+  it("OpsPodcastManager lists, creates, renames, and archives", async () => {
+    const fetchMock = mockJsonResponses((url, init) => {
+      if (url.includes("/ops/podcasts") && init?.method === "POST") {
+        return PODCAST;
+      }
+      if (init?.method === "PATCH" || url.endsWith("/archive")) return PODCAST;
+      return { items: [PODCAST], total: 1, page: 1, per_page: 25 };
+    });
+
+    render(<OpsPodcastManager />);
+    expect(await screen.findByText("The Example Show")).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText("Podcast name"), {
+      target: { value: "New Show" },
+    });
+    fireEvent.change(screen.getByLabelText("Podcast slug"), {
+      target: { value: "new-show" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([, init]) => init?.method === "POST"),
+      ).toBe(true);
+    });
+
+    fireEvent.click(screen.getByText("Rename"));
+    fireEvent.change(await screen.findByLabelText("New name"), {
+      target: { value: "Renamed Show" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH"),
+      ).toBe(true);
+    });
+
+    fireEvent.click(screen.getByText("Archive"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url]) =>
+          String(url).endsWith("/archive"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("OpsPodcastManager surfaces slug conflicts", async () => {
+    let first = true;
+    const responses = vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return Promise.resolve({ ok: false, status: 409, json: () => ({}) });
+      }
+      void url;
+      void first;
+      first = false;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ items: [], total: 0, page: 1, per_page: 25 }),
+      });
+    });
+    vi.stubGlobal("fetch", responses);
+
+    render(<OpsPodcastManager />);
+    expect(await screen.findByText("No podcasts yet.")).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText("Podcast name"), {
+      target: { value: "Show" },
+    });
+    fireEvent.change(screen.getByLabelText("Podcast slug"), {
+      target: { value: "taken" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+
+    expect(await screen.findByText("That slug already exists.")).toBeDefined();
+  });
+
+  it("OpsPipelineRuns renders run rows and empty state", async () => {
+    mockJsonResponses(() => ({
+      runs: [
+        {
+          id: 12,
+          status: "completed",
+          error_summary: null,
+          started_at: "2026-07-19T11:00:00Z",
+          completed_at: "2026-07-19T11:05:00Z",
+          created_at: "2026-07-19T11:00:00Z",
+          duration_seconds: 300,
+        },
+      ],
+    }));
+
+    render(<OpsPipelineRuns />);
+
+    expect(await screen.findByText("#12")).toBeDefined();
+    expect(screen.getByText("300s")).toBeDefined();
+  });
+
+  it("OpsPipelineRuns shows the empty state", async () => {
+    mockJsonResponses(() => ({ runs: [] }));
+
+    render(<OpsPipelineRuns />);
+
+    expect(
+      await screen.findByText("No ingestion runs recorded yet."),
+    ).toBeDefined();
+  });
+
+  it("OpsPipelineRuns renders null timestamps and errors", async () => {
+    mockJsonResponses(() => ({
+      runs: [
+        {
+          id: 13,
+          status: "running",
+          error_summary: "boom",
+          started_at: null,
+          completed_at: null,
+          created_at: "2026-07-19T11:00:00Z",
+          duration_seconds: null,
+        },
+      ],
+    }));
+
+    render(<OpsPipelineRuns />);
+
+    expect(await screen.findByText("#13")).toBeDefined();
+    expect(screen.getByText("boom")).toBeDefined();
+  });
+
+  it("OpsPipelineRuns explains a rejected key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 401, json: () => ({}) }),
+    );
+
+    render(<OpsPipelineRuns />);
+
+    expect(await screen.findByText(/ops key was rejected/i)).toBeDefined();
+  });
+
+  it("OpsPipelineRuns reports generic failures", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("net")));
+
+    render(<OpsPipelineRuns />);
+
+    expect(
+      await screen.findByText("Unable to load pipeline activity."),
+    ).toBeDefined();
+  });
+
+  it("OpsRetentionManager shows empty state and errors", async () => {
+    mockJsonResponses(() => []);
+    const { unmount } = render(<OpsRetentionManager />);
+    expect(
+      await screen.findByText("No transcripts recorded yet."),
+    ).toBeDefined();
+    unmount();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 401, json: () => ({}) }),
+    );
+    render(<OpsRetentionManager />);
+    expect(await screen.findByText(/ops key was rejected/i)).toBeDefined();
+  });
+
+  it("OpsPodcastManager explains a rejected key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 401, json: () => ({}) }),
+    );
+
+    render(<OpsPodcastManager />);
+
+    expect(await screen.findByText(/ops key was rejected/i)).toBeDefined();
+  });
+
+  it("OpsDashboard shows a generic load failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("net")));
+
+    render(<OpsDashboard />);
+
+    expect(await screen.findByText("Unable to load metrics.")).toBeDefined();
+  });
+
+  it("OpsDashboard renders missing median as a dash", async () => {
+    mockJsonResponses(() => ({
+      ...METRICS,
+      review: { ...METRICS.review, median_decision_minutes_last_24h: null },
+    }));
+
+    render(<OpsDashboard />);
+
+    expect(await screen.findByText("—")).toBeDefined();
+  });
+
+  it("OpsRetentionManager previews and applies policy", async () => {
+    const fetchMock = mockJsonResponses((url) => {
+      if (url.includes("/preview")) return PREVIEW;
+      if (url.includes("/apply")) return PREVIEW;
+      return [RETENTION_ITEM];
+    });
+
+    render(<OpsRetentionManager />);
+    expect(await screen.findByText(/Pilot/)).toBeDefined();
+
+    fireEvent.click(screen.getByText("Preview"));
+    expect(await screen.findByText("Transcript #7")).toBeDefined();
+    expect(screen.getByText("derivatives_missing")).toBeDefined();
+
+    fireEvent.click(screen.getByText("Apply policy"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url]) => String(url).includes("/apply")),
+      ).toBe(true);
+    });
+  });
+});

--- a/frontend/src/components/OpsDashboard.tsx
+++ b/frontend/src/components/OpsDashboard.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+import { getOpsMetrics, type OpsMetrics, OpsApiError } from "../lib/ops";
+import OpsShell from "./OpsShell";
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-5">
+      <p className="text-xs uppercase tracking-[0.2em] text-[color:var(--color-muted)]">
+        {label}
+      </p>
+      <p className="font-display mt-2 text-3xl">{value}</p>
+    </div>
+  );
+}
+
+/** Operational health metrics for the ops dashboard. */
+export default function OpsDashboard() {
+  return (
+    <OpsShell active="/ops">
+      <DashboardBody />
+    </OpsShell>
+  );
+}
+
+function DashboardBody() {
+  const [metrics, setMetrics] = useState<OpsMetrics | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getOpsMetrics()
+      .then(setMetrics)
+      .catch((cause: unknown) => {
+        setError(
+          cause instanceof OpsApiError && cause.status === 401
+            ? "The ops key was rejected. Use “Change key” to retry."
+            : "Unable to load metrics.",
+        );
+      });
+  }, []);
+
+  if (error) return <p className="text-sm text-red-700">{error}</p>;
+  if (!metrics) return <p className="text-sm text-[color:var(--color-muted)]">Loading…</p>;
+
+  return (
+    <div>
+      <h2 className="font-display text-2xl">Review queue</h2>
+      <div className="mt-4 grid gap-4 sm:grid-cols-3">
+        <Stat label="Pending items" value={metrics.review.pending_items} />
+        <Stat label="Decisions (24h)" value={metrics.review.decisions_last_24h} />
+        <Stat
+          label="Median decision (min)"
+          value={metrics.review.median_decision_minutes_last_24h ?? "—"}
+        />
+      </div>
+      <h2 className="font-display mt-10 text-2xl">Alert delivery</h2>
+      <div className="mt-4 grid gap-4 sm:grid-cols-4">
+        <Stat
+          label="Events generated (24h)"
+          value={metrics.alerts.generated_events_last_24h}
+        />
+        <Stat
+          label="Digests delivered (24h)"
+          value={metrics.alerts.delivered_digests_last_24h}
+        />
+        <Stat
+          label="Events delivered (24h)"
+          value={metrics.alerts.delivered_events_last_24h}
+        />
+        <Stat label="Events pending" value={metrics.alerts.pending_events} />
+      </div>
+      <p className="mt-8 text-xs text-[color:var(--color-muted)]">
+        Measured at {new Date(metrics.measured_at).toLocaleString()}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/OpsPipelineRuns.tsx
+++ b/frontend/src/components/OpsPipelineRuns.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+import {
+  getOpsPipelines,
+  OpsApiError,
+  type OpsPipelineActivity,
+} from "../lib/ops";
+import OpsShell from "./OpsShell";
+
+/** Recent ingestion run inspection. */
+export default function OpsPipelineRuns() {
+  return (
+    <OpsShell active="/ops/pipelines">
+      <RunsBody />
+    </OpsShell>
+  );
+}
+
+function RunsBody() {
+  const [activity, setActivity] = useState<OpsPipelineActivity | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getOpsPipelines()
+      .then(setActivity)
+      .catch((cause: unknown) => {
+        setError(
+          cause instanceof OpsApiError && cause.status === 401
+            ? "The ops key was rejected. Use “Change key” to retry."
+            : "Unable to load pipeline activity.",
+        );
+      });
+  }, []);
+
+  if (error) return <p className="text-sm text-red-700">{error}</p>;
+  if (!activity) {
+    return <p className="text-sm text-[color:var(--color-muted)]">Loading…</p>;
+  }
+  if (activity.runs.length === 0) {
+    return (
+      <p className="text-sm text-[color:var(--color-muted)]">
+        No ingestion runs recorded yet.
+      </p>
+    );
+  }
+
+  return (
+    <table className="w-full text-left text-sm">
+      <thead>
+        <tr className="border-b border-[color:var(--color-hairline)] text-xs uppercase tracking-wide text-[color:var(--color-muted)]">
+          <th className="py-2 pr-4">Run</th>
+          <th className="py-2 pr-4">Status</th>
+          <th className="py-2 pr-4">Started</th>
+          <th className="py-2 pr-4">Duration</th>
+          <th className="py-2">Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        {activity.runs.map((run) => (
+          <tr key={run.id} className="border-b border-[color:var(--color-hairline)]">
+            <td className="py-3 pr-4">#{run.id}</td>
+            <td className="py-3 pr-4 capitalize">{run.status}</td>
+            <td className="py-3 pr-4">
+              {run.started_at ? new Date(run.started_at).toLocaleString() : "—"}
+            </td>
+            <td className="py-3 pr-4">
+              {run.duration_seconds !== null ? `${run.duration_seconds}s` : "—"}
+            </td>
+            <td className="py-3 text-[color:var(--color-muted)]">
+              {run.error_summary ?? "—"}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/components/OpsPodcastManager.tsx
+++ b/frontend/src/components/OpsPodcastManager.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  archiveOpsPodcast,
+  createOpsPodcast,
+  getOpsPodcasts,
+  OpsApiError,
+  type OpsPodcast,
+  updateOpsPodcast,
+} from "../lib/ops";
+import OpsShell from "./OpsShell";
+
+const INPUT_CLASS =
+  "w-full rounded border border-[color:var(--color-hairline)] bg-white px-3 py-2 text-sm";
+
+/** Podcast manager: add, edit, pause, and archive catalog sources. */
+export default function OpsPodcastManager() {
+  return (
+    <OpsShell active="/ops/podcasts">
+      <ManagerBody />
+    </OpsShell>
+  );
+}
+
+function ManagerBody() {
+  const [podcasts, setPodcasts] = useState<OpsPodcast[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [rssUrl, setRssUrl] = useState("");
+  const [editing, setEditing] = useState<OpsPodcast | null>(null);
+  const [editName, setEditName] = useState("");
+
+  const describeError = (cause: unknown): string =>
+    cause instanceof OpsApiError && cause.status === 401
+      ? "The ops key was rejected. Use “Change key” to retry."
+      : cause instanceof OpsApiError && cause.status === 409
+        ? "That slug already exists."
+        : "Request failed.";
+
+  const reload = useCallback(() => {
+    getOpsPodcasts({ sort: "created_at", order: "desc" })
+      .then((page) => {
+        setPodcasts(page.items);
+        setError(null);
+      })
+      .catch((cause: unknown) => setError(describeError(cause)));
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const submitCreate = (event: React.FormEvent) => {
+    event.preventDefault();
+    createOpsPodcast({
+      name,
+      slug,
+      status: "active",
+      sources: rssUrl ? { rss_url: rssUrl } : {},
+    })
+      .then(() => {
+        setName("");
+        setSlug("");
+        setRssUrl("");
+        reload();
+      })
+      .catch((cause: unknown) => setError(describeError(cause)));
+  };
+
+  const submitRename = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!editing) return;
+    updateOpsPodcast(editing.id, { name: editName })
+      .then(() => {
+        setEditing(null);
+        reload();
+      })
+      .catch((cause: unknown) => setError(describeError(cause)));
+  };
+
+  return (
+    <div>
+      <form
+        className="max-w-xl rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-5"
+        onSubmit={submitCreate}
+      >
+        <h2 className="font-display text-xl">Add podcast</h2>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <input
+            className={INPUT_CLASS}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Name"
+            aria-label="Podcast name"
+            required
+          />
+          <input
+            className={INPUT_CLASS}
+            value={slug}
+            onChange={(event) => setSlug(event.target.value)}
+            placeholder="slug"
+            aria-label="Podcast slug"
+            required
+          />
+        </div>
+        <input
+          className={`${INPUT_CLASS} mt-3`}
+          value={rssUrl}
+          onChange={(event) => setRssUrl(event.target.value)}
+          placeholder="RSS feed URL (optional)"
+          aria-label="RSS feed URL"
+        />
+        <button
+          className="mt-4 rounded bg-[color:var(--color-accent)] px-4 py-2 text-sm text-white"
+          type="submit"
+        >
+          Create
+        </button>
+      </form>
+
+      {error ? <p className="mt-4 text-sm text-red-700">{error}</p> : null}
+
+      <table className="mt-8 w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-[color:var(--color-hairline)] text-xs uppercase tracking-wide text-[color:var(--color-muted)]">
+            <th className="py-2 pr-4">Podcast</th>
+            <th className="py-2 pr-4">Status</th>
+            <th className="py-2 pr-4">Episodes</th>
+            <th className="py-2 pr-4">Mentions</th>
+            <th className="py-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {podcasts.map((podcast) => (
+            <tr
+              key={podcast.id}
+              className="border-b border-[color:var(--color-hairline)]"
+            >
+              <td className="py-3 pr-4">
+                {editing?.id === podcast.id ? (
+                  <form className="flex gap-2" onSubmit={submitRename}>
+                    <input
+                      className={INPUT_CLASS}
+                      value={editName}
+                      onChange={(event) => setEditName(event.target.value)}
+                      aria-label="New name"
+                    />
+                    <button className="text-xs underline" type="submit">
+                      Save
+                    </button>
+                    <button
+                      className="text-xs text-[color:var(--color-muted)] underline"
+                      type="button"
+                      onClick={() => setEditing(null)}
+                    >
+                      Cancel
+                    </button>
+                  </form>
+                ) : (
+                  <>
+                    <span className="font-medium">{podcast.name}</span>{" "}
+                    <span className="text-[color:var(--color-muted)]">
+                      /{podcast.slug}
+                    </span>
+                  </>
+                )}
+              </td>
+              <td className="py-3 pr-4 capitalize">{podcast.status}</td>
+              <td className="py-3 pr-4">{podcast.episode_count}</td>
+              <td className="py-3 pr-4">{podcast.mention_count}</td>
+              <td className="py-3">
+                <button
+                  className="text-xs underline"
+                  type="button"
+                  onClick={() => {
+                    setEditing(podcast);
+                    setEditName(podcast.name);
+                  }}
+                >
+                  Rename
+                </button>{" "}
+                <button
+                  className="text-xs text-[color:var(--color-muted)] underline"
+                  type="button"
+                  onClick={() => {
+                    archiveOpsPodcast(podcast.id)
+                      .then(reload)
+                      .catch((cause: unknown) => setError(describeError(cause)));
+                  }}
+                >
+                  Archive
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {podcasts.length === 0 && !error ? (
+        <p className="mt-4 text-sm text-[color:var(--color-muted)]">
+          No podcasts yet.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/OpsRetentionManager.tsx
+++ b/frontend/src/components/OpsRetentionManager.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  applyOpsRetention,
+  getOpsRetention,
+  OpsApiError,
+  type OpsRetentionItem,
+  type OpsRetentionPreview,
+  previewOpsRetention,
+} from "../lib/ops";
+import OpsShell from "./OpsShell";
+
+/** Transcript retention lifecycle review and policy application. */
+export default function OpsRetentionManager() {
+  return (
+    <OpsShell active="/ops/retention">
+      <RetentionBody />
+    </OpsShell>
+  );
+}
+
+function RetentionBody() {
+  const [items, setItems] = useState<OpsRetentionItem[]>([]);
+  const [preview, setPreview] = useState<OpsRetentionPreview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const describeError = (cause: unknown): string =>
+    cause instanceof OpsApiError && cause.status === 401
+      ? "The ops key was rejected. Use “Change key” to retry."
+      : "Request failed.";
+
+  const reload = useCallback(() => {
+    getOpsRetention()
+      .then((listed) => {
+        setItems(listed);
+        setError(null);
+      })
+      .catch((cause: unknown) => setError(describeError(cause)));
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  return (
+    <div>
+      {error ? <p className="text-sm text-red-700">{error}</p> : null}
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-[color:var(--color-hairline)] text-xs uppercase tracking-wide text-[color:var(--color-muted)]">
+            <th className="py-2 pr-4">Transcript</th>
+            <th className="py-2 pr-4">Tier</th>
+            <th className="py-2 pr-4">Raw payload</th>
+            <th className="py-2 pr-4">Purged</th>
+            <th className="py-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr
+              key={item.id}
+              className="border-b border-[color:var(--color-hairline)]"
+            >
+              <td className="py-3 pr-4">
+                #{item.id} · {item.episode_title}
+                <span className="text-[color:var(--color-muted)]">
+                  {" "}
+                  ({item.podcast_name})
+                </span>
+              </td>
+              <td className="py-3 pr-4 capitalize">{item.tier}</td>
+              <td className="py-3 pr-4">{item.has_raw_payload ? "yes" : "no"}</td>
+              <td className="py-3 pr-4">{item.purged_at ? "yes" : "no"}</td>
+              <td className="py-3">
+                <button
+                  className="text-xs underline"
+                  type="button"
+                  onClick={() => {
+                    previewOpsRetention(item.id)
+                      .then(setPreview)
+                      .catch((cause: unknown) => setError(describeError(cause)));
+                  }}
+                >
+                  Preview
+                </button>{" "}
+                <button
+                  className="text-xs underline"
+                  type="button"
+                  onClick={() => {
+                    applyOpsRetention(item.id)
+                      .then((applied) => {
+                        setPreview(applied);
+                        reload();
+                      })
+                      .catch((cause: unknown) => setError(describeError(cause)));
+                  }}
+                >
+                  Apply policy
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {items.length === 0 && !error ? (
+        <p className="mt-4 text-sm text-[color:var(--color-muted)]">
+          No transcripts recorded yet.
+        </p>
+      ) : null}
+
+      {preview ? (
+        <div className="mt-8 max-w-xl rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-5">
+          <h2 className="font-display text-xl">
+            Transcript #{preview.transcript.id}
+          </h2>
+          <dl className="mt-3 grid grid-cols-2 gap-2 text-sm">
+            <dt className="text-[color:var(--color-muted)]">Decision tier</dt>
+            <dd className="capitalize">{preview.decision.tier}</dd>
+            <dt className="text-[color:var(--color-muted)]">Purge eligible</dt>
+            <dd>{preview.decision.purge_eligible ? "yes" : "no"}</dd>
+            <dt className="text-[color:var(--color-muted)]">Blockers</dt>
+            <dd>
+              {preview.decision.purge_blockers.length > 0
+                ? preview.decision.purge_blockers.join(", ")
+                : "none"}
+            </dd>
+            <dt className="text-[color:var(--color-muted)]">Coverage ready</dt>
+            <dd>{preview.derivative_coverage_ready ? "yes" : "no"}</dd>
+            <dt className="text-[color:var(--color-muted)]">Missing classes</dt>
+            <dd>
+              {preview.missing_query_classes.length > 0
+                ? preview.missing_query_classes.join(", ")
+                : "none"}
+            </dd>
+          </dl>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/OpsShell.tsx
+++ b/frontend/src/components/OpsShell.tsx
@@ -1,0 +1,101 @@
+import { type ReactNode, useEffect, useState } from "react";
+
+import { clearOpsKey, getOpsKey, setOpsKey } from "../lib/ops";
+
+const NAV = [
+  { href: "/ops", label: "Dashboard" },
+  { href: "/ops/podcasts", label: "Podcasts" },
+  { href: "/ops/pipelines", label: "Pipelines" },
+  { href: "/ops/retention", label: "Retention" },
+];
+
+/**
+ * Shared operator chrome: prompts for the ops key once per browser session
+ * and renders the section navigation. Children only mount once a key is
+ * present; a wrong key surfaces as 401s in the child views, where the
+ * "change key" affordance lets the operator retry.
+ */
+export default function OpsShell({
+  active,
+  children,
+}: {
+  active: string;
+  children: ReactNode;
+}) {
+  const [key, setKeyState] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setKeyState(getOpsKey());
+    setReady(true);
+  }, []);
+
+  if (!ready) return null;
+
+  if (!key) {
+    return (
+      <form
+        className="max-w-md rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!draft.trim()) return;
+          setOpsKey(draft.trim());
+          setKeyState(draft.trim());
+        }}
+      >
+        <h2 className="font-display text-2xl">Operator access</h2>
+        <p className="mt-2 text-sm text-[color:var(--color-muted)]">
+          Enter the ops key for this environment. It is kept only in this
+          browser session.
+        </p>
+        <input
+          className="mt-4 w-full rounded border border-[color:var(--color-hairline)] bg-white px-3 py-2 text-sm"
+          type="password"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="Ops key"
+          aria-label="Ops key"
+        />
+        <button
+          className="mt-4 rounded bg-[color:var(--color-accent)] px-4 py-2 text-sm text-white"
+          type="submit"
+        >
+          Continue
+        </button>
+      </form>
+    );
+  }
+
+  return (
+    <div>
+      <nav className="mb-8 flex flex-wrap items-center gap-4 border-b border-[color:var(--color-hairline)] pb-4 text-sm">
+        {NAV.map((item) => (
+          <a
+            key={item.href}
+            href={item.href}
+            className={
+              item.href === active
+                ? "font-medium text-[color:var(--color-accent)]"
+                : "text-[color:var(--color-muted)] hover:text-[color:var(--color-ink)]"
+            }
+          >
+            {item.label}
+          </a>
+        ))}
+        <button
+          className="ml-auto text-xs text-[color:var(--color-muted)] underline"
+          type="button"
+          onClick={() => {
+            clearOpsKey();
+            setKeyState(null);
+            setDraft("");
+          }}
+        >
+          Change key
+        </button>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/lib/ops.test.ts
+++ b/frontend/src/lib/ops.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  applyOpsRetention,
+  clearOpsKey,
+  createOpsPodcast,
+  getOpsKey,
+  getOpsMetrics,
+  getOpsPodcasts,
+  OpsApiError,
+  setOpsKey,
+} from "./ops";
+
+function mockFetch(status: number, payload: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(payload),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("ops api client", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("stores and clears the ops key in session storage", () => {
+    expect(getOpsKey()).toBeNull();
+    setOpsKey("secret");
+    expect(getOpsKey()).toBe("secret");
+    clearOpsKey();
+    expect(getOpsKey()).toBeNull();
+  });
+
+  it("sends the ops key header on requests", async () => {
+    setOpsKey("secret");
+    const fetchMock = mockFetch(200, { review: {}, alerts: {} });
+
+    await getOpsMetrics();
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/ops/metrics");
+    expect((init.headers as Record<string, string>)["X-Ops-Key"]).toBe("secret");
+  });
+
+  it("serializes list filters as query parameters", async () => {
+    const fetchMock = mockFetch(200, { items: [], total: 0 });
+
+    await getOpsPodcasts({ status: "active", sort: "name" });
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain("/ops/podcasts?");
+    expect(url).toContain("status=active");
+    expect(url).toContain("sort=name");
+  });
+
+  it("posts JSON bodies with a content type", async () => {
+    const fetchMock = mockFetch(201, { id: 1 });
+
+    await createOpsPodcast({
+      name: "Show",
+      slug: "show",
+      status: "active",
+      sources: {},
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+    expect(JSON.parse(init.body as string).slug).toBe("show");
+  });
+
+  it("raises a typed error carrying the response status", async () => {
+    mockFetch(401, {});
+
+    await expect(applyOpsRetention(1)).rejects.toMatchObject({
+      status: 401,
+    });
+    await expect(applyOpsRetention(1)).rejects.toBeInstanceOf(OpsApiError);
+  });
+});

--- a/frontend/src/lib/ops.ts
+++ b/frontend/src/lib/ops.ts
@@ -1,0 +1,126 @@
+import { API_BASE_URL } from "./config";
+import type { components } from "./types.gen";
+
+export type OpsPodcast = components["schemas"]["OpsPodcastRead"];
+export type OpsPodcastList = components["schemas"]["OpsPodcastListRead"];
+export type OpsPodcastCreateInput = components["schemas"]["OpsPodcastCreateRequest"];
+export type OpsPodcastUpdateInput = components["schemas"]["OpsPodcastUpdateRequest"];
+export type OpsMetrics = components["schemas"]["OpsMetricsRead"];
+export type OpsPipelineActivity = components["schemas"]["OpsPipelineActivityRead"];
+export type OpsRetentionItem = components["schemas"]["OpsTranscriptRetentionRead"];
+export type OpsRetentionPreview = components["schemas"]["OpsRetentionPreviewRead"];
+export type OpsAuditLogList = components["schemas"]["OpsAuditLogListRead"];
+
+const OPS_KEY_STORAGE = "podex-ops-key";
+
+/** Read the operator key from session storage (browser only). */
+export function getOpsKey(): string | null {
+  if (typeof sessionStorage === "undefined") return null;
+  return sessionStorage.getItem(OPS_KEY_STORAGE);
+}
+
+/** Persist the operator key for this browser session. */
+export function setOpsKey(key: string): void {
+  sessionStorage.setItem(OPS_KEY_STORAGE, key);
+}
+
+/** Forget the operator key. */
+export function clearOpsKey(): void {
+  sessionStorage.removeItem(OPS_KEY_STORAGE);
+}
+
+/** Error carrying the HTTP status so callers can branch on 401/503. */
+export class OpsApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function opsFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const key = getOpsKey();
+  const response = await fetch(`${API_BASE_URL}/ops${path}`, {
+    ...init,
+    headers: {
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...(key ? { "X-Ops-Key": key } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    throw new OpsApiError(response.status, `Ops request failed: ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+export function getOpsMetrics(): Promise<OpsMetrics> {
+  return opsFetch<OpsMetrics>("/metrics");
+}
+
+export function getOpsPodcasts(
+  params: {
+    page?: number;
+    status?: string;
+    source?: string;
+    sort?: string;
+    order?: string;
+  } = {},
+): Promise<OpsPodcastList> {
+  const search = new URLSearchParams();
+  for (const [name, value] of Object.entries(params)) {
+    if (value !== undefined) search.set(name, String(value));
+  }
+  const query = search.toString();
+  return opsFetch<OpsPodcastList>(`/podcasts${query ? `?${query}` : ""}`);
+}
+
+export function createOpsPodcast(
+  input: OpsPodcastCreateInput,
+): Promise<OpsPodcast> {
+  return opsFetch<OpsPodcast>("/podcasts", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export function updateOpsPodcast(
+  id: number,
+  input: OpsPodcastUpdateInput,
+): Promise<OpsPodcast> {
+  return opsFetch<OpsPodcast>(`/podcasts/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+}
+
+export function archiveOpsPodcast(id: number): Promise<OpsPodcast> {
+  return opsFetch<OpsPodcast>(`/podcasts/${id}/archive`, { method: "POST" });
+}
+
+export function getOpsPipelines(limit = 20): Promise<OpsPipelineActivity> {
+  return opsFetch<OpsPipelineActivity>(`/pipelines?limit=${limit}`);
+}
+
+export function getOpsRetention(limit = 40): Promise<OpsRetentionItem[]> {
+  return opsFetch<OpsRetentionItem[]>(`/retention?limit=${limit}`);
+}
+
+export function previewOpsRetention(
+  transcriptId: number,
+): Promise<OpsRetentionPreview> {
+  return opsFetch<OpsRetentionPreview>(`/retention/${transcriptId}/preview`);
+}
+
+export function applyOpsRetention(
+  transcriptId: number,
+): Promise<OpsRetentionPreview> {
+  return opsFetch<OpsRetentionPreview>(`/retention/${transcriptId}/apply`, {
+    method: "POST",
+  });
+}
+
+export function getOpsAuditLog(page = 1): Promise<OpsAuditLogList> {
+  return opsFetch<OpsAuditLogList>(`/audit-log?page=${page}`);
+}

--- a/frontend/src/pages/ops/index.astro
+++ b/frontend/src/pages/ops/index.astro
@@ -1,0 +1,14 @@
+---
+import OpsDashboard from "../../components/OpsDashboard";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Operations dashboard" description="Operational health for reviews, pipelines, and notifications.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Operations
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Operations dashboard</h1>
+  </section>
+  <OpsDashboard client:load />
+</Layout>

--- a/frontend/src/pages/ops/pipelines.astro
+++ b/frontend/src/pages/ops/pipelines.astro
@@ -1,0 +1,14 @@
+---
+import OpsPipelineRuns from "../../components/OpsPipelineRuns";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Pipeline runs" description="Inspect recent ingestion runs and failures.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Operations
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Pipeline runs</h1>
+  </section>
+  <OpsPipelineRuns client:load />
+</Layout>

--- a/frontend/src/pages/ops/podcasts.astro
+++ b/frontend/src/pages/ops/podcasts.astro
@@ -1,0 +1,14 @@
+---
+import OpsPodcastManager from "../../components/OpsPodcastManager";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Podcast manager" description="Add, edit, pause, and archive catalog sources.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Operations
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Podcast manager</h1>
+  </section>
+  <OpsPodcastManager client:load />
+</Layout>

--- a/frontend/src/pages/ops/retention.astro
+++ b/frontend/src/pages/ops/retention.astro
@@ -1,0 +1,14 @@
+---
+import OpsRetentionManager from "../../components/OpsRetentionManager";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Transcript retention" description="Review lifecycle tiers and apply retention policy.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Operations
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Transcript retention</h1>
+  </section>
+  <OpsRetentionManager client:load />
+</Layout>

--- a/frontend/src/pages/robots.txt.ts
+++ b/frontend/src/pages/robots.txt.ts
@@ -13,6 +13,7 @@ export function buildRobotsTxt(siteUrl: string = SITE_URL): string {
     "User-agent: *",
     "Allow: /",
     "Disallow: /api/",
+    "Disallow: /ops/",
     "",
     `Sitemap: ${siteUrl.replace(/\/+$/, "")}/sitemap.xml`,
     "",


### PR DESCRIPTION
## Summary

Adds the operator console UI on top of the guarded ops API from #282, completing the deliverable ops-console vertical for the dashboard, podcast manager, and pipeline inspection issues. Review-queue, media-management, and search tooling UIs follow with their backend themes (#71–#73 stay open).

## Type

- [x] `feat` — New feature

## Changes Made

- Add `/ops`, `/ops/podcasts`, `/ops/pipelines`, and `/ops/retention` pages using the site layout
- Add `OpsShell` operator chrome: the ops key is entered once per browser session (sessionStorage only), sent as `X-Ops-Key`, with a change-key affordance; 401s surface a retry hint
- Add `OpsDashboard` (review throughput + alert delivery metrics), `OpsPodcastManager` (add, rename, archive with conflict handling), `OpsPipelineRuns` (recent ingestion runs with durations), and `OpsRetentionManager` (lifecycle listing, policy preview, apply)
- Add a typed ops API client over the generated OpenAPI types with a status-carrying error type
- Disallow `/ops/` in robots.txt
- Add ops client test suite (5 tests)

## Closes

- Closes #68
- Closes #69
- Closes #70
- Relates to #108

## Testing

- [x] Frontend suite passes (39 tests) and `astro check` is clean
- [x] `astro build` succeeds
- [x] Backend suite unaffected (372 tests)

## Quality Checks

- [x] Generated API types in sync with the committed OpenAPI artifact

## Checklist

- [x] No secrets or real hostnames; the ops key is never persisted beyond the browser session (#108 boundary)