### PR TITLE
feat(scheduler): promote scheduler into an explicit deployable with recurring digest and retention work

### DIFF
--- a/backend/src/podex/api/v2/ops.py
+++ b/backend/src/podex/api/v2/ops.py
@@ -16,6 +16,8 @@ from podex.schemas.ops import (
     OpsAuditLogEntryRead,
     OpsAuditLogListRead,
     OpsMetricsRead,
+    OpsOperationalAlertListRead,
+    OpsOperationalAlertRead,
     OpsPipelineActivityRead,
     OpsPodcastCreateRequest,
     OpsPodcastListRead,
@@ -29,6 +31,10 @@ from podex.schemas.ops import (
     PodcastSourceType,
 )
 from podex.services.audit_log import list_audit_logs, record_audit_log
+from podex.services.operational_alerts import (
+    OperationalAlertThresholdsData,
+    evaluate_operational_alerts,
+)
 from podex.services.ops_metrics import get_operational_metrics
 from podex.services.ops_podcast_commands import (
     CreateOpsPodcastInputData,
@@ -99,6 +105,31 @@ def get_ops_metrics(
     metrics = get_operational_metrics(db=db)
     db.commit()
     return OpsMetricsRead.model_validate(metrics, from_attributes=True)
+
+
+def get_ops_operational_alerts(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsOperationalAlertListRead:
+    """Return configured operational threshold breaches."""
+    _require_ops_access(request=request, settings=settings)
+    metrics = get_operational_metrics(db=db)
+    alerts = evaluate_operational_alerts(
+        metrics=metrics,
+        thresholds=OperationalAlertThresholdsData(
+            review_pending=settings.ops_review_pending_alert_threshold,
+            alert_delivery_pending=settings.ops_alert_delivery_pending_threshold,
+        ),
+    )
+    db.commit()
+    return OpsOperationalAlertListRead(
+        measured_at=metrics.measured_at,
+        alerts=[
+            OpsOperationalAlertRead.model_validate(alert, from_attributes=True)
+            for alert in alerts
+        ],
+    )
 
 
 def list_ops_podcasts_endpoint(
@@ -406,6 +437,12 @@ def get_ops_audit_log(
 
 
 router.add_api_route("/metrics", get_ops_metrics, methods=["GET"])
+router.add_api_route(
+    "/alerts",
+    get_ops_operational_alerts,
+    methods=["GET"],
+    response_model=OpsOperationalAlertListRead,
+)
 router.add_api_route(
     "/podcasts",
     list_ops_podcasts_endpoint,

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -87,6 +87,14 @@ class Settings(BaseSettings):
     # configured by the deployment environment; requests must present it in
     # the X-Ops-Key header.
     ops_api_key: str = ""
+    ops_review_pending_alert_threshold: int = 50
+    ops_alert_delivery_pending_threshold: int = 25
+
+    # Scheduler runner deployable. The loop plans due interval work and
+    # executes recurring discovery, digest delivery, and retention sweeps.
+    scheduler_tick_seconds: int = 60
+    scheduler_digest_interval_minutes: int = 1440
+    scheduler_retention_interval_minutes: int = 1440
 
 
 @lru_cache

--- a/backend/src/podex/scheduler_runner.py
+++ b/backend/src/podex/scheduler_runner.py
@@ -1,0 +1,137 @@
+"""Scheduler runner deployable.
+
+Runs the recurring-work loop as its own process (``python -m
+podex.scheduler_runner``): each tick reconciles schedules, plans due
+interval work, and executes pending discovery, digest delivery, and
+retention sweeps. The API deployable stays request-only; this process owns
+all background cadence.
+"""
+
+import signal
+import time
+from dataclasses import dataclass
+from types import FrameType
+
+from sqlalchemy.orm import Session
+
+from podex.config import Settings, get_settings
+from podex.database import SessionLocal
+from podex.logging_config import get_logger
+from podex.services.notification_delivery import DigestSender, build_digest_sender
+from podex.services.recurring_discovery import (
+    reconcile_recurring_discovery_schedules,
+    run_due_episode_discovery_work,
+)
+from podex.services.recurring_notifications import (
+    reconcile_notification_schedules,
+    run_due_digest_work,
+    run_due_retention_work,
+)
+from podex.services.scheduled_work import plan_due_scheduled_work
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class TickSummaryData:
+    """Work performed during a single scheduler tick."""
+
+    planned: int
+    discovery_runs: int
+    digest_runs: int
+    retention_runs: int
+
+
+def run_tick(
+    *,
+    db: Session,
+    settings: Settings,
+    digest_sender: DigestSender | None,
+) -> TickSummaryData:
+    """Run one scheduler tick: reconcile, plan, and execute due work.
+
+    Args:
+        db: Database session.
+        settings: Runtime settings controlling cadences.
+        digest_sender: Configured digest delivery boundary, if any.
+
+    Returns:
+        Summary of the work performed this tick.
+    """
+    reconcile_recurring_discovery_schedules(db=db)
+    reconcile_notification_schedules(
+        db=db,
+        digest_interval_minutes=settings.scheduler_digest_interval_minutes,
+        retention_interval_minutes=settings.scheduler_retention_interval_minutes,
+    )
+    planned = plan_due_scheduled_work(db=db)
+    discovery = run_due_episode_discovery_work(db=db)
+    digests = run_due_digest_work(db=db, sender=digest_sender)
+    retention = run_due_retention_work(db=db)
+    db.commit()
+    return TickSummaryData(
+        planned=len(planned),
+        discovery_runs=len(discovery),
+        digest_runs=len(digests),
+        retention_runs=len(retention),
+    )
+
+
+class SchedulerRunner:
+    """Long-running loop that executes scheduler ticks until stopped."""
+
+    def __init__(self, *, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self._stopping = False
+
+    def request_stop(self, signum: int, frame: FrameType | None) -> None:
+        """Signal handler that ends the loop after the current tick."""
+        del signum, frame
+        self._stopping = True
+
+    def run_forever(self) -> None:
+        """Run ticks at the configured cadence until stop is requested."""
+        signal.signal(signal.SIGTERM, self.request_stop)
+        signal.signal(signal.SIGINT, self.request_stop)
+        logger.info(
+            "scheduler_runner_started tick_seconds=%s",
+            self.settings.scheduler_tick_seconds,
+        )
+        while not self._stopping:
+            db = SessionLocal()
+            try:
+                summary = run_tick(
+                    db=db,
+                    settings=self.settings,
+                    digest_sender=build_digest_sender(settings=self.settings),
+                )
+                logger.info(
+                    "scheduler_tick planned=%s discovery=%s digests=%s retention=%s",
+                    summary.planned,
+                    summary.discovery_runs,
+                    summary.digest_runs,
+                    summary.retention_runs,
+                )
+            except Exception:
+                db.rollback()
+                logger.exception("scheduler_tick_failed")
+            finally:
+                db.close()
+            self._sleep_until_next_tick()
+        logger.info("scheduler_runner_stopped")
+
+    def _sleep_until_next_tick(self) -> None:
+        """Sleep in one-second slices so stop requests stay responsive."""
+        for _ in range(self.settings.scheduler_tick_seconds):
+            if self._stopping:
+                return
+            time.sleep(1)
+
+
+def main() -> None:
+    """Entry point for the scheduler deployable."""
+    SchedulerRunner().run_forever()
+
+
+if __name__ == "__main__":  # pragma: no cover - process entry point
+    main()

--- a/backend/src/podex/schemas/ops.py
+++ b/backend/src/podex/schemas/ops.py
@@ -131,6 +131,27 @@ class OpsMetricsRead(BaseModel):
     alerts: OpsAlertDeliveryRead
 
 
+class OpsOperationalAlertRead(BaseModel):
+    """One actionable operator-facing health alert."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    key: str
+    severity: str
+    title: str
+    message: str
+    current_value: int
+    threshold: int
+    playbook_slug: str
+
+
+class OpsOperationalAlertListRead(BaseModel):
+    """Threshold breaches measured from operational metrics."""
+
+    measured_at: datetime
+    alerts: list[OpsOperationalAlertRead]
+
+
 class OpsTranscriptRetentionRead(BaseModel):
     """Operator-facing state for one raw transcript asset."""
 
@@ -214,6 +235,8 @@ __all__ = [
     "OpsAlertDeliveryRead",
     "OpsIngestionRunRead",
     "OpsMetricsRead",
+    "OpsOperationalAlertListRead",
+    "OpsOperationalAlertRead",
     "OpsPipelineActivityRead",
     "OpsPodcastCreateRequest",
     "OpsPodcastListRead",

--- a/backend/src/podex/services/operational_alerts.py
+++ b/backend/src/podex/services/operational_alerts.py
@@ -1,0 +1,61 @@
+"""Threshold-based alerts derived from operational health metrics."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from podex.services.ops_metrics import OperationalMetricsData
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalAlertThresholdsData:
+    """Configuration values that turn metric pressure into alerts."""
+
+    review_pending: int
+    alert_delivery_pending: int
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalAlertData:
+    """One actionable operator-facing health alert."""
+
+    key: str
+    severity: Literal["warning", "critical"]
+    title: str
+    message: str
+    current_value: int
+    threshold: int
+    playbook_slug: str
+
+
+def evaluate_operational_alerts(
+    *,
+    metrics: OperationalMetricsData,
+    thresholds: OperationalAlertThresholdsData,
+) -> list[OperationalAlertData]:
+    """Evaluate operational metrics against configured intervention thresholds."""
+    alerts: list[OperationalAlertData] = []
+    if metrics.review.pending_items >= thresholds.review_pending:
+        alerts.append(
+            OperationalAlertData(
+                key="review_backlog",
+                severity="warning",
+                title="Review queue backlog is elevated",
+                message="Pending review work is above the operator response threshold.",
+                current_value=metrics.review.pending_items,
+                threshold=thresholds.review_pending,
+                playbook_slug="review-backlog",
+            )
+        )
+    if metrics.alerts.pending_events >= thresholds.alert_delivery_pending:
+        alerts.append(
+            OperationalAlertData(
+                key="delivery_backlog",
+                severity="warning",
+                title="Notification delivery backlog is elevated",
+                message="Generated account alerts are awaiting digest delivery.",
+                current_value=metrics.alerts.pending_events,
+                threshold=thresholds.alert_delivery_pending,
+                playbook_slug="notification-delivery",
+            )
+        )
+    return alerts

--- a/backend/src/podex/services/recurring_notifications.py
+++ b/backend/src/podex/services/recurring_notifications.py
@@ -1,0 +1,220 @@
+"""Recurring digest delivery and retention sweep scheduled work."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    AccountPreference,
+    AccountUser,
+    ScheduledWorkItemModel,
+    ScheduledWorkStatus,
+    Transcript,
+)
+from podex.services.account_alerts import evaluate_alert_rules
+from podex.services.account_digests import send_pending_digest
+from podex.services.notification_delivery import DigestSender
+from podex.services.scheduled_work import (
+    PipelineScheduleInputData,
+    upsert_pipeline_schedule,
+)
+from podex.services.scheduler import ScheduledTaskKind
+from podex.services.transcript_retention import TranscriptRetentionPolicy
+from podex.services.transcript_retention_commands import (
+    evaluate_transcript_retention,
+)
+
+DIGEST_SCHEDULE_KEY = "notifications:digest-delivery"
+RETENTION_SCHEDULE_KEY = "retention:policy-sweep"
+
+
+@dataclass(frozen=True, slots=True)
+class DigestWorkRunData:
+    """Result of one recurring digest delivery sweep."""
+
+    work_key: str
+    users_evaluated: int
+    digests_delivered: int
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionWorkRunData:
+    """Result of one recurring retention evaluation sweep."""
+
+    work_key: str
+    transcripts_evaluated: int
+
+
+def reconcile_notification_schedules(
+    *,
+    db: Session,
+    digest_interval_minutes: int,
+    retention_interval_minutes: int,
+    now: datetime | None = None,
+) -> None:
+    """Ensure the digest delivery and retention sweep schedules exist.
+
+    Args:
+        db: Database session.
+        digest_interval_minutes: Cadence for digest delivery sweeps.
+        retention_interval_minutes: Cadence for retention evaluation sweeps.
+        now: Deterministic timestamp for next-due calculation.
+    """
+    upsert_pipeline_schedule(
+        db=db,
+        payload=PipelineScheduleInputData(
+            schedule_key=DIGEST_SCHEDULE_KEY,
+            task_kind=ScheduledTaskKind.DIGEST,
+            interval_minutes=digest_interval_minutes,
+        ),
+        now=now,
+    )
+    upsert_pipeline_schedule(
+        db=db,
+        payload=PipelineScheduleInputData(
+            schedule_key=RETENTION_SCHEDULE_KEY,
+            task_kind=ScheduledTaskKind.RETENTION,
+            interval_minutes=retention_interval_minutes,
+        ),
+        now=now,
+    )
+
+
+def run_due_digest_work(
+    *,
+    db: Session,
+    sender: DigestSender | None,
+    limit: int = 5,
+    now: datetime | None = None,
+) -> list[DigestWorkRunData]:
+    """Run pending digest work: evaluate rules and deliver pending digests.
+
+    Args:
+        db: Database session.
+        sender: Configured digest sender; without one, work stays pending so
+            deliveries resume when delivery is configured.
+        limit: Maximum pending work items to run.
+        now: Deterministic completion timestamp.
+
+    Returns:
+        Execution summaries for the work items that ran.
+    """
+    if sender is None:
+        return []
+    effective_now = now or datetime.now(UTC)
+    pending = _pending_items(db=db, task_kind=ScheduledTaskKind.DIGEST, limit=limit)
+    results: list[DigestWorkRunData] = []
+    for item in pending:
+        item.status = ScheduledWorkStatus.RUNNING.value
+        item.started_at = effective_now
+        db.flush()
+        users = (
+            db.query(AccountUser)
+            .join(
+                AccountPreference,
+                AccountPreference.user_id == AccountUser.id,
+            )
+            .filter(AccountPreference.digest_enabled.is_(True))
+            .order_by(AccountUser.id.asc())
+            .all()
+        )
+        delivered = 0
+        for user in users:
+            evaluate_alert_rules(db=db, user_id=user.id, now=effective_now)
+            digest = send_pending_digest(
+                db=db,
+                user=user,
+                sender=sender,
+                now=effective_now,
+            )
+            if digest is not None:
+                delivered += 1
+        item.status = ScheduledWorkStatus.COMPLETED.value
+        item.completed_at = effective_now
+        db.flush()
+        results.append(
+            DigestWorkRunData(
+                work_key=item.work_key,
+                users_evaluated=len(users),
+                digests_delivered=delivered,
+            ),
+        )
+    return results
+
+
+def run_due_retention_work(
+    *,
+    db: Session,
+    policy: TranscriptRetentionPolicy | None = None,
+    limit: int = 5,
+    batch_size: int = 200,
+    now: datetime | None = None,
+) -> list[RetentionWorkRunData]:
+    """Run pending retention work: evaluate lifecycle policy over transcripts.
+
+    Args:
+        db: Database session.
+        policy: Retention policy; defaults to the standard policy.
+        limit: Maximum pending work items to run.
+        batch_size: Maximum transcripts evaluated per work item.
+        now: Deterministic evaluation timestamp.
+
+    Returns:
+        Execution summaries for the work items that ran.
+    """
+    effective_policy = policy or TranscriptRetentionPolicy()
+    effective_now = now or datetime.now(UTC)
+    pending = _pending_items(
+        db=db,
+        task_kind=ScheduledTaskKind.RETENTION,
+        limit=limit,
+    )
+    results: list[RetentionWorkRunData] = []
+    for item in pending:
+        item.status = ScheduledWorkStatus.RUNNING.value
+        item.started_at = effective_now
+        db.flush()
+        transcripts = (
+            db.query(Transcript)
+            .filter(Transcript.purged_at.is_(None))
+            .order_by(Transcript.id.asc())
+            .limit(batch_size)
+            .all()
+        )
+        for transcript in transcripts:
+            evaluate_transcript_retention(
+                db=db,
+                transcript=transcript,
+                extraction_confidence=None,
+                source_retention_opt_out=transcript.source_retention_opt_out,
+                policy=effective_policy,
+                now=effective_now,
+            )
+        item.status = ScheduledWorkStatus.COMPLETED.value
+        item.completed_at = effective_now
+        db.flush()
+        results.append(
+            RetentionWorkRunData(
+                work_key=item.work_key,
+                transcripts_evaluated=len(transcripts),
+            ),
+        )
+    return results
+
+
+def _pending_items(
+    *,
+    db: Session,
+    task_kind: ScheduledTaskKind,
+    limit: int,
+) -> list[ScheduledWorkItemModel]:
+    """Load pending scheduled work items of one kind, oldest first."""
+    return list(
+        db.query(ScheduledWorkItemModel)
+        .filter(ScheduledWorkItemModel.status == ScheduledWorkStatus.PENDING.value)
+        .filter(ScheduledWorkItemModel.task_kind == task_kind.value)
+        .order_by(ScheduledWorkItemModel.due_at.asc(), ScheduledWorkItemModel.id.asc())
+        .limit(limit)
+        .all(),
+    )

--- a/backend/src/podex/services/scheduled_work.py
+++ b/backend/src/podex/services/scheduled_work.py
@@ -235,6 +235,9 @@ def _next_due_after(
     after: datetime,
 ) -> datetime:
     """Calculate the next due timestamp after a reference time."""
+    if start_at.tzinfo is None:
+        # SQLite returns naive datetimes; stored values are always UTC.
+        start_at = start_at.replace(tzinfo=UTC)
     if start_at > after:
         return start_at
     interval = timedelta(minutes=interval_minutes)

--- a/backend/tests/test_scheduler_runner.py
+++ b/backend/tests/test_scheduler_runner.py
@@ -1,0 +1,181 @@
+"""Tests for the scheduler runner, recurring work, and operational alerts."""
+
+from datetime import UTC, datetime
+
+from assertpy import assert_that
+from sqlalchemy.orm import Session
+
+from podex.config import Settings
+from podex.models import (
+    AccountPreference,
+    AccountUser,
+    Episode,
+    PipelineSchedule,
+    ScheduledWorkItemModel,
+    ScheduledWorkStatus,
+    Transcript,
+)
+from podex.scheduler_runner import run_tick
+from podex.services.account_alerts import create_alert_rule
+from podex.services.account_follows import follow_podcast
+from podex.services.operational_alerts import (
+    OperationalAlertThresholdsData,
+    evaluate_operational_alerts,
+)
+from podex.services.ops_metrics import get_operational_metrics
+from podex.services.recurring_notifications import (
+    DIGEST_SCHEDULE_KEY,
+    RETENTION_SCHEDULE_KEY,
+    reconcile_notification_schedules,
+    run_due_digest_work,
+    run_due_retention_work,
+)
+from podex.services.scheduled_work import plan_due_scheduled_work
+from tests.conftest import seed_catalog_graph
+
+_NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+
+
+class RecordingDigestSender:
+    """In-memory digest delivery for scheduler tests."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    def send_digest(self, *, email: str, subject: str, body_text: str) -> None:
+        """Record one delivered digest."""
+        del subject, body_text
+        self.sent.append(email)
+
+
+def _plan_notification_work(db_session: Session) -> None:
+    reconcile_notification_schedules(
+        db=db_session,
+        digest_interval_minutes=60,
+        retention_interval_minutes=60,
+        now=_NOW,
+    )
+    plan_due_scheduled_work(db=db_session, now=_NOW)
+
+
+def test_reconcile_notification_schedules_is_idempotent(
+    db_session: Session,
+) -> None:
+    """Reconciling twice keeps exactly one schedule per kind."""
+    _plan_notification_work(db_session)
+    _plan_notification_work(db_session)
+    db_session.commit()
+
+    keys = [
+        schedule.schedule_key for schedule in db_session.query(PipelineSchedule).all()
+    ]
+    assert_that(keys).contains(DIGEST_SCHEDULE_KEY, RETENTION_SCHEDULE_KEY)
+    assert_that(len(keys)).is_equal_to(len(set(keys)))
+
+
+def test_run_due_digest_work_delivers_and_completes(db_session: Session) -> None:
+    """Digest work evaluates rules, delivers digests, and completes items."""
+    graph = seed_catalog_graph(db_session)
+    user = AccountUser(email="reader@example.com")
+    db_session.add(user)
+    db_session.flush()
+    db_session.add(AccountPreference(user_id=user.id))
+    follow_podcast(db=db_session, user_id=user.id, podcast_id=graph.podcast_id)
+    create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="podcast",
+        target_id=graph.podcast_id,
+        event_type="new_episode",
+    )
+    db_session.add(
+        Episode(podcast_id=graph.podcast_id, title="Pilot II", episode_number=2),
+    )
+    _plan_notification_work(db_session)
+    db_session.commit()
+    sender = RecordingDigestSender()
+
+    skipped = run_due_digest_work(db=db_session, sender=None, now=_NOW)
+    assert_that(skipped).is_empty()
+
+    results = run_due_digest_work(db=db_session, sender=sender, now=_NOW)
+    db_session.commit()
+
+    assert_that(results).is_length(1)
+    assert_that(results[0].users_evaluated).is_equal_to(1)
+    assert_that(results[0].digests_delivered).is_equal_to(1)
+    assert_that(sender.sent).is_equal_to(["reader@example.com"])
+    item = (
+        db_session.query(ScheduledWorkItemModel)
+        .filter(ScheduledWorkItemModel.schedule_key == DIGEST_SCHEDULE_KEY)
+        .one()
+    )
+    assert_that(item.status).is_equal_to(ScheduledWorkStatus.COMPLETED.value)
+
+
+def test_run_due_retention_work_evaluates_transcripts(
+    db_session: Session,
+) -> None:
+    """Retention work evaluates unpurged transcripts and completes items."""
+    graph = seed_catalog_graph(db_session)
+    db_session.add(
+        Transcript(
+            episode_id=graph.episode_id,
+            provider="podscripts",
+            raw_text="raw",
+        ),
+    )
+    _plan_notification_work(db_session)
+    db_session.commit()
+
+    results = run_due_retention_work(db=db_session, now=_NOW)
+    db_session.commit()
+
+    assert_that(results).is_length(1)
+    assert_that(results[0].transcripts_evaluated).is_equal_to(1)
+    transcript = db_session.query(Transcript).one()
+    assert_that(transcript.retention_evaluated_at).is_not_none()
+
+
+def test_run_tick_plans_and_executes(db_session: Session) -> None:
+    """A single tick reconciles, plans, and executes due work."""
+    settings = Settings(
+        scheduler_digest_interval_minutes=60,
+        scheduler_retention_interval_minutes=60,
+    )
+
+    summary = run_tick(
+        db=db_session,
+        settings=settings,
+        digest_sender=RecordingDigestSender(),
+    )
+
+    assert_that(summary.planned).is_greater_than_or_equal_to(2)
+    assert_that(summary.digest_runs).is_equal_to(1)
+    assert_that(summary.retention_runs).is_equal_to(1)
+
+
+def test_operational_alerts_fire_on_thresholds(db_session: Session) -> None:
+    """Alerts fire only when metric pressure crosses configured thresholds."""
+    metrics = get_operational_metrics(db=db_session, now=_NOW)
+
+    quiet = evaluate_operational_alerts(
+        metrics=metrics,
+        thresholds=OperationalAlertThresholdsData(
+            review_pending=1,
+            alert_delivery_pending=1,
+        ),
+    )
+    assert_that(quiet).is_empty()
+
+    firing = evaluate_operational_alerts(
+        metrics=metrics,
+        thresholds=OperationalAlertThresholdsData(
+            review_pending=0,
+            alert_delivery_pending=0,
+        ),
+    )
+    assert_that([alert.key for alert in firing]).contains(
+        "review_backlog",
+        "delivery_backlog",
+    )

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -67,6 +67,21 @@ services:
       api:
         condition: service_healthy
 
+  scheduler:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    command: ["python", "-m", "podex.scheduler_runner"]
+    env_file:
+      - path: .env.staging
+        required: true
+    environment:
+      PODEX_ENVIRONMENT: ${PODEX_ENVIRONMENT:-staging}
+    depends_on:
+      db:
+        condition: service_healthy
+
   # Future services (not wired on main yet):
   #
   # redis:
@@ -78,11 +93,6 @@ services:
   #   env_file:
   #     - path: .env.staging
   #       required: true
-  #   ...
-  #
-  # worker / scheduler:
-  #   build: ./backend
-  #   command: ["python", "-m", "podex.worker"]
   #   ...
 
 volumes:

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1044,6 +1044,73 @@
         "title": "OpsMetricsRead",
         "type": "object"
       },
+      "OpsOperationalAlertListRead": {
+        "description": "Threshold breaches measured from operational metrics.",
+        "properties": {
+          "alerts": {
+            "items": {
+              "$ref": "#/components/schemas/OpsOperationalAlertRead"
+            },
+            "title": "Alerts",
+            "type": "array"
+          },
+          "measured_at": {
+            "format": "date-time",
+            "title": "Measured At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "measured_at",
+          "alerts"
+        ],
+        "title": "OpsOperationalAlertListRead",
+        "type": "object"
+      },
+      "OpsOperationalAlertRead": {
+        "description": "One actionable operator-facing health alert.",
+        "properties": {
+          "current_value": {
+            "title": "Current Value",
+            "type": "integer"
+          },
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "playbook_slug": {
+            "title": "Playbook Slug",
+            "type": "string"
+          },
+          "severity": {
+            "title": "Severity",
+            "type": "string"
+          },
+          "threshold": {
+            "title": "Threshold",
+            "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "severity",
+          "title",
+          "message",
+          "current_value",
+          "threshold",
+          "playbook_slug"
+        ],
+        "title": "OpsOperationalAlertRead",
+        "type": "object"
+      },
       "OpsPipelineActivityRead": {
         "description": "Recent pipeline activity.",
         "properties": {
@@ -3244,6 +3311,29 @@
         "tags": [
           "v2",
           "media"
+        ]
+      }
+    },
+    "/api/v2/ops/alerts": {
+      "get": {
+        "description": "Return configured operational threshold breaches.",
+        "operationId": "get_ops_operational_alerts_api_v2_ops_alerts_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsOperationalAlertListRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Ops Operational Alerts",
+        "tags": [
+          "v2",
+          "ops"
         ]
       }
     },

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -464,6 +464,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/ops/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Ops Operational Alerts
+         * @description Return configured operational threshold breaches.
+         */
+        get: operations["get_ops_operational_alerts_api_v2_ops_alerts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/ops/audit-log": {
         parameters: {
             query?: never;
@@ -1260,6 +1280,39 @@ export interface components {
              */
             measured_at: string;
             review: components["schemas"]["OpsReviewThroughputRead"];
+        };
+        /**
+         * OpsOperationalAlertListRead
+         * @description Threshold breaches measured from operational metrics.
+         */
+        OpsOperationalAlertListRead: {
+            /** Alerts */
+            alerts: components["schemas"]["OpsOperationalAlertRead"][];
+            /**
+             * Measured At
+             * Format: date-time
+             */
+            measured_at: string;
+        };
+        /**
+         * OpsOperationalAlertRead
+         * @description One actionable operator-facing health alert.
+         */
+        OpsOperationalAlertRead: {
+            /** Current Value */
+            current_value: number;
+            /** Key */
+            key: string;
+            /** Message */
+            message: string;
+            /** Playbook Slug */
+            playbook_slug: string;
+            /** Severity */
+            severity: string;
+            /** Threshold */
+            threshold: number;
+            /** Title */
+            title: string;
         };
         /**
          * OpsPipelineActivityRead
@@ -2413,6 +2466,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_ops_operational_alerts_api_v2_ops_alerts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsOperationalAlertListRead"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Scheduler/observability slice of the #108 split stack. The scheduler becomes its own deployable process owning all background cadence; recurring digest delivery and retention sweeps join the existing recurring discovery; and threshold-based operational alerts land behind the guarded ops surface. Reindex jobs and projection-lag metrics stay gated on the search theme, so #11/#88 remain open; #89's playbooks live in podex-ops per the content boundary.

## Type

- [x] `feat` — New feature

## Changes Made

- Add `podex/scheduler_runner.py`: tick loop (`python -m podex.scheduler_runner`) that reconciles schedules, plans due interval work, executes discovery/digest/retention work, commits per tick, logs summaries, and stops gracefully on SIGTERM/SIGINT
- Add `recurring_notifications.py`: digest-delivery work (evaluates alert rules and delivers pending digests for accounts with digests enabled; stays pending without a configured sender) and retention-sweep work (policy evaluation over unpurged transcripts), both idempotent via the scheduled-work model
- Port `operational_alerts.py` (review backlog + delivery backlog thresholds; projection alerts stay with the search theme) and expose `GET /api/v2/ops/alerts` behind the ops key
- Add scheduler cadence and alert-threshold settings with safe defaults; add the `scheduler` service to `docker-compose.staging.yml`
- Fix `_next_due_after` to normalize naive SQLite timestamps before comparison
- Regenerate OpenAPI artifact and frontend API types; add scheduler/alerts test suite (5 tests)

## Closes

- Closes #100
- Relates to #11
- Relates to #88
- Relates to #89
- Relates to #108

## Testing

- [x] Added scheduler runner, recurring work, and alert threshold tests
- [x] Full backend suite passes with coverage ≥85% (86.71%)
- [x] Migration replay + schema-drift guard passes

## Quality Checks

- [x] `lintro chk` (ruff, mypy, bandit, pydoclint) clean — health 100/100
- [x] `ruff format` applied

## Checklist

- [x] Code follows repo conventions
- [x] No playbook/runbook content in docs/; thresholds are counts, not tuned ranking values (#108 boundary)