### PR TITLE
feat(frontend): add account pages for sign-in, saved, follows, alerts, and settings

### DIFF
--- a/frontend/src/components/AccountAlerts.tsx
+++ b/frontend/src/components/AccountAlerts.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  type AlertRuleList,
+  deleteAlertRule,
+  getAlertRules,
+  setAlertRuleEnabled,
+} from "../lib/account";
+import AccountShell from "./AccountShell";
+
+/** Alert rules manager: pause, resume, and delete rules. */
+export default function AccountAlerts() {
+  return (
+    <AccountShell active="/account/alerts">{() => <AlertsBody />}</AccountShell>
+  );
+}
+
+function AlertsBody() {
+  const [rules, setRules] = useState<AlertRuleList | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(() => {
+    getAlertRules()
+      .then(setRules)
+      .catch(() => setError("Unable to load alert rules."));
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  if (error) return <p className="text-sm text-red-700">{error}</p>;
+  if (rules === null) {
+    return <p className="text-sm text-[color:var(--color-muted)]">Loading…</p>;
+  }
+  if (rules.items.length === 0) {
+    return (
+      <p className="text-sm text-[color:var(--color-muted)]">
+        No alert rules yet. Save media or follow podcasts, then create alerts
+        from their pages to get notified about new activity.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {rules.items.map((rule) => (
+        <li
+          key={rule.id}
+          className="flex items-center justify-between rounded-lg border border-[color:var(--color-hairline)] p-4"
+        >
+          <div>
+            <p className="font-medium">
+              {rule.event_type === "new_mention"
+                ? "New mentions of saved media"
+                : "New episodes from followed podcast"}
+              <span className="text-[color:var(--color-muted)]">
+                {" "}
+                · {rule.target_type} #{rule.target_id}
+              </span>
+            </p>
+            <p className="mt-1 text-xs text-[color:var(--color-muted)]">
+              {rule.enabled ? "active" : "paused"} · created{" "}
+              {new Date(rule.created_at).toLocaleDateString()}
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              className="text-xs underline"
+              type="button"
+              onClick={() => {
+                setAlertRuleEnabled(rule.id, !rule.enabled)
+                  .then(reload)
+                  .catch(() => setError("Unable to update that rule."));
+              }}
+            >
+              {rule.enabled ? "Pause" : "Resume"}
+            </button>
+            <button
+              className="text-xs text-[color:var(--color-muted)] underline"
+              type="button"
+              onClick={() => {
+                deleteAlertRule(rule.id)
+                  .then(reload)
+                  .catch(() => setError("Unable to delete that rule."));
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/AccountFollows.tsx
+++ b/frontend/src/components/AccountFollows.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  type FollowedPodcastList,
+  getFollowedPodcasts,
+  unfollowPodcast,
+} from "../lib/account";
+import AccountShell from "./AccountShell";
+
+/** Followed podcasts list with unfollow. */
+export default function AccountFollows() {
+  return (
+    <AccountShell active="/account/follows">
+      {() => <FollowsBody />}
+    </AccountShell>
+  );
+}
+
+function FollowsBody() {
+  const [follows, setFollows] = useState<FollowedPodcastList | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(() => {
+    getFollowedPodcasts()
+      .then(setFollows)
+      .catch(() => setError("Unable to load followed podcasts."));
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  if (error) return <p className="text-sm text-red-700">{error}</p>;
+  if (follows === null) {
+    return <p className="text-sm text-[color:var(--color-muted)]">Loading…</p>;
+  }
+  if (follows.items.length === 0) {
+    return (
+      <p className="text-sm text-[color:var(--color-muted)]">
+        You are not following any podcasts yet.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {follows.items.map((item) => (
+        <li
+          key={item.podcast.id}
+          className="flex items-center justify-between rounded-lg border border-[color:var(--color-hairline)] p-4"
+        >
+          <div>
+            <a
+              className="font-medium underline"
+              href={`/podcasts/${item.podcast.id}`}
+            >
+              {item.podcast.name}
+            </a>
+            <p className="mt-1 text-xs text-[color:var(--color-muted)]">
+              followed {new Date(item.followed_at).toLocaleDateString()}
+            </p>
+          </div>
+          <button
+            className="text-xs underline"
+            type="button"
+            onClick={() => {
+              unfollowPodcast(item.podcast.id)
+                .then(reload)
+                .catch(() => setError("Unable to unfollow that podcast."));
+            }}
+          >
+            Unfollow
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/AccountOverview.tsx
+++ b/frontend/src/components/AccountOverview.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+
+import { type DigestList, getDigests } from "../lib/account";
+import AccountShell from "./AccountShell";
+
+/** Account overview: identity summary and recent digest activity. */
+export default function AccountOverview() {
+  return (
+    <AccountShell active="/account">
+      {(user) => <OverviewBody email={user.email} createdAt={user.created_at} />}
+    </AccountShell>
+  );
+}
+
+function OverviewBody({
+  email,
+  createdAt,
+}: {
+  email: string;
+  createdAt: string;
+}) {
+  const [digests, setDigests] = useState<DigestList | null>(null);
+
+  useEffect(() => {
+    getDigests()
+      .then(setDigests)
+      .catch(() => setDigests({ items: [], total: 0 }));
+  }, []);
+
+  return (
+    <div>
+      <div className="max-w-xl rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-5">
+        <p className="text-xs uppercase tracking-[0.2em] text-[color:var(--color-muted)]">
+          Signed in as
+        </p>
+        <p className="font-display mt-2 text-2xl">{email}</p>
+        <p className="mt-1 text-sm text-[color:var(--color-muted)]">
+          Member since {new Date(createdAt).toLocaleDateString()}
+        </p>
+      </div>
+
+      <h2 className="font-display mt-10 text-2xl">Recent digests</h2>
+      {digests === null ? (
+        <p className="mt-3 text-sm text-[color:var(--color-muted)]">Loading…</p>
+      ) : digests.items.length === 0 ? (
+        <p className="mt-3 text-sm text-[color:var(--color-muted)]">
+          No digests delivered yet. Follow podcasts and save media, then set
+          up alerts to receive activity digests.
+        </p>
+      ) : (
+        <ul className="mt-3 space-y-3">
+          {digests.items.map((digest) => (
+            <li
+              key={digest.id}
+              className="rounded-lg border border-[color:var(--color-hairline)] p-4"
+            >
+              <p className="font-medium">{digest.subject}</p>
+              <p className="mt-1 text-xs text-[color:var(--color-muted)]">
+                {digest.event_count} update{digest.event_count === 1 ? "" : "s"}
+                {" · "}
+                {new Date(digest.created_at).toLocaleString()}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/AccountPages.test.tsx
+++ b/frontend/src/components/AccountPages.test.tsx
@@ -1,0 +1,380 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import AccountAlerts from "./AccountAlerts";
+import AccountFollows from "./AccountFollows";
+import AccountOverview from "./AccountOverview";
+import AccountSaved from "./AccountSaved";
+import AccountSettings from "./AccountSettings";
+import AccountShell from "./AccountShell";
+import MagicLinkVerify from "./MagicLinkVerify";
+
+const USER = {
+  id: 1,
+  email: "reader@example.com",
+  created_at: "2026-07-01T00:00:00Z",
+  last_signed_in_at: null,
+};
+
+const SAVED = {
+  items: [
+    {
+      media: {
+        id: 3,
+        type: "book",
+        title: "Dune",
+        author: "Herbert",
+        year: 1965,
+        description: null,
+        cover_url: null,
+        created_at: "2026-07-01T00:00:00Z",
+        public_id: "med_ae",
+      },
+      saved_at: "2026-07-10T00:00:00Z",
+    },
+  ],
+  total: 1,
+};
+
+const FOLLOWS = {
+  items: [
+    {
+      podcast: {
+        id: 2,
+        name: "The Example Show",
+        slug: "example-show",
+        description: null,
+        created_at: "2026-07-01T00:00:00Z",
+        public_id: "pod_ae",
+      },
+      followed_at: "2026-07-10T00:00:00Z",
+    },
+  ],
+  total: 1,
+};
+
+const RULES = {
+  items: [
+    {
+      id: 9,
+      target_type: "podcast",
+      target_id: 2,
+      event_type: "new_episode",
+      enabled: true,
+      baseline_count: 1,
+      last_evaluated_at: null,
+      created_at: "2026-07-10T00:00:00Z",
+    },
+  ],
+  total: 1,
+};
+
+const PREFERENCE = {
+  digest_enabled: true,
+  digest_frequency: "daily",
+  updated_at: "2026-07-10T00:00:00Z",
+};
+
+function mockRoutes(
+  routes: Record<string, unknown>,
+  overrides: Record<string, (init?: RequestInit) => unknown> = {},
+) {
+  const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+    const matched = Object.entries(overrides).find(([fragment]) =>
+      String(url).includes(fragment),
+    );
+    if (matched) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(matched[1](init)),
+      } as unknown as Response);
+    }
+    const found = Object.entries(routes).find(([fragment]) =>
+      String(url).endsWith(fragment),
+    );
+    if (!found) {
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(found[1]),
+    } as unknown as Response);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function mockAnonymous() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string, init?: RequestInit) => {
+      if (String(url).endsWith("/me")) {
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({}),
+        } as unknown as Response);
+      }
+      if (String(url).includes("/auth/magic-link/request")) {
+        return Promise.resolve({
+          ok: true,
+          status: 202,
+          json: () => Promise.resolve({ accepted: true }),
+        } as unknown as Response);
+      }
+      void init;
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+    }),
+  );
+}
+
+describe("account pages", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("AccountShell offers passwordless sign-in when anonymous", async () => {
+    mockAnonymous();
+
+    render(<AccountShell active="/account">{() => <p>body</p>}</AccountShell>);
+
+    const input = await screen.findByLabelText("Email address");
+    fireEvent.change(input, { target: { value: "reader@example.com" } });
+    fireEvent.click(screen.getByText("Email me a link"));
+
+    expect(await screen.findByText(/Check your email/)).toBeDefined();
+  });
+
+  it("AccountShell reports unavailable sign-in delivery", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) =>
+        Promise.resolve({
+          ok: false,
+          status: String(url).endsWith("/me") ? 401 : 503,
+          json: () => Promise.resolve({}),
+        } as unknown as Response),
+      ),
+    );
+
+    render(<AccountShell active="/account">{() => <p>body</p>}</AccountShell>);
+    const input = await screen.findByLabelText("Email address");
+    fireEvent.change(input, { target: { value: "reader@example.com" } });
+    fireEvent.click(screen.getByText("Email me a link"));
+
+    expect(
+      await screen.findByText("Email sign-in is not available right now."),
+    ).toBeDefined();
+  });
+
+  it("AccountShell shows a generic account error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("net")));
+
+    render(<AccountShell active="/account">{() => <p>body</p>}</AccountShell>);
+
+    expect(
+      await screen.findByText("Unable to load your account right now."),
+    ).toBeDefined();
+  });
+
+  it("AccountOverview shows identity and digests", async () => {
+    mockRoutes({
+      "/me/digests": {
+        items: [
+          {
+            id: 5,
+            channel: "email",
+            subject: "Podex digest: 2 new updates",
+            body_text: "…",
+            event_count: 2,
+            created_at: "2026-07-18T00:00:00Z",
+            delivered_at: "2026-07-18T00:00:00Z",
+          },
+        ],
+        total: 1,
+      },
+      "/me": USER,
+    });
+
+    render(<AccountOverview />);
+
+    expect((await screen.findAllByText("reader@example.com")).length).toBe(2);
+    expect(
+      await screen.findByText("Podex digest: 2 new updates"),
+    ).toBeDefined();
+  });
+
+  it("AccountSaved lists and removes saved media", async () => {
+    const fetchMock = mockRoutes(
+      { "/me/saves": SAVED, "/me": USER },
+      {},
+    );
+
+    render(<AccountSaved />);
+    expect(await screen.findByText("Dune")).toBeDefined();
+
+    fireEvent.click(screen.getByText("Remove"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([, init]) => init?.method === "DELETE"),
+      ).toBe(true);
+    });
+  });
+
+  it("AccountFollows lists and unfollows podcasts", async () => {
+    const fetchMock = mockRoutes({ "/me/follows": FOLLOWS, "/me": USER });
+
+    render(<AccountFollows />);
+    expect(await screen.findByText("The Example Show")).toBeDefined();
+
+    fireEvent.click(screen.getByText("Unfollow"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([, init]) => init?.method === "DELETE"),
+      ).toBe(true);
+    });
+  });
+
+  it("AccountAlerts pauses and deletes rules", async () => {
+    const fetchMock = mockRoutes(
+      { "/me/alerts": RULES, "/me": USER },
+      { "/me/alerts/9": () => ({ ...RULES.items[0], enabled: false }) },
+    );
+
+    render(<AccountAlerts />);
+    expect(
+      await screen.findByText(/New episodes from followed podcast/),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByText("Pause"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH"),
+      ).toBe(true);
+    });
+
+    fireEvent.click(screen.getByText("Delete"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([, init]) => init?.method === "DELETE"),
+      ).toBe(true);
+    });
+  });
+
+  it("AccountSaved shows empty and error states", async () => {
+    mockRoutes({ "/me/saves": { items: [], total: 0 }, "/me": USER });
+    const { unmount } = render(<AccountSaved />);
+    expect(await screen.findByText(/Nothing saved yet/)).toBeDefined();
+    unmount();
+
+    mockRoutes({ "/me": USER });
+    render(<AccountSaved />);
+    expect(
+      await screen.findByText("Unable to load saved media."),
+    ).toBeDefined();
+  });
+
+  it("AccountFollows shows empty and error states", async () => {
+    mockRoutes({ "/me/follows": { items: [], total: 0 }, "/me": USER });
+    const { unmount } = render(<AccountFollows />);
+    expect(
+      await screen.findByText("You are not following any podcasts yet."),
+    ).toBeDefined();
+    unmount();
+
+    mockRoutes({ "/me": USER });
+    render(<AccountFollows />);
+    expect(
+      await screen.findByText("Unable to load followed podcasts."),
+    ).toBeDefined();
+  });
+
+  it("AccountAlerts reports load failures", async () => {
+    mockRoutes({ "/me": USER });
+
+    render(<AccountAlerts />);
+
+    expect(
+      await screen.findByText("Unable to load alert rules."),
+    ).toBeDefined();
+  });
+
+  it("AccountSettings reports load failures", async () => {
+    mockRoutes({ "/me": USER });
+
+    render(<AccountSettings />);
+
+    expect(
+      await screen.findByText("Unable to load preferences."),
+    ).toBeDefined();
+  });
+
+  it("AccountAlerts shows the empty state", async () => {
+    mockRoutes({ "/me/alerts": { items: [], total: 0 }, "/me": USER });
+
+    render(<AccountAlerts />);
+
+    expect(await screen.findByText(/No alert rules yet/)).toBeDefined();
+  });
+
+  it("AccountSettings persists preference changes", async () => {
+    const fetchMock = mockRoutes(
+      { "/me/preferences": PREFERENCE, "/me": USER },
+      {},
+    );
+
+    render(<AccountSettings />);
+    const checkbox = await screen.findByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([, init]) => init?.method === "PATCH"),
+      ).toBe(true);
+    });
+    expect(await screen.findByText("Saved.")).toBeDefined();
+  });
+
+  it("MagicLinkVerify redeems the token and redirects", async () => {
+    mockRoutes({
+      "/auth/magic-link/verify": {
+        user: USER,
+        expires_at: "2026-08-18T00:00:00Z",
+      },
+    });
+    const assign = vi.fn();
+    vi.stubGlobal("location", {
+      ...window.location,
+      search: "?token=abc&redirect_path=/account/saved",
+      assign,
+    });
+
+    render(<MagicLinkVerify />);
+
+    await waitFor(() => {
+      expect(assign).toHaveBeenCalledWith("/account/saved");
+    });
+  });
+
+  it("MagicLinkVerify explains invalid links", async () => {
+    vi.stubGlobal("location", {
+      ...window.location,
+      search: "",
+      assign: vi.fn(),
+    });
+
+    render(<MagicLinkVerify />);
+
+    expect(await screen.findByText("Sign-in link invalid")).toBeDefined();
+  });
+});

--- a/frontend/src/components/AccountSaved.tsx
+++ b/frontend/src/components/AccountSaved.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  getSavedMedia,
+  removeSavedMedia,
+  type SavedMediaList,
+} from "../lib/account";
+import AccountShell from "./AccountShell";
+
+/** Saved media list with removal. */
+export default function AccountSaved() {
+  return (
+    <AccountShell active="/account/saved">{() => <SavedBody />}</AccountShell>
+  );
+}
+
+function SavedBody() {
+  const [saved, setSaved] = useState<SavedMediaList | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(() => {
+    getSavedMedia()
+      .then(setSaved)
+      .catch(() => setError("Unable to load saved media."));
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  if (error) return <p className="text-sm text-red-700">{error}</p>;
+  if (saved === null) {
+    return <p className="text-sm text-[color:var(--color-muted)]">Loading…</p>;
+  }
+  if (saved.items.length === 0) {
+    return (
+      <p className="text-sm text-[color:var(--color-muted)]">
+        Nothing saved yet. Browse the catalog and save media to keep it here.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {saved.items.map((item) => (
+        <li
+          key={item.media.id}
+          className="flex items-center justify-between rounded-lg border border-[color:var(--color-hairline)] p-4"
+        >
+          <div>
+            <a className="font-medium underline" href={`/media/${item.media.id}`}>
+              {item.media.title}
+            </a>
+            <p className="mt-1 text-xs text-[color:var(--color-muted)]">
+              {item.media.type}
+              {item.media.author ? ` · ${item.media.author}` : ""}
+              {" · saved "}
+              {new Date(item.saved_at).toLocaleDateString()}
+            </p>
+          </div>
+          <button
+            className="text-xs underline"
+            type="button"
+            onClick={() => {
+              removeSavedMedia(item.media.id)
+                .then(reload)
+                .catch(() => setError("Unable to remove that save."));
+            }}
+          >
+            Remove
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/AccountSettings.tsx
+++ b/frontend/src/components/AccountSettings.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+
+import {
+  getPreferences,
+  type Preference,
+  updatePreferences,
+} from "../lib/account";
+import AccountShell from "./AccountShell";
+
+const FREQUENCIES = ["immediate", "daily", "weekly"] as const;
+
+/** Notification preference settings. */
+export default function AccountSettings() {
+  return (
+    <AccountShell active="/account/settings">
+      {() => <SettingsBody />}
+    </AccountShell>
+  );
+}
+
+function SettingsBody() {
+  const [preference, setPreference] = useState<Preference | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    getPreferences()
+      .then(setPreference)
+      .catch(() => setError("Unable to load preferences."));
+  }, []);
+
+  if (error) return <p className="text-sm text-red-700">{error}</p>;
+  if (preference === null) {
+    return <p className="text-sm text-[color:var(--color-muted)]">Loading…</p>;
+  }
+
+  const persist = (next: {
+    digest_enabled: boolean;
+    digest_frequency: (typeof FREQUENCIES)[number];
+  }) => {
+    setSaved(false);
+    updatePreferences(next)
+      .then((updated) => {
+        setPreference(updated);
+        setSaved(true);
+      })
+      .catch(() => setError("Unable to save preferences."));
+  };
+
+  return (
+    <div className="max-w-xl rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-6">
+      <h2 className="font-display text-2xl">Notifications</h2>
+      <label className="mt-4 flex items-center gap-3 text-sm">
+        <input
+          type="checkbox"
+          checked={preference.digest_enabled}
+          onChange={(event) =>
+            persist({
+              digest_enabled: event.target.checked,
+              digest_frequency: preference.digest_frequency as
+                | "immediate"
+                | "daily"
+                | "weekly",
+            })
+          }
+        />
+        Send me activity digests by email
+      </label>
+      <label className="mt-4 block text-sm">
+        <span className="text-[color:var(--color-muted)]">Frequency</span>
+        <select
+          className="mt-1 block rounded border border-[color:var(--color-hairline)] bg-white px-3 py-2 text-sm"
+          value={preference.digest_frequency}
+          onChange={(event) =>
+            persist({
+              digest_enabled: preference.digest_enabled,
+              digest_frequency: event.target.value as
+                | "immediate"
+                | "daily"
+                | "weekly",
+            })
+          }
+        >
+          {FREQUENCIES.map((frequency) => (
+            <option key={frequency} value={frequency}>
+              {frequency}
+            </option>
+          ))}
+        </select>
+      </label>
+      {saved ? (
+        <p className="mt-4 text-sm text-[color:var(--color-accent)]">Saved.</p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/AccountShell.tsx
+++ b/frontend/src/components/AccountShell.tsx
@@ -1,0 +1,153 @@
+import { type ReactNode, useEffect, useState } from "react";
+
+import {
+  AccountApiError,
+  type AccountUser,
+  getMe,
+  logout,
+  requestMagicLink,
+} from "../lib/account";
+
+const NAV = [
+  { href: "/account", label: "Overview" },
+  { href: "/account/saved", label: "Saved" },
+  { href: "/account/follows", label: "Follows" },
+  { href: "/account/alerts", label: "Alerts" },
+  { href: "/account/settings", label: "Settings" },
+];
+
+/**
+ * Shared account chrome: resolves the signed-in user from the session
+ * cookie, offers passwordless sign-in when anonymous, and renders section
+ * navigation once authenticated.
+ */
+export default function AccountShell({
+  active,
+  children,
+}: {
+  active: string;
+  children: (user: AccountUser) => ReactNode;
+}) {
+  const [user, setUser] = useState<AccountUser | null>(null);
+  const [state, setState] = useState<"loading" | "anonymous" | "ready" | "error">(
+    "loading",
+  );
+  const [email, setEmail] = useState("");
+  const [requested, setRequested] = useState(false);
+  const [signInError, setSignInError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getMe()
+      .then((me) => {
+        setUser(me);
+        setState("ready");
+      })
+      .catch((cause: unknown) => {
+        setState(
+          cause instanceof AccountApiError && cause.status === 401
+            ? "anonymous"
+            : "error",
+        );
+      });
+  }, []);
+
+  if (state === "loading") {
+    return <p className="text-sm text-[color:var(--color-muted)]">Loading…</p>;
+  }
+
+  if (state === "error") {
+    return (
+      <p className="text-sm text-red-700">
+        Unable to load your account right now.
+      </p>
+    );
+  }
+
+  if (state === "anonymous" || user === null) {
+    return (
+      <form
+        className="max-w-md rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          setSignInError(null);
+          requestMagicLink(email, active)
+            .then(() => setRequested(true))
+            .catch((cause: unknown) => {
+              setSignInError(
+                cause instanceof AccountApiError && cause.status === 503
+                  ? "Email sign-in is not available right now."
+                  : "Unable to send the sign-in link.",
+              );
+            });
+        }}
+      >
+        <h2 className="font-display text-2xl">Sign in</h2>
+        {requested ? (
+          <p className="mt-3 text-sm text-[color:var(--color-muted)]">
+            Check your email — if the address is valid, a single-use sign-in
+            link is on its way.
+          </p>
+        ) : (
+          <>
+            <p className="mt-2 text-sm text-[color:var(--color-muted)]">
+              We will email you a single-use sign-in link. No password needed.
+            </p>
+            <input
+              className="mt-4 w-full rounded border border-[color:var(--color-hairline)] bg-white px-3 py-2 text-sm"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              aria-label="Email address"
+              required
+            />
+            <button
+              className="mt-4 rounded bg-[color:var(--color-accent)] px-4 py-2 text-sm text-white"
+              type="submit"
+            >
+              Email me a link
+            </button>
+            {signInError ? (
+              <p className="mt-3 text-sm text-red-700">{signInError}</p>
+            ) : null}
+          </>
+        )}
+      </form>
+    );
+  }
+
+  return (
+    <div>
+      <nav className="mb-8 flex flex-wrap items-center gap-4 border-b border-[color:var(--color-hairline)] pb-4 text-sm">
+        {NAV.map((item) => (
+          <a
+            key={item.href}
+            href={item.href}
+            className={
+              item.href === active
+                ? "font-medium text-[color:var(--color-accent)]"
+                : "text-[color:var(--color-muted)] hover:text-[color:var(--color-ink)]"
+            }
+          >
+            {item.label}
+          </a>
+        ))}
+        <span className="ml-auto text-xs text-[color:var(--color-muted)]">
+          {user.email}
+        </span>
+        <button
+          className="text-xs underline"
+          type="button"
+          onClick={() => {
+            logout().finally(() => {
+              window.location.assign("/account");
+            });
+          }}
+        >
+          Sign out
+        </button>
+      </nav>
+      {children(user)}
+    </div>
+  );
+}

--- a/frontend/src/components/MagicLinkVerify.tsx
+++ b/frontend/src/components/MagicLinkVerify.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+import { AccountApiError, verifyMagicLink } from "../lib/account";
+
+/**
+ * Redeems the one-time token from the emailed sign-in link and forwards the
+ * signed-in user to their requested destination.
+ */
+export default function MagicLinkVerify() {
+  const [state, setState] = useState<"working" | "failed">("working");
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("token");
+    if (!token) {
+      setState("failed");
+      return;
+    }
+    verifyMagicLink(token)
+      .then(() => {
+        const redirect = params.get("redirect_path");
+        window.location.assign(
+          redirect && redirect.startsWith("/") ? redirect : "/account",
+        );
+      })
+      .catch((cause: unknown) => {
+        void (cause instanceof AccountApiError);
+        setState("failed");
+      });
+  }, []);
+
+  if (state === "failed") {
+    return (
+      <div className="max-w-md rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-6">
+        <h2 className="font-display text-2xl">Sign-in link invalid</h2>
+        <p className="mt-2 text-sm text-[color:var(--color-muted)]">
+          This link has expired or was already used. Request a new one from
+          the <a className="underline" href="/account">account page</a>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <p className="text-sm text-[color:var(--color-muted)]">Signing you in…</p>
+  );
+}

--- a/frontend/src/lib/account.ts
+++ b/frontend/src/lib/account.ts
@@ -1,0 +1,127 @@
+import { API_BASE_URL } from "./config";
+import type { components } from "./types.gen";
+
+export type AccountUser = components["schemas"]["AccountUserRead"];
+export type SavedMediaList = components["schemas"]["SavedMediaListRead"];
+export type FollowedPodcastList =
+  components["schemas"]["FollowedPodcastListRead"];
+export type AlertRule = components["schemas"]["AlertRuleRead"];
+export type AlertRuleList = components["schemas"]["AlertRuleListRead"];
+export type DigestList = components["schemas"]["DigestListRead"];
+export type Preference = components["schemas"]["PreferenceRead"];
+export type AuthSession = components["schemas"]["AuthSessionRead"];
+
+/** Error carrying the HTTP status so callers can branch on 401/503. */
+export class AccountApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function accountFetch<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: "include",
+    ...init,
+    headers: {
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    throw new AccountApiError(
+      response.status,
+      `Account request failed: ${response.status}`,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+export function requestMagicLink(
+  email: string,
+  redirectPath?: string,
+): Promise<{ accepted: boolean }> {
+  return accountFetch("/auth/magic-link/request", {
+    method: "POST",
+    body: JSON.stringify({
+      email,
+      ...(redirectPath ? { redirect_path: redirectPath } : {}),
+    }),
+  });
+}
+
+export function verifyMagicLink(token: string): Promise<AuthSession> {
+  return accountFetch("/auth/magic-link/verify", {
+    method: "POST",
+    body: JSON.stringify({ token }),
+  });
+}
+
+export function logout(): Promise<{ signed_out: boolean }> {
+  return accountFetch("/auth/logout", { method: "POST" });
+}
+
+export function getMe(): Promise<AccountUser> {
+  return accountFetch("/me");
+}
+
+export function getSavedMedia(): Promise<SavedMediaList> {
+  return accountFetch("/me/saves");
+}
+
+export function removeSavedMedia(
+  mediaId: number,
+): Promise<{ deleted: boolean }> {
+  return accountFetch(`/me/saves/${mediaId}`, { method: "DELETE" });
+}
+
+export function getFollowedPodcasts(): Promise<FollowedPodcastList> {
+  return accountFetch("/me/follows");
+}
+
+export function unfollowPodcast(
+  podcastId: number,
+): Promise<{ deleted: boolean }> {
+  return accountFetch(`/me/follows/${podcastId}`, { method: "DELETE" });
+}
+
+export function getAlertRules(): Promise<AlertRuleList> {
+  return accountFetch("/me/alerts");
+}
+
+export function setAlertRuleEnabled(
+  ruleId: number,
+  enabled: boolean,
+): Promise<AlertRule> {
+  return accountFetch(`/me/alerts/${ruleId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ enabled }),
+  });
+}
+
+export function deleteAlertRule(ruleId: number): Promise<{ deleted: boolean }> {
+  return accountFetch(`/me/alerts/${ruleId}`, { method: "DELETE" });
+}
+
+export function getDigests(): Promise<DigestList> {
+  return accountFetch("/me/digests");
+}
+
+export function getPreferences(): Promise<Preference> {
+  return accountFetch("/me/preferences");
+}
+
+export function updatePreferences(input: {
+  digest_enabled: boolean;
+  digest_frequency: "immediate" | "daily" | "weekly";
+}): Promise<Preference> {
+  return accountFetch("/me/preferences", {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+}

--- a/frontend/src/pages/account/alerts.astro
+++ b/frontend/src/pages/account/alerts.astro
@@ -1,0 +1,14 @@
+---
+import AccountAlerts from "../../components/AccountAlerts";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Alerts" description="Your alert rules for new activity.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Account
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Alerts</h1>
+  </section>
+  <AccountAlerts client:load />
+</Layout>

--- a/frontend/src/pages/account/follows.astro
+++ b/frontend/src/pages/account/follows.astro
@@ -1,0 +1,14 @@
+---
+import AccountFollows from "../../components/AccountFollows";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Followed podcasts" description="Podcasts you follow.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Account
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Followed podcasts</h1>
+  </section>
+  <AccountFollows client:load />
+</Layout>

--- a/frontend/src/pages/account/index.astro
+++ b/frontend/src/pages/account/index.astro
@@ -1,0 +1,14 @@
+---
+import AccountOverview from "../../components/AccountOverview";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Your account" description="Overview of your Podex account and recent digests.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Account
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Your account</h1>
+  </section>
+  <AccountOverview client:load />
+</Layout>

--- a/frontend/src/pages/account/saved.astro
+++ b/frontend/src/pages/account/saved.astro
@@ -1,0 +1,14 @@
+---
+import AccountSaved from "../../components/AccountSaved";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Saved media" description="Media you saved from the catalog.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Account
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Saved media</h1>
+  </section>
+  <AccountSaved client:load />
+</Layout>

--- a/frontend/src/pages/account/settings.astro
+++ b/frontend/src/pages/account/settings.astro
@@ -1,0 +1,14 @@
+---
+import AccountSettings from "../../components/AccountSettings";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Settings" description="Notification preferences for your account.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Account
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Settings</h1>
+  </section>
+  <AccountSettings client:load />
+</Layout>

--- a/frontend/src/pages/auth/verify.astro
+++ b/frontend/src/pages/auth/verify.astro
@@ -1,0 +1,14 @@
+---
+import MagicLinkVerify from "../../components/MagicLinkVerify";
+import Layout from "../../layouts/Layout.astro";
+---
+
+<Layout title="Sign in" description="Completing your passwordless sign-in.">
+  <section class="mb-8 max-w-2xl">
+    <p class="text-xs uppercase tracking-[0.28em] text-[color:var(--color-accent)]">
+      Account
+    </p>
+    <h1 class="font-display mt-3 text-4xl tracking-tight">Sign in</h1>
+  </section>
+  <MagicLinkVerify client:load />
+</Layout>

--- a/frontend/src/pages/robots.txt.ts
+++ b/frontend/src/pages/robots.txt.ts
@@ -14,6 +14,8 @@ export function buildRobotsTxt(siteUrl: string = SITE_URL): string {
     "Allow: /",
     "Disallow: /api/",
     "Disallow: /ops/",
+    "Disallow: /account/",
+    "Disallow: /auth/",
     "",
     `Sitemap: ${siteUrl.replace(/\/+$/, "")}/sitemap.xml`,
     "",


### PR DESCRIPTION
## Summary

Adds the signed-in account experience on top of the account API (#281), completing #80. Passwordless sign-in, saved media, followed podcasts, alert-rule management, digest history, and notification settings — all riding the http-only session cookie.

## Type

- [x] `feat` — New feature

## Changes Made

- Add `/account` (overview + digests), `/account/saved`, `/account/follows`, `/account/alerts`, `/account/settings`, and `/auth/verify` pages
- Add `AccountShell` chrome: resolves the session, offers magic-link sign-in when anonymous (enumeration-safe copy, 503 handling), renders section navigation and sign-out
- Add typed account API client over the generated OpenAPI types with `credentials: "include"` and a status-carrying error type
- Add `MagicLinkVerify`: redeems the one-time token and forwards only to same-site redirect paths
- Disallow `/account/` and `/auth/` in robots.txt
- Add component/client test suite (15 tests) covering sign-in flows, CRUD round-trips, empty/error states, and verification

## Closes

- Closes #80
- Relates to #108

## Testing

- [x] Frontend suite passes (70 tests) with coverage ≥85% on all four metrics
- [x] `astro check` clean and `astro build` succeeds

## Quality Checks

- [x] Generated API types in sync with the committed OpenAPI artifact

## Checklist

- [x] No secrets; session state only in the http-only cookie (#108 boundary)