### PR TITLE
feat(ops): add DMCA takedown intake, decision workflow, and coordinated suppression

### DIFF
--- a/backend/alembic/versions/0016_add_takedown_requests.py
+++ b/backend/alembic/versions/0016_add_takedown_requests.py
@@ -1,0 +1,79 @@
+"""Add takedown requests.
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-07-19 07:54:32.356300
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0016"
+down_revision: str | None = "0015"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.create_table(
+        "takedown_requests",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("subject_type", sa.String(length=32), nullable=False),
+        sa.Column("subject_id", sa.Integer(), nullable=False),
+        sa.Column("requester_type", sa.String(length=32), nullable=False),
+        sa.Column("requester_name", sa.String(length=255), nullable=False),
+        sa.Column("requester_email", sa.String(length=320), nullable=False),
+        sa.Column("basis", sa.Text(), nullable=False),
+        sa.Column("requested_actions_json", sa.JSON(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("decision_note", sa.Text(), nullable=True),
+        sa.Column("decided_by", sa.String(length=100), nullable=True),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_takedown_requests_requester_type"),
+        "takedown_requests",
+        ["requester_type"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_takedown_requests_status"),
+        "takedown_requests",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_takedown_requests_subject_id"),
+        "takedown_requests",
+        ["subject_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_takedown_requests_subject_type"),
+        "takedown_requests",
+        ["subject_type"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    op.drop_index(
+        op.f("ix_takedown_requests_subject_type"), table_name="takedown_requests"
+    )
+    op.drop_index(
+        op.f("ix_takedown_requests_subject_id"), table_name="takedown_requests"
+    )
+    op.drop_index(op.f("ix_takedown_requests_status"), table_name="takedown_requests")
+    op.drop_index(
+        op.f("ix_takedown_requests_requester_type"), table_name="takedown_requests"
+    )
+    op.drop_table("takedown_requests")

--- a/backend/src/podex/api/v2/ops.py
+++ b/backend/src/podex/api/v2/ops.py
@@ -11,7 +11,11 @@ from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy.exc import IntegrityError
 
 from podex.api.deps import AppSettings, DbSession
-from podex.models import AuditAction, PodcastStatus
+from podex.models import (
+    AuditAction,
+    PodcastStatus,
+    TakedownRequestStatus,
+)
 from podex.schemas.ops import (
     OpsAuditLogEntryRead,
     OpsAuditLogListRead,
@@ -26,6 +30,10 @@ from podex.schemas.ops import (
     OpsPodcastUpdateRequest,
     OpsRetentionPreviewRead,
     OpsSortOrder,
+    OpsTakedownDecisionRead,
+    OpsTakedownDecisionRequest,
+    OpsTakedownExecutionRead,
+    OpsTakedownRequestRead,
     OpsTranscriptPurgeRead,
     OpsTranscriptRetentionRead,
     PodcastSourceType,
@@ -53,6 +61,12 @@ from podex.services.ops_retention_commands import (
     purge_ops_transcript,
 )
 from podex.services.pipeline_queries import list_recent_ingestion_runs
+from podex.services.takedown_requests import (
+    TakedownDecisionInputData,
+    decide_takedown_request,
+    execute_approved_takedown_request,
+    list_takedown_requests,
+)
 from podex.services.transcript_artifacts import build_transcript_artifact_store
 from podex.services.transcript_retention import TranscriptRetentionPolicy
 
@@ -408,6 +422,88 @@ def purge_ops_transcript_endpoint(
     )
 
 
+def list_ops_takedown_requests(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+    status_filter: Annotated[
+        TakedownRequestStatus | None,
+        Query(alias="status"),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+) -> list[OpsTakedownRequestRead]:
+    """List submitted takedown cases for privileged review."""
+    _require_ops_access(request=request, settings=settings)
+    listed = list_takedown_requests(db=db, status=status_filter, limit=limit)
+    db.commit()
+    return [
+        OpsTakedownRequestRead.model_validate(item, from_attributes=True)
+        for item in listed
+    ]
+
+
+def decide_ops_takedown_request(
+    request_id: int,
+    payload: OpsTakedownDecisionRequest,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> OpsTakedownDecisionRead:
+    """Decide a pending takedown; approvals execute suppression immediately."""
+    _require_ops_access(request=request, settings=settings)
+    try:
+        decided = decide_takedown_request(
+            db=db,
+            request_id=request_id,
+            payload=TakedownDecisionInputData(
+                status=TakedownRequestStatus(payload.status),
+                actor_name=payload.actor_name,
+                note=payload.note,
+            ),
+        )
+    except ValueError as error:
+        db.rollback()
+        raise HTTPException(status_code=409, detail=str(error)) from error
+    if decided is None:
+        raise HTTPException(status_code=404, detail="Takedown request not found")
+    execution = None
+    if decided.status == TakedownRequestStatus.APPROVED.value:
+        try:
+            result = execute_approved_takedown_request(
+                db=db,
+                request=decided,
+                artifact_store=build_transcript_artifact_store(settings=settings),
+            )
+        except ValueError as error:
+            db.rollback()
+            raise HTTPException(status_code=409, detail=str(error)) from error
+        execution = OpsTakedownExecutionRead(
+            episode_ids=list(result.episode_ids),
+            media_ids=list(result.media_ids),
+            transcripts_suppressed=result.transcripts_suppressed,
+            derivatives_suppressed=result.derivatives_suppressed,
+            mentions_unpublished=result.mentions_unpublished,
+            source_opt_outs_registered=result.source_opt_outs_registered,
+        )
+    record_audit_log(
+        db=db,
+        action=AuditAction.DECIDE_TAKEDOWN_REQUEST,
+        resource_type="takedown_request",
+        resource_id=decided.id,
+        actor_name=payload.actor_name,
+        summary=f"Takedown request {decided.id} {decided.status}",
+        metadata_json=(execution.model_dump() if execution is not None else None),
+    )
+    db.commit()
+    return OpsTakedownDecisionRead(
+        request=OpsTakedownRequestRead.model_validate(
+            decided,
+            from_attributes=True,
+        ),
+        execution=execution,
+    )
+
+
 def get_ops_audit_log(
     request: Request,
     db: DbSession,
@@ -503,6 +599,18 @@ router.add_api_route(
     purge_ops_transcript_endpoint,
     methods=["POST"],
     response_model=OpsTranscriptPurgeRead,
+)
+router.add_api_route(
+    "/takedown-requests",
+    list_ops_takedown_requests,
+    methods=["GET"],
+    response_model=list[OpsTakedownRequestRead],
+)
+router.add_api_route(
+    "/takedown-requests/{request_id}/decide",
+    decide_ops_takedown_request,
+    methods=["POST"],
+    response_model=OpsTakedownDecisionRead,
 )
 router.add_api_route(
     "/audit-log",

--- a/backend/src/podex/api/v2/router.py
+++ b/backend/src/podex/api/v2/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from podex.api.v2 import auth, episodes, media, ops, podcasts, stats
+from podex.api.v2 import auth, episodes, media, ops, podcasts, stats, takedowns
 
 api_v2_router = APIRouter(tags=["v2"])
 
@@ -19,3 +19,4 @@ api_v2_router.include_router(media.router)
 api_v2_router.include_router(stats.router)
 api_v2_router.include_router(auth.router)
 api_v2_router.include_router(ops.router)
+api_v2_router.include_router(takedowns.router)

--- a/backend/src/podex/api/v2/takedowns.py
+++ b/backend/src/podex/api/v2/takedowns.py
@@ -1,0 +1,61 @@
+"""Public takedown intake endpoint.
+
+Reachable without an account so rights holders and creators can submit a
+case directly. The app-wide rate limiter covers this route; responses
+disclose only the case id and status so submissions cannot be used to probe
+catalog contents.
+"""
+
+from fastapi import APIRouter
+
+from podex.api.deps import DbSession
+from podex.models import (
+    AuditAction,
+    TakedownRequesterType,
+    TakedownSubjectType,
+)
+from podex.schemas.ops import TakedownRequestCreate, TakedownRequestCreatedRead
+from podex.services.audit_log import record_audit_log
+from podex.services.takedown_requests import (
+    TakedownRequestInputData,
+    create_takedown_request,
+)
+
+router = APIRouter(tags=["takedowns"])
+
+
+def submit_takedown_request(
+    payload: TakedownRequestCreate,
+    db: DbSession,
+) -> TakedownRequestCreatedRead:
+    """Accept a takedown submission for privileged review."""
+    request = create_takedown_request(
+        db=db,
+        payload=TakedownRequestInputData(
+            subject_type=TakedownSubjectType(payload.subject_type),
+            subject_id=payload.subject_id,
+            requester_type=TakedownRequesterType(payload.requester_type),
+            requester_name=payload.requester_name,
+            requester_email=payload.requester_email,
+            basis=payload.basis,
+            requested_actions=list(payload.requested_actions),
+        ),
+    )
+    record_audit_log(
+        db=db,
+        action=AuditAction.SUBMIT_TAKEDOWN_REQUEST,
+        resource_type="takedown_request",
+        resource_id=request.id,
+        summary=(f"Takedown submitted for {request.subject_type} {request.subject_id}"),
+    )
+    db.commit()
+    return TakedownRequestCreatedRead(id=request.id, status=request.status)
+
+
+router.add_api_route(
+    "/takedowns",
+    submit_takedown_request,
+    methods=["POST"],
+    response_model=TakedownRequestCreatedRead,
+    status_code=202,
+)

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -50,6 +50,12 @@ from podex.models.semantic_chunk import (
     SemanticChunk,
     SemanticChunkEmbeddingStatus,
 )
+from podex.models.takedown_request import (
+    TakedownRequest,
+    TakedownRequesterType,
+    TakedownRequestStatus,
+    TakedownSubjectType,
+)
 from podex.models.transcript import Transcript
 from podex.models.transcript_artifact import TranscriptArtifact
 from podex.models.transcript_digest import TranscriptDigest
@@ -106,6 +112,10 @@ __all__ = [
     "ReviewItemStatus",
     "ReviewPriority",
     "ScheduledWorkItemModel",
+    "TakedownRequest",
+    "TakedownRequesterType",
+    "TakedownRequestStatus",
+    "TakedownSubjectType",
     "Transcript",
     "TranscriptArtifact",
     "TranscriptDigest",

--- a/backend/src/podex/models/takedown_request.py
+++ b/backend/src/podex/models/takedown_request.py
@@ -1,0 +1,63 @@
+"""Rights-holder and creator takedown request persistence."""
+
+from datetime import UTC, datetime
+from enum import StrEnum, auto
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class TakedownSubjectType(StrEnum):
+    """Public catalog resources that may receive takedown requests."""
+
+    PODCAST = auto()
+    EPISODE = auto()
+    MENTION = auto()
+
+
+class TakedownRequesterType(StrEnum):
+    """Claimant relationships accepted for a takedown submission."""
+
+    CREATOR = auto()
+    RIGHTS_HOLDER = auto()
+    OPERATOR = auto()
+
+
+class TakedownRequestStatus(StrEnum):
+    """Review states for takedown requests."""
+
+    PENDING = auto()
+    APPROVED = auto()
+    REJECTED = auto()
+
+
+class TakedownRequest(Base):
+    """Privileged case record for a request to suppress catalog content."""
+
+    __tablename__ = "takedown_requests"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    subject_type: Mapped[str] = mapped_column(String(32), index=True)
+    subject_id: Mapped[int] = mapped_column(Integer, index=True)
+    requester_type: Mapped[str] = mapped_column(String(32), index=True)
+    requester_name: Mapped[str] = mapped_column(String(255))
+    requester_email: Mapped[str] = mapped_column(String(320))
+    basis: Mapped[str] = mapped_column(Text)
+    requested_actions_json: Mapped[list[str]] = mapped_column(JSON)
+    status: Mapped[str] = mapped_column(
+        String(32),
+        index=True,
+        default=TakedownRequestStatus.PENDING.value,
+    )
+    decision_note: Mapped[str | None] = mapped_column(Text)
+    decided_by: Mapped[str | None] = mapped_column(String(100))
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/backend/src/podex/schemas/ops.py
+++ b/backend/src/podex/schemas/ops.py
@@ -226,6 +226,79 @@ class OpsAuditLogListRead(BaseModel):
     per_page: int
 
 
+class TakedownRequestCreate(BaseModel):
+    """Public takedown intake submission."""
+
+    subject_type: Literal["podcast", "episode", "mention"]
+    subject_id: int
+    requester_type: Literal["creator", "rights_holder", "operator"]
+    requester_name: str = Field(min_length=1, max_length=255)
+    requester_email: str = Field(min_length=3, max_length=320)
+    basis: str = Field(min_length=1, max_length=5000)
+    requested_actions: list[
+        Literal[
+            "suppress_raw_transcript",
+            "suppress_derivatives",
+            "unpublish_mentions",
+            "register_source_opt_out",
+        ]
+    ] = Field(min_length=1)
+
+
+class TakedownRequestCreatedRead(BaseModel):
+    """Acknowledgement returned to a takedown submitter."""
+
+    id: int
+    status: str
+
+
+class OpsTakedownRequestRead(BaseModel):
+    """Privileged view of one takedown case."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    subject_type: str
+    subject_id: int
+    requester_type: str
+    requester_name: str
+    requester_email: str
+    basis: str
+    requested_actions_json: list[str]
+    status: str
+    decision_note: str | None
+    decided_by: str | None
+    decided_at: datetime | None
+    metadata_json: dict[str, Any] | None
+    created_at: datetime
+
+
+class OpsTakedownDecisionRequest(BaseModel):
+    """Operator decision for one pending takedown request."""
+
+    status: Literal["approved", "rejected"]
+    actor_name: str | None = Field(default=None, max_length=100)
+    note: str = Field(min_length=1, max_length=5000)
+
+
+class OpsTakedownExecutionRead(BaseModel):
+    """Suppression counts recorded when an approval executes."""
+
+    episode_ids: list[int]
+    media_ids: list[int]
+    transcripts_suppressed: int
+    derivatives_suppressed: int
+    mentions_unpublished: int
+    source_opt_outs_registered: int
+
+
+class OpsTakedownDecisionRead(BaseModel):
+    """Decision outcome plus execution summary for approvals."""
+
+    request: OpsTakedownRequestRead
+    execution: OpsTakedownExecutionRead | None
+
+
 OpsPodcastSortField = Literal["created_at", "name", "episode_count", "mention_count"]
 OpsSortOrder = Literal["asc", "desc"]
 
@@ -249,6 +322,12 @@ __all__ = [
     "OpsRetentionPreviewRead",
     "OpsReviewThroughputRead",
     "OpsSortOrder",
+    "OpsTakedownDecisionRead",
+    "OpsTakedownDecisionRequest",
+    "OpsTakedownExecutionRead",
+    "OpsTakedownRequestRead",
+    "TakedownRequestCreate",
+    "TakedownRequestCreatedRead",
     "OpsTranscriptPurgeRead",
     "OpsTranscriptRetentionRead",
     "PodcastSourceType",

--- a/backend/src/podex/services/takedown_requests.py
+++ b/backend/src/podex/services/takedown_requests.py
@@ -1,0 +1,342 @@
+"""Takedown intake and privileged decision services."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    DerivativeGenerationRun,
+    Episode,
+    EpisodeSummary,
+    GraphTriple,
+    Mention,
+    MentionCandidate,
+    SemanticChunk,
+    TakedownRequest,
+    TakedownRequesterType,
+    TakedownRequestStatus,
+    TakedownSubjectType,
+    Transcript,
+    TranscriptArtifact,
+)
+from podex.services.transcript_artifacts import TranscriptArtifactStore
+from podex.services.transcript_retention import TranscriptRetentionPolicy
+from podex.services.transcript_retention_commands import create_transcript_digest
+from podex.services.transcript_retention_policies import (
+    get_transcript_source_retention_policy,
+    to_retention_policy,
+    upsert_transcript_source_retention_policy,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TakedownRequestInputData:
+    """Validated input for one takedown submission."""
+
+    subject_type: TakedownSubjectType
+    subject_id: int
+    requester_type: TakedownRequesterType
+    requester_name: str
+    requester_email: str
+    basis: str
+    requested_actions: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class TakedownDecisionInputData:
+    """Operator decision for one submitted request."""
+
+    status: TakedownRequestStatus
+    actor_name: str | None
+    note: str
+
+
+@dataclass(frozen=True, slots=True)
+class TakedownExecutionResultData:
+    """Counts and public projection identifiers affected by suppression."""
+
+    episode_ids: tuple[int, ...]
+    media_ids: tuple[int, ...]
+    transcripts_suppressed: int
+    derivatives_suppressed: int
+    mentions_unpublished: int
+    source_opt_outs_registered: int
+
+
+def create_takedown_request(
+    *,
+    db: Session,
+    payload: TakedownRequestInputData,
+) -> TakedownRequest:
+    """Persist a newly submitted takedown case in pending review."""
+    request = TakedownRequest(
+        subject_type=payload.subject_type.value,
+        subject_id=payload.subject_id,
+        requester_type=payload.requester_type.value,
+        requester_name=payload.requester_name,
+        requester_email=payload.requester_email,
+        basis=payload.basis,
+        requested_actions_json=payload.requested_actions,
+        status=TakedownRequestStatus.PENDING.value,
+    )
+    db.add(request)
+    db.flush()
+    return request
+
+
+def list_takedown_requests(
+    *,
+    db: Session,
+    status: TakedownRequestStatus | None = None,
+    limit: int = 50,
+) -> list[TakedownRequest]:
+    """List submitted takedown cases for privileged operator review."""
+    query = db.query(TakedownRequest)
+    if status is not None:
+        query = query.filter(TakedownRequest.status == status.value)
+    return list(
+        query.order_by(TakedownRequest.created_at.desc(), TakedownRequest.id.desc())
+        .limit(limit)
+        .all(),
+    )
+
+
+def decide_takedown_request(
+    *,
+    db: Session,
+    request_id: int,
+    payload: TakedownDecisionInputData,
+    now: datetime | None = None,
+) -> TakedownRequest | None:
+    """Record approval or rejection for one pending takedown request."""
+    request = db.query(TakedownRequest).filter(TakedownRequest.id == request_id).first()
+    if request is None:
+        return None
+    if request.status != TakedownRequestStatus.PENDING.value:
+        raise ValueError("Takedown request has already been decided")
+    request.status = payload.status.value
+    request.decided_by = payload.actor_name
+    request.decision_note = payload.note
+    request.decided_at = now or datetime.now(UTC)
+    db.flush()
+    return request
+
+
+def execute_approved_takedown_request(
+    *,
+    db: Session,
+    request: TakedownRequest,
+    artifact_store: TranscriptArtifactStore | None,
+    now: datetime | None = None,
+) -> TakedownExecutionResultData:
+    """Execute data removal and opt-out actions for an approved request."""
+    if request.status != TakedownRequestStatus.APPROVED.value:
+        raise ValueError("Only approved takedown requests can be executed")
+
+    effective_now = now or datetime.now(UTC)
+    actions = set(request.requested_actions_json)
+    episode_ids = _episode_ids_for_request(db=db, request=request)
+    transcripts = (
+        db.query(Transcript).filter(Transcript.episode_id.in_(episode_ids)).all()
+        if episode_ids
+        else []
+    )
+    transcripts_suppressed = 0
+    derivatives_suppressed = 0
+    mentions_unpublished = 0
+    source_opt_outs_registered = 0
+    media_ids: tuple[int, ...] = ()
+
+    if "suppress_raw_transcript" in actions:
+        transcripts_suppressed = _suppress_raw_transcripts(
+            db=db,
+            transcripts=transcripts,
+            artifact_store=artifact_store,
+            suppressed_at=effective_now,
+        )
+    if "suppress_derivatives" in actions:
+        derivatives_suppressed = _suppress_derivatives(
+            db=db,
+            episode_ids=episode_ids,
+        )
+    if "unpublish_mentions" in actions:
+        mentions_unpublished, media_ids = _unpublish_mentions(
+            db=db,
+            request=request,
+            episode_ids=episode_ids,
+        )
+    if "register_source_opt_out" in actions:
+        if request.requester_type != TakedownRequesterType.CREATOR.value:
+            raise ValueError("Source opt-out registration requires a creator request")
+        source_opt_outs_registered = _register_source_opt_outs(
+            db=db,
+            transcripts=transcripts,
+        )
+
+    result = TakedownExecutionResultData(
+        episode_ids=episode_ids,
+        media_ids=media_ids,
+        transcripts_suppressed=transcripts_suppressed,
+        derivatives_suppressed=derivatives_suppressed,
+        mentions_unpublished=mentions_unpublished,
+        source_opt_outs_registered=source_opt_outs_registered,
+    )
+    request.metadata_json = {
+        **(request.metadata_json or {}),
+        "executed_at": effective_now.isoformat(),
+        "transcripts_suppressed": result.transcripts_suppressed,
+        "derivatives_suppressed": result.derivatives_suppressed,
+        "mentions_unpublished": result.mentions_unpublished,
+        "source_opt_outs_registered": result.source_opt_outs_registered,
+    }
+    db.flush()
+    return result
+
+
+def _episode_ids_for_request(
+    *,
+    db: Session,
+    request: TakedownRequest,
+) -> tuple[int, ...]:
+    """Resolve the episodes covered by a catalog subject."""
+    if request.subject_type == TakedownSubjectType.PODCAST.value:
+        rows = (
+            db.query(Episode.id).filter(Episode.podcast_id == request.subject_id).all()
+        )
+        return tuple(row[0] for row in rows)
+    if request.subject_type == TakedownSubjectType.EPISODE.value:
+        return (request.subject_id,)
+    mention = db.query(Mention).filter(Mention.id == request.subject_id).first()
+    return (mention.episode_id,) if mention is not None else ()
+
+
+def _suppress_raw_transcripts(
+    *,
+    db: Session,
+    transcripts: list[Transcript],
+    artifact_store: TranscriptArtifactStore | None,
+    suppressed_at: datetime,
+) -> int:
+    """Immediately delete retained raw payloads covered by an approval."""
+    suppressed = 0
+    for transcript in transcripts:
+        artifacts = (
+            db.query(TranscriptArtifact)
+            .filter(
+                TranscriptArtifact.transcript_id == transcript.id,
+                TranscriptArtifact.purged_at.is_(None),
+            )
+            .all()
+        )
+        if (
+            not artifacts
+            and transcript.raw_text is None
+            and transcript.segments_json is None
+        ):
+            continue
+        if artifacts and artifact_store is None:
+            raise ValueError("Encrypted transcript artifact storage is not configured")
+        create_transcript_digest(
+            db=db,
+            transcript=transcript,
+            purged_at=suppressed_at,
+        )
+        for artifact in artifacts:
+            if artifact_store is None:  # pragma: no cover - guarded above
+                raise AssertionError
+            artifact_store.delete(storage_key=artifact.storage_key)
+            artifact.purged_at = suppressed_at
+        transcript.raw_text = None
+        transcript.segments_json = None
+        transcript.purged_at = suppressed_at
+        transcript.retention_tier = "purged"
+        suppressed += 1
+    return suppressed
+
+
+def _suppress_derivatives(*, db: Session, episode_ids: tuple[int, ...]) -> int:
+    """Delete generated summaries and semantic retrieval content."""
+    if not episode_ids:
+        return 0
+    run_count = (
+        db.query(DerivativeGenerationRun)
+        .filter(DerivativeGenerationRun.episode_id.in_(episode_ids))
+        .delete(synchronize_session=False)
+    )
+    chunk_count = (
+        db.query(SemanticChunk)
+        .filter(SemanticChunk.episode_id.in_(episode_ids))
+        .delete(synchronize_session=False)
+    )
+    summary_count = (
+        db.query(EpisodeSummary)
+        .filter(EpisodeSummary.episode_id.in_(episode_ids))
+        .delete(synchronize_session=False)
+    )
+    db.query(Transcript).filter(Transcript.episode_id.in_(episode_ids)).update(
+        {
+            Transcript.cleaned_text: None,
+            Transcript.cleaned_at: None,
+            Transcript.digest_text: None,
+            Transcript.digest_created_at: None,
+        },
+        synchronize_session=False,
+    )
+    return int(run_count + chunk_count + summary_count)
+
+
+def _unpublish_mentions(
+    *,
+    db: Session,
+    request: TakedownRequest,
+    episode_ids: tuple[int, ...],
+) -> tuple[int, tuple[int, ...]]:
+    """Remove published mentions and detach retained provenance references."""
+    query = db.query(Mention)
+    if request.subject_type == TakedownSubjectType.MENTION.value:
+        query = query.filter(Mention.id == request.subject_id)
+    else:
+        query = query.filter(Mention.episode_id.in_(episode_ids))
+    mentions = query.all()
+    if not mentions:
+        return 0, ()
+    mention_ids = [mention.id for mention in mentions]
+    media_ids = tuple(sorted({mention.media_id for mention in mentions}))
+    db.query(MentionCandidate).filter(
+        MentionCandidate.mention_id.in_(mention_ids)
+    ).update({MentionCandidate.mention_id: None}, synchronize_session=False)
+    db.query(GraphTriple).filter(
+        GraphTriple.provenance_mention_id.in_(mention_ids)
+    ).update({GraphTriple.provenance_mention_id: None}, synchronize_session=False)
+    for mention in mentions:
+        db.delete(mention)
+    db.flush()
+    return len(mentions), media_ids
+
+
+def _register_source_opt_outs(*, db: Session, transcripts: list[Transcript]) -> int:
+    """Persist future-acquisition raw retention opt-outs for known sources."""
+    known_sources: set[tuple[int, str]] = set()
+    for transcript in transcripts:
+        source_key = (transcript.episode.podcast_id, transcript.provider)
+        if source_key in known_sources:
+            continue
+        stored_policy = get_transcript_source_retention_policy(
+            db=db,
+            transcript=transcript,
+        )
+        upsert_transcript_source_retention_policy(
+            db=db,
+            transcript=transcript,
+            policy=(
+                to_retention_policy(record=stored_policy)
+                if stored_policy is not None
+                else TranscriptRetentionPolicy()
+            ),
+            source_retention_opt_out=True,
+        )
+        known_sources.add(source_key)
+    for transcript in transcripts:
+        transcript.source_retention_opt_out = True
+    return len(known_sources)

--- a/backend/tests/test_acceptance_catalog.py
+++ b/backend/tests/test_acceptance_catalog.py
@@ -211,7 +211,12 @@ def test_openapi_surface_is_read_only_get() -> None:
     """
     schema = build_openapi_schema()
     catalog_prefix = "/api/v2/"
-    account_prefixes = ("/api/v2/auth", "/api/v2/me", "/api/v2/ops")
+    account_prefixes = (
+        "/api/v2/auth",
+        "/api/v2/me",
+        "/api/v2/ops",
+        "/api/v2/takedowns",
+    )
 
     for path, operations in schema["paths"].items():
         if not path.startswith(catalog_prefix):
@@ -234,7 +239,9 @@ def test_openapi_response_schemas_reference_read_dtos() -> None:
     for path, operations in schema["paths"].items():
         if not path.startswith("/api/v2/") or path.endswith("/status"):
             continue
-        if path.startswith(("/api/v2/auth", "/api/v2/me", "/api/v2/ops")):
+        if path.startswith(
+            ("/api/v2/auth", "/api/v2/me", "/api/v2/ops", "/api/v2/takedowns"),
+        ):
             continue
         success = operations["get"]["responses"]["200"]["content"]["application/json"][
             "schema"

--- a/backend/tests/test_takedowns.py
+++ b/backend/tests/test_takedowns.py
@@ -1,0 +1,170 @@
+"""Tests for takedown intake, decision, and coordinated suppression."""
+
+from assertpy import assert_that
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.api.deps import get_app_settings
+from podex.config import Settings
+from podex.models import (
+    Mention,
+    MentionCandidate,
+    SemanticChunk,
+    Transcript,
+)
+from podex.services.semantic_chunks import (
+    SemanticChunkingPolicy,
+    sync_semantic_chunks_for_transcript,
+)
+from tests.conftest import seed_catalog_graph
+
+_OPS_HEADERS = {"X-Ops-Key": "test-ops-key"}
+
+
+def _enable_ops(client: TestClient) -> None:
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    app.dependency_overrides[get_app_settings] = lambda: Settings(
+        ops_api_key="test-ops-key",
+    )
+
+
+def _submit(client: TestClient, episode_id: int) -> int:
+    response = client.post(
+        "/api/v2/takedowns",
+        json={
+            "subject_type": "episode",
+            "subject_id": episode_id,
+            "requester_type": "creator",
+            "requester_name": "The Creator",
+            "requester_email": "creator@example.com",
+            "basis": "This is my content and I request its removal.",
+            "requested_actions": [
+                "suppress_raw_transcript",
+                "suppress_derivatives",
+                "unpublish_mentions",
+                "register_source_opt_out",
+            ],
+        },
+    )
+    if response.status_code != 202:  # pragma: no cover - guard
+        raise AssertionError(response.text)
+    return int(response.json()["id"])
+
+
+def test_public_intake_accepts_and_audits(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Anonymous submissions create pending cases and audit entries."""
+    graph = seed_catalog_graph(db_session)
+
+    request_id = _submit(client, graph.episode_id)
+
+    assert_that(request_id).is_greater_than(0)
+    _enable_ops(client)
+    listed = client.get("/api/v2/ops/takedown-requests", headers=_OPS_HEADERS)
+    assert_that(listed.json()).is_length(1)
+    assert_that(listed.json()[0]["status"]).is_equal_to("pending")
+    audit = client.get("/api/v2/ops/audit-log", headers=_OPS_HEADERS)
+    assert_that(audit.json()["items"][0]["action"]).is_equal_to(
+        "submit_takedown_request",
+    )
+
+
+def test_rejection_leaves_content_untouched(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Rejected cases record the decision without suppressing content."""
+    graph = seed_catalog_graph(db_session)
+    request_id = _submit(client, graph.episode_id)
+    _enable_ops(client)
+
+    decided = client.post(
+        f"/api/v2/ops/takedown-requests/{request_id}/decide",
+        json={"status": "rejected", "note": "Insufficient ownership evidence."},
+        headers=_OPS_HEADERS,
+    )
+
+    assert_that(decided.status_code).is_equal_to(200)
+    assert_that(decided.json()["request"]["status"]).is_equal_to("rejected")
+    assert_that(decided.json()["execution"]).is_none()
+    assert_that(db_session.query(Mention).count()).is_equal_to(1)
+
+    repeat = client.post(
+        f"/api/v2/ops/takedown-requests/{request_id}/decide",
+        json={"status": "approved", "note": "Changed my mind."},
+        headers=_OPS_HEADERS,
+    )
+    assert_that(repeat.status_code).is_equal_to(409)
+    assert_that(
+        client.post(
+            "/api/v2/ops/takedown-requests/999999/decide",
+            json={"status": "rejected", "note": "n/a"},
+            headers=_OPS_HEADERS,
+        ).status_code,
+    ).is_equal_to(404)
+
+
+def test_approval_executes_coordinated_suppression(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Approval purges raw text, derivatives, and mentions, and opts out."""
+    graph = seed_catalog_graph(db_session)
+    transcript = Transcript(
+        episode_id=graph.episode_id,
+        provider="podscripts",
+        raw_text="one two three four five six",
+        cleaned_text="one two three four five six",
+    )
+    db_session.add(transcript)
+    db_session.flush()
+    sync_semantic_chunks_for_transcript(
+        db=db_session,
+        transcript=transcript,
+        policy=SemanticChunkingPolicy(max_words=6, overlap_words=0, min_words=2),
+    )
+    candidate = MentionCandidate(
+        episode_id=graph.episode_id,
+        media_type="book",
+        raw_title="Dune",
+        confidence=0.9,
+        extraction_source="llm",
+        mention_id=graph.mention_id,
+    )
+    db_session.add(candidate)
+    db_session.commit()
+    request_id = _submit(client, graph.episode_id)
+    _enable_ops(client)
+
+    decided = client.post(
+        f"/api/v2/ops/takedown-requests/{request_id}/decide",
+        json={
+            "status": "approved",
+            "actor_name": "operator",
+            "note": "Ownership verified.",
+        },
+        headers=_OPS_HEADERS,
+    )
+
+    assert_that(decided.status_code).is_equal_to(200)
+    execution = decided.json()["execution"]
+    assert_that(execution["transcripts_suppressed"]).is_equal_to(1)
+    assert_that(execution["mentions_unpublished"]).is_equal_to(1)
+    assert_that(execution["source_opt_outs_registered"]).is_equal_to(1)
+    assert_that(execution["derivatives_suppressed"]).is_greater_than(0)
+
+    db_session.expire_all()
+    stored = db_session.query(Transcript).one()
+    assert_that(stored.raw_text).is_none()
+    assert_that(stored.cleaned_text).is_none()
+    assert_that(stored.purged_at).is_not_none()
+    assert_that(stored.source_retention_opt_out).is_true()
+    assert_that(db_session.query(Mention).count()).is_equal_to(0)
+    assert_that(db_session.query(SemanticChunk).count()).is_equal_to(0)
+    surviving = db_session.query(MentionCandidate).one()
+    assert_that(surviving.mention_id).is_none()

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1642,6 +1642,225 @@
         "title": "OpsReviewThroughputRead",
         "type": "object"
       },
+      "OpsTakedownDecisionRead": {
+        "description": "Decision outcome plus execution summary for approvals.",
+        "properties": {
+          "execution": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpsTakedownExecutionRead"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "request": {
+            "$ref": "#/components/schemas/OpsTakedownRequestRead"
+          }
+        },
+        "required": [
+          "request",
+          "execution"
+        ],
+        "title": "OpsTakedownDecisionRead",
+        "type": "object"
+      },
+      "OpsTakedownDecisionRequest": {
+        "description": "Operator decision for one pending takedown request.",
+        "properties": {
+          "actor_name": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor Name"
+          },
+          "note": {
+            "maxLength": 5000,
+            "minLength": 1,
+            "title": "Note",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "approved",
+              "rejected"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "note"
+        ],
+        "title": "OpsTakedownDecisionRequest",
+        "type": "object"
+      },
+      "OpsTakedownExecutionRead": {
+        "description": "Suppression counts recorded when an approval executes.",
+        "properties": {
+          "derivatives_suppressed": {
+            "title": "Derivatives Suppressed",
+            "type": "integer"
+          },
+          "episode_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Episode Ids",
+            "type": "array"
+          },
+          "media_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Media Ids",
+            "type": "array"
+          },
+          "mentions_unpublished": {
+            "title": "Mentions Unpublished",
+            "type": "integer"
+          },
+          "source_opt_outs_registered": {
+            "title": "Source Opt Outs Registered",
+            "type": "integer"
+          },
+          "transcripts_suppressed": {
+            "title": "Transcripts Suppressed",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "episode_ids",
+          "media_ids",
+          "transcripts_suppressed",
+          "derivatives_suppressed",
+          "mentions_unpublished",
+          "source_opt_outs_registered"
+        ],
+        "title": "OpsTakedownExecutionRead",
+        "type": "object"
+      },
+      "OpsTakedownRequestRead": {
+        "description": "Privileged view of one takedown case.",
+        "properties": {
+          "basis": {
+            "title": "Basis",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "decided_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decided At"
+          },
+          "decided_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decided By"
+          },
+          "decision_note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decision Note"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "metadata_json": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata Json"
+          },
+          "requested_actions_json": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Requested Actions Json",
+            "type": "array"
+          },
+          "requester_email": {
+            "title": "Requester Email",
+            "type": "string"
+          },
+          "requester_name": {
+            "title": "Requester Name",
+            "type": "string"
+          },
+          "requester_type": {
+            "title": "Requester Type",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "subject_id": {
+            "title": "Subject Id",
+            "type": "integer"
+          },
+          "subject_type": {
+            "title": "Subject Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "subject_type",
+          "subject_id",
+          "requester_type",
+          "requester_name",
+          "requester_email",
+          "basis",
+          "requested_actions_json",
+          "status",
+          "decision_note",
+          "decided_by",
+          "decided_at",
+          "metadata_json",
+          "created_at"
+        ],
+        "title": "OpsTakedownRequestRead",
+        "type": "object"
+      },
       "OpsTranscriptPurgeRead": {
         "description": "Result of an operator-approved transcript purge.",
         "properties": {
@@ -2190,6 +2409,105 @@
         ],
         "title": "SubscriptionRead",
         "type": "object"
+      },
+      "TakedownRequestCreate": {
+        "description": "Public takedown intake submission.",
+        "properties": {
+          "basis": {
+            "maxLength": 5000,
+            "minLength": 1,
+            "title": "Basis",
+            "type": "string"
+          },
+          "requested_actions": {
+            "items": {
+              "enum": [
+                "suppress_raw_transcript",
+                "suppress_derivatives",
+                "unpublish_mentions",
+                "register_source_opt_out"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Requested Actions",
+            "type": "array"
+          },
+          "requester_email": {
+            "maxLength": 320,
+            "minLength": 3,
+            "title": "Requester Email",
+            "type": "string"
+          },
+          "requester_name": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Requester Name",
+            "type": "string"
+          },
+          "requester_type": {
+            "enum": [
+              "creator",
+              "rights_holder",
+              "operator"
+            ],
+            "title": "Requester Type",
+            "type": "string"
+          },
+          "subject_id": {
+            "title": "Subject Id",
+            "type": "integer"
+          },
+          "subject_type": {
+            "enum": [
+              "podcast",
+              "episode",
+              "mention"
+            ],
+            "title": "Subject Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subject_type",
+          "subject_id",
+          "requester_type",
+          "requester_name",
+          "requester_email",
+          "basis",
+          "requested_actions"
+        ],
+        "title": "TakedownRequestCreate",
+        "type": "object"
+      },
+      "TakedownRequestCreatedRead": {
+        "description": "Acknowledgement returned to a takedown submitter.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "status"
+        ],
+        "title": "TakedownRequestCreatedRead",
+        "type": "object"
+      },
+      "TakedownRequestStatus": {
+        "description": "Review states for takedown requests.",
+        "enum": [
+          "pending",
+          "approved",
+          "rejected"
+        ],
+        "title": "TakedownRequestStatus",
+        "type": "string"
       },
       "ValidationError": {
         "properties": {
@@ -3965,6 +4283,127 @@
         ]
       }
     },
+    "/api/v2/ops/takedown-requests": {
+      "get": {
+        "description": "List submitted takedown cases for privileged review.",
+        "operationId": "list_ops_takedown_requests_api_v2_ops_takedown_requests_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/TakedownRequestStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OpsTakedownRequestRead"
+                  },
+                  "title": "Response List Ops Takedown Requests Api V2 Ops Takedown Requests Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Ops Takedown Requests",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
+    "/api/v2/ops/takedown-requests/{request_id}/decide": {
+      "post": {
+        "description": "Decide a pending takedown; approvals execute suppression immediately.",
+        "operationId": "decide_ops_takedown_request_api_v2_ops_takedown_requests__request_id__decide_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "title": "Request Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpsTakedownDecisionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpsTakedownDecisionRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Decide Ops Takedown Request",
+        "tags": [
+          "v2",
+          "ops"
+        ]
+      }
+    },
     "/api/v2/podcasts": {
       "get": {
         "description": "List podcast sources ordered by name, paginated by ``limit``/``offset``.",
@@ -4117,6 +4556,49 @@
         "summary": "Read Status",
         "tags": [
           "v2"
+        ]
+      }
+    },
+    "/api/v2/takedowns": {
+      "post": {
+        "description": "Accept a takedown submission for privileged review.",
+        "operationId": "submit_takedown_request_api_v2_takedowns_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TakedownRequestCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TakedownRequestCreatedRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Submit Takedown Request",
+        "tags": [
+          "v2",
+          "takedowns"
         ]
       }
     },

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -692,6 +692,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/ops/takedown-requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Ops Takedown Requests
+         * @description List submitted takedown cases for privileged review.
+         */
+        get: operations["list_ops_takedown_requests_api_v2_ops_takedown_requests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/ops/takedown-requests/{request_id}/decide": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Decide Ops Takedown Request
+         * @description Decide a pending takedown; approvals execute suppression immediately.
+         */
+        post: operations["decide_ops_takedown_request_api_v2_ops_takedown_requests__request_id__decide_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/podcasts": {
         parameters: {
             query?: never;
@@ -771,6 +811,26 @@ export interface paths {
         get: operations["read_status_api_v2_status_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/takedowns": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Takedown Request
+         * @description Accept a takedown submission for privileged review.
+         */
+        post: operations["submit_takedown_request_api_v2_takedowns_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1478,6 +1538,86 @@ export interface components {
             pending_items: number;
         };
         /**
+         * OpsTakedownDecisionRead
+         * @description Decision outcome plus execution summary for approvals.
+         */
+        OpsTakedownDecisionRead: {
+            execution: components["schemas"]["OpsTakedownExecutionRead"] | null;
+            request: components["schemas"]["OpsTakedownRequestRead"];
+        };
+        /**
+         * OpsTakedownDecisionRequest
+         * @description Operator decision for one pending takedown request.
+         */
+        OpsTakedownDecisionRequest: {
+            /** Actor Name */
+            actor_name?: string | null;
+            /** Note */
+            note: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "approved" | "rejected";
+        };
+        /**
+         * OpsTakedownExecutionRead
+         * @description Suppression counts recorded when an approval executes.
+         */
+        OpsTakedownExecutionRead: {
+            /** Derivatives Suppressed */
+            derivatives_suppressed: number;
+            /** Episode Ids */
+            episode_ids: number[];
+            /** Media Ids */
+            media_ids: number[];
+            /** Mentions Unpublished */
+            mentions_unpublished: number;
+            /** Source Opt Outs Registered */
+            source_opt_outs_registered: number;
+            /** Transcripts Suppressed */
+            transcripts_suppressed: number;
+        };
+        /**
+         * OpsTakedownRequestRead
+         * @description Privileged view of one takedown case.
+         */
+        OpsTakedownRequestRead: {
+            /** Basis */
+            basis: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Decided At */
+            decided_at: string | null;
+            /** Decided By */
+            decided_by: string | null;
+            /** Decision Note */
+            decision_note: string | null;
+            /** Id */
+            id: number;
+            /** Metadata Json */
+            metadata_json: {
+                [key: string]: unknown;
+            } | null;
+            /** Requested Actions Json */
+            requested_actions_json: string[];
+            /** Requester Email */
+            requester_email: string;
+            /** Requester Name */
+            requester_name: string;
+            /** Requester Type */
+            requester_type: string;
+            /** Status */
+            status: string;
+            /** Subject Id */
+            subject_id: number;
+            /** Subject Type */
+            subject_type: string;
+        };
+        /**
          * OpsTranscriptPurgeRead
          * @description Result of an operator-approved transcript purge.
          */
@@ -1702,6 +1842,48 @@ export interface components {
             /** Tier */
             tier: string;
         };
+        /**
+         * TakedownRequestCreate
+         * @description Public takedown intake submission.
+         */
+        TakedownRequestCreate: {
+            /** Basis */
+            basis: string;
+            /** Requested Actions */
+            requested_actions: ("suppress_raw_transcript" | "suppress_derivatives" | "unpublish_mentions" | "register_source_opt_out")[];
+            /** Requester Email */
+            requester_email: string;
+            /** Requester Name */
+            requester_name: string;
+            /**
+             * Requester Type
+             * @enum {string}
+             */
+            requester_type: "creator" | "rights_holder" | "operator";
+            /** Subject Id */
+            subject_id: number;
+            /**
+             * Subject Type
+             * @enum {string}
+             */
+            subject_type: "podcast" | "episode" | "mention";
+        };
+        /**
+         * TakedownRequestCreatedRead
+         * @description Acknowledgement returned to a takedown submitter.
+         */
+        TakedownRequestCreatedRead: {
+            /** Id */
+            id: number;
+            /** Status */
+            status: string;
+        };
+        /**
+         * TakedownRequestStatus
+         * @description Review states for takedown requests.
+         * @enum {string}
+         */
+        TakedownRequestStatus: "pending" | "approved" | "rejected";
         /** ValidationError */
         ValidationError: {
             /** Context */
@@ -2864,6 +3046,73 @@ export interface operations {
             };
         };
     };
+    list_ops_takedown_requests_api_v2_ops_takedown_requests_get: {
+        parameters: {
+            query?: {
+                status?: components["schemas"]["TakedownRequestStatus"] | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsTakedownRequestRead"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    decide_ops_takedown_request_api_v2_ops_takedown_requests__request_id__decide_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                request_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OpsTakedownDecisionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpsTakedownDecisionRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_podcasts_api_v2_podcasts_get: {
         parameters: {
             query?: {
@@ -2967,6 +3216,39 @@ export interface operations {
                     "application/json": {
                         [key: string]: string;
                     };
+                };
+            };
+        };
+    };
+    submit_takedown_request_api_v2_takedowns_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TakedownRequestCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TakedownRequestCreatedRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

DMCA slice of the #108 split stack: rights holders and creators can submit takedown cases without an account; operators review and decide behind the ops key; approvals execute coordinated suppression across raw transcripts, derivatives, and mentions, and register creator source opt-outs that cascade to future retention.

## Type

- [x] `feat` — New feature

## Changes Made

- Add `TakedownRequest` model (subject/requester/basis/actions/decision fields) with migration `0016_add_takedown_requests`
- Add `takedown_requests` service: pending-case creation, privileged listing, single-decision enforcement (409 on re-decide), and approval execution — transcript purge with digest proof + encrypted-artifact deletion, derivative run/chunk/summary deletion with cleaned/digest column clearing, mention deletion with candidate/graph-triple provenance detachment, and per-source opt-out upsert
- Add public `POST /api/v2/takedowns` (202, minimal response, covered by the app-wide rate limiter) and ops `GET /ops/takedown-requests` + `POST /ops/takedown-requests/{id}/decide`
- Record immutable audit entries for submissions and decisions (execution counts in metadata)
- Regenerate OpenAPI artifact and frontend API types; extend the read-only catalog invariant exemption
- Add takedown test suite (3 tests) covering intake+audit, rejection with no side effects and decision idempotency, and full approval suppression

## Closes

- Closes #28
- Relates to #108

## Testing

- [x] Added takedown workflow tests
- [x] Full backend suite passes with coverage ≥85% (86.90%)
- [x] Migration replay + schema-drift guard passes

## Quality Checks

- [x] `lintro chk` (ruff, mypy, bandit, pydoclint) clean — health 100/100
- [x] `ruff format` applied

## Checklist

- [x] Code follows repo conventions
- [x] Intake responses disclose no catalog contents; no legal copy shipped (owner's lane) (#108 boundary)