### PR TITLE
fix(security): harden the magic-link flow

### DIFF
--- a/backend/alembic/versions/0017_carry_email_on_magic_link_tokens.py
+++ b/backend/alembic/versions/0017_carry_email_on_magic_link_tokens.py
@@ -1,0 +1,45 @@
+"""Carry email on magic link tokens.
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-07-19 08:00:27.986762
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0017"
+down_revision: str | None = "0016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    with op.batch_alter_table("magic_link_tokens") as batch:
+        batch.add_column(
+            sa.Column(
+                "email",
+                sa.String(length=320),
+                nullable=False,
+                server_default="",
+            ),
+        )
+        batch.alter_column("user_id", existing_type=sa.INTEGER(), nullable=True)
+    op.create_index(
+        op.f("ix_magic_link_tokens_email"),
+        "magic_link_tokens",
+        ["email"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    op.drop_index(op.f("ix_magic_link_tokens_email"), table_name="magic_link_tokens")
+    with op.batch_alter_table("magic_link_tokens") as batch:
+        batch.alter_column("user_id", existing_type=sa.INTEGER(), nullable=False)
+        batch.drop_column("email")

--- a/backend/src/podex/api/v2/auth.py
+++ b/backend/src/podex/api/v2/auth.py
@@ -210,11 +210,17 @@ def request_auth_magic_link(
         redirect_path=payload.redirect_path,
         ttl_minutes=settings.auth_magic_link_ttl_minutes,
     )
-    query = {"token": issued.token}
-    if issued.redirect_path is not None:
-        query["redirect_path"] = issued.redirect_path
+    # The token travels in the URL fragment, which browsers never send in
+    # Referer headers or request lines, so it stays out of proxy and access
+    # logs. Only the redirect path rides in the query string.
+    query = (
+        f"?{urlencode({'redirect_path': issued.redirect_path})}"
+        if issued.redirect_path is not None
+        else ""
+    )
+    fragment = urlencode({"token": issued.token})
     verification_url = (
-        f"{settings.public_web_url.rstrip('/')}/auth/verify?{urlencode(query)}"
+        f"{settings.public_web_url.rstrip('/')}/auth/verify{query}#{fragment}"
     )
     try:
         sender.send_magic_link(email=issued.email, verification_url=verification_url)

--- a/backend/src/podex/models/magic_link_token.py
+++ b/backend/src/podex/models/magic_link_token.py
@@ -14,7 +14,11 @@ class MagicLinkToken(Base):
     __tablename__ = "magic_link_tokens"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("account_users.id"), index=True)
+    user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("account_users.id"),
+        index=True,
+    )
+    email: Mapped[str] = mapped_column(String(320), index=True, default="")
     token_digest: Mapped[str] = mapped_column(String(64), unique=True, index=True)
     redirect_path: Mapped[str | None] = mapped_column(String(300))
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)

--- a/backend/src/podex/services/account_auth.py
+++ b/backend/src/podex/services/account_auth.py
@@ -40,21 +40,18 @@ def issue_magic_link(
     """Create a one-time magic-link challenge for a normalized email address."""
     effective_now = now or datetime.now(UTC)
     normalized_email = email.strip().casefold()
-    user = db.query(AccountUser).filter(AccountUser.email == normalized_email).first()
-    if user is None:
-        user = AccountUser(email=normalized_email)
-        db.add(user)
-        db.flush()
 
+    # Account rows are created only on successful verification so that
+    # unauthenticated link requests cannot mint unbounded users.
     db.query(MagicLinkToken).filter(
-        MagicLinkToken.user_id == user.id,
+        MagicLinkToken.email == normalized_email,
         MagicLinkToken.consumed_at.is_(None),
     ).update({MagicLinkToken.consumed_at: effective_now}, synchronize_session=False)
     raw_token = token_urlsafe(32)
     expires_at = effective_now + timedelta(minutes=ttl_minutes)
     db.add(
         MagicLinkToken(
-            user_id=user.id,
+            email=normalized_email,
             token_digest=_token_digest(raw_token),
             redirect_path=redirect_path,
             expires_at=expires_at,
@@ -90,7 +87,12 @@ def authenticate_magic_link(
     ):
         return None
 
-    user = db.query(AccountUser).filter(AccountUser.id == challenge.user_id).one()
+    user = db.query(AccountUser).filter(AccountUser.email == challenge.email).first()
+    if user is None:
+        user = AccountUser(email=challenge.email)
+        db.add(user)
+        db.flush()
+    challenge.user_id = user.id
     raw_session_token = token_urlsafe(32)
     expires_at = effective_now + timedelta(days=session_ttl_days)
     challenge.consumed_at = effective_now

--- a/backend/tests/test_account_auth.py
+++ b/backend/tests/test_account_auth.py
@@ -17,10 +17,10 @@ from podex.services.account_auth import (
 _NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
 
 
-def test_issue_magic_link_creates_user_and_hashed_token(
+def test_issue_magic_link_defers_account_creation(
     db_session: Session,
 ) -> None:
-    """A first sign-in request creates the account and a hashed challenge."""
+    """A sign-in request stores a hashed challenge without minting a user."""
     issued = issue_magic_link(
         db=db_session,
         email="  Reader@Example.COM ",
@@ -30,10 +30,11 @@ def test_issue_magic_link_creates_user_and_hashed_token(
     )
     db_session.commit()
 
-    user = db_session.execute(select(AccountUser)).scalar_one()
     challenge = db_session.execute(select(MagicLinkToken)).scalar_one()
     assert_that(issued.email).is_equal_to("reader@example.com")
-    assert_that(user.email).is_equal_to("reader@example.com")
+    assert_that(db_session.execute(select(AccountUser)).scalar_one_or_none()).is_none()
+    assert_that(challenge.email).is_equal_to("reader@example.com")
+    assert_that(challenge.user_id).is_none()
     assert_that(challenge.token_digest).is_not_equal_to(issued.token)
     assert_that(challenge.redirect_path).is_equal_to("/account")
     assert_that(issued.expires_at).is_equal_to(_NOW + timedelta(minutes=15))
@@ -90,8 +91,12 @@ def test_authenticate_magic_link_issues_single_use_session(
     assert_that(session).is_not_none()
     if session is None:  # pragma: no cover - narrowed above
         raise AssertionError
+    assert_that(session.user.email).is_equal_to("reader@example.com")
     assert_that(session.user.last_signed_in_at).is_equal_to(
         _NOW.replace(tzinfo=None),
+    )
+    assert_that(db_session.execute(select(AccountUser)).scalar_one().id).is_equal_to(
+        session.user.id,
     )
     replay = authenticate_magic_link(
         db=db_session,

--- a/backend/tests/test_api_auth.py
+++ b/backend/tests/test_api_auth.py
@@ -49,7 +49,7 @@ def _sign_in(client: TestClient) -> str:
     )
     if requested.status_code != 202:  # pragma: no cover - guard
         raise AssertionError(requested.text)
-    token = parse_qs(urlparse(sender.deliveries[-1][1]).query)["token"][0]
+    token = parse_qs(urlparse(sender.deliveries[-1][1]).fragment)["token"][0]
     verified = client.post("/api/v2/auth/magic-link/verify", json={"token": token})
     if verified.status_code != 200:  # pragma: no cover - guard
         raise AssertionError(verified.text)
@@ -82,7 +82,7 @@ def test_magic_link_session_lifecycle_uses_hashed_credentials(
     assert_that(requested.status_code).is_equal_to(202)
     assert_that(sender.deliveries[0][0]).is_equal_to("reader@example.com")
     assert_that(sender.deliveries[0][1]).contains("redirect_path=%2Faccount%2Fsaved")
-    token = parse_qs(urlparse(sender.deliveries[0][1]).query)["token"][0]
+    token = parse_qs(urlparse(sender.deliveries[0][1]).fragment)["token"][0]
     challenge = db_session.query(MagicLinkToken).one()
     assert_that(challenge.token_digest).is_not_equal_to(token)
 

--- a/frontend/src/components/AccountPages.test.tsx
+++ b/frontend/src/components/AccountPages.test.tsx
@@ -355,7 +355,8 @@ describe("account pages", () => {
     const assign = vi.fn();
     vi.stubGlobal("location", {
       ...window.location,
-      search: "?token=abc&redirect_path=/account/saved",
+      search: "?redirect_path=/account/saved",
+      hash: "#token=abc",
       assign,
     });
 
@@ -370,6 +371,7 @@ describe("account pages", () => {
     vi.stubGlobal("location", {
       ...window.location,
       search: "",
+      hash: "",
       assign: vi.fn(),
     });
 

--- a/frontend/src/components/MagicLinkVerify.tsx
+++ b/frontend/src/components/MagicLinkVerify.tsx
@@ -11,7 +11,10 @@ export default function MagicLinkVerify() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const token = params.get("token");
+    const fragment = new URLSearchParams(
+      window.location.hash.replace(/^#/, ""),
+    );
+    const token = fragment.get("token");
     if (!token) {
       setState("failed");
       return;


### PR DESCRIPTION
## Summary

Closes the two residual weaknesses in the passwordless flow flagged by #113: sign-in tokens no longer travel in URL query strings, and unauthenticated link requests can no longer mint account rows.

## Type

- [x] `fix` — Bug fix

## Changes Made

- Deliver the verification token in the URL fragment (`/auth/verify#token=…`); fragments are never sent in Referer headers or request lines, keeping tokens out of proxy and access logs — only the redirect path rides in the query string
- Defer `AccountUser` creation to successful verification: challenges now carry the normalized email (migration `0017`, batch-alter for SQLite) with a nullable user binding stamped at redemption; the request response stays uniform to preserve enumeration resistance
- Update the frontend verifier to read the token from the fragment
- Update auth test suites for both behaviors

## Closes

- Closes #113
- Relates to #108

## Testing

- [x] Full backend suite passes with coverage ≥85% (86.70%)
- [x] Frontend suite passes (70 tests) with all coverage gates
- [x] Migration replay + schema-drift guard passes

## Quality Checks

- [x] `lintro chk` (ruff, mypy, bandit, pydoclint) clean — health 100/100
- [x] `ruff format` applied

## Checklist

- [x] Code follows repo conventions
- [x] Enumeration resistance preserved; tokens stored only as SHA-256 digests (#108 boundary)