### PR TITLE
feat(accounts): add self-serve data export and account deletion

### DIFF
--- a/backend/src/podex/api/v2/auth.py
+++ b/backend/src/podex/api/v2/auth.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from podex.api.deps import AppSettings, DbSession
 from podex.config import Settings, get_settings
 from podex.logging_config import get_logger
-from podex.models import AccountUser
+from podex.models import AccountUser, AuditAction
 from podex.schemas.account import (
     AccountUserRead,
     AlertEvaluationRead,
@@ -69,6 +69,7 @@ from podex.services.account_preferences import (
     get_account_preferences,
     update_account_preferences,
 )
+from podex.services.account_privacy import delete_account, export_account_data
 from podex.services.account_saves import (
     SavedMediaData,
     list_saved_media,
@@ -84,6 +85,7 @@ from podex.services.account_subscriptions import (
     get_account_subscription,
     get_quota_snapshot,
 )
+from podex.services.audit_log import record_audit_log
 from podex.services.billing_checkout import (
     BillingCheckoutProvider,
     build_billing_checkout_provider,
@@ -564,6 +566,47 @@ def update_current_account_preferences(
     return PreferenceRead.model_validate(preferences)
 
 
+def export_current_account(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> dict[str, object]:
+    """Return a machine-readable export of the account's stored data."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    export: dict[str, object] = export_account_data(db=db, user=user)
+    db.commit()
+    return export
+
+
+def delete_current_account(
+    request: Request,
+    response: Response,
+    db: DbSession,
+    settings: AppSettings,
+) -> AuthLogoutResponse:
+    """Delete the account and everything stored for it, then sign out."""
+    user = _require_authenticated_account(request=request, db=db, settings=settings)
+    result = delete_account(db=db, user=user)
+    record_audit_log(
+        db=db,
+        action=AuditAction.DELETE_ACCOUNT,
+        resource_type="account_user",
+        resource_id=result.user_id,
+        summary=f"Account {result.user_id} deleted at the owner's request",
+        metadata_json={
+            "sessions": result.sessions,
+            "saves": result.saves,
+            "follows": result.follows,
+            "alert_rules": result.alert_rules,
+            "alert_events": result.alert_events,
+            "digests": result.digests,
+        },
+    )
+    response.delete_cookie(key=settings.auth_session_cookie_name, path="/")
+    db.commit()
+    return AuthLogoutResponse(signed_out=True)
+
+
 def get_current_account_subscription(
     request: Request,
     db: DbSession,
@@ -771,4 +814,16 @@ router.add_api_route(
     begin_current_account_checkout,
     methods=["POST"],
     response_model=SubscriptionCheckoutRead,
+)
+
+router.add_api_route(
+    "/me/export",
+    export_current_account,
+    methods=["GET"],
+)
+router.add_api_route(
+    "/me",
+    delete_current_account,
+    methods=["DELETE"],
+    response_model=AuthLogoutResponse,
 )

--- a/backend/src/podex/models/audit_log.py
+++ b/backend/src/podex/models/audit_log.py
@@ -37,6 +37,7 @@ class AuditAction(StrEnum):
     UPDATE_RETENTION_SAMPLING = auto()
     UPDATE_TRANSCRIPT_RETENTION_POLICY = auto()
     DECIDE_TAKEDOWN_REQUEST = auto()
+    DELETE_ACCOUNT = auto()
     UPSERT_MEDIA_EXTERNAL_REF = auto()
 
 

--- a/backend/src/podex/services/account_privacy.py
+++ b/backend/src/podex/services/account_privacy.py
@@ -1,0 +1,261 @@
+"""Self-serve account data export and deletion.
+
+Deletion removes every row keyed to the account — sessions, magic-link
+challenges, saves, follows, alert rules and their events, digests,
+preferences, subscription, and quota usage — and finally the user row
+itself. Nothing is anonymized in place: the audit log records the deletion
+under an opaque numeric account id, which is the only reference retained.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    AccountAlertEvent,
+    AccountAlertRule,
+    AccountDigest,
+    AccountFollowedPodcast,
+    AccountPreference,
+    AccountQuotaUsage,
+    AccountSavedMedia,
+    AccountSubscription,
+    AccountUser,
+    MagicLinkToken,
+    UserSession,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AccountDeletionResultData:
+    """Counts of rows removed by one account deletion."""
+
+    user_id: int
+    sessions: int
+    magic_link_tokens: int
+    saves: int
+    follows: int
+    alert_rules: int
+    alert_events: int
+    digests: int
+    preferences: int
+    subscriptions: int
+    quota_usage: int
+
+
+def export_account_data(*, db: Session, user: AccountUser) -> dict[str, Any]:
+    """Assemble a machine-readable dump of everything stored for an account.
+
+    Args:
+        db: Database session.
+        user: The authenticated account.
+
+    Returns:
+        JSON-serializable mapping of the account's stored data.
+    """
+    saves = (
+        db.query(AccountSavedMedia)
+        .filter(AccountSavedMedia.user_id == user.id)
+        .order_by(AccountSavedMedia.id.asc())
+        .all()
+    )
+    follows = (
+        db.query(AccountFollowedPodcast)
+        .filter(AccountFollowedPodcast.user_id == user.id)
+        .order_by(AccountFollowedPodcast.id.asc())
+        .all()
+    )
+    rules = (
+        db.query(AccountAlertRule)
+        .filter(AccountAlertRule.user_id == user.id)
+        .order_by(AccountAlertRule.id.asc())
+        .all()
+    )
+    rule_ids = [rule.id for rule in rules]
+    events = (
+        db.query(AccountAlertEvent)
+        .filter(AccountAlertEvent.rule_id.in_(rule_ids))
+        .order_by(AccountAlertEvent.id.asc())
+        .all()
+        if rule_ids
+        else []
+    )
+    digests = (
+        db.query(AccountDigest)
+        .filter(AccountDigest.user_id == user.id)
+        .order_by(AccountDigest.id.asc())
+        .all()
+    )
+    preference = (
+        db.query(AccountPreference).filter(AccountPreference.user_id == user.id).first()
+    )
+    subscription = (
+        db.query(AccountSubscription)
+        .filter(AccountSubscription.user_id == user.id)
+        .first()
+    )
+    quotas = (
+        db.query(AccountQuotaUsage)
+        .filter(AccountQuotaUsage.user_id == user.id)
+        .order_by(AccountQuotaUsage.id.asc())
+        .all()
+    )
+    return {
+        "account": {
+            "email": user.email,
+            "created_at": _iso(user.created_at),
+            "last_signed_in_at": _iso(user.last_signed_in_at),
+        },
+        "saved_media": [
+            {"media_id": row.media_id, "saved_at": _iso(row.created_at)}
+            for row in saves
+        ],
+        "followed_podcasts": [
+            {"podcast_id": row.podcast_id, "followed_at": _iso(row.created_at)}
+            for row in follows
+        ],
+        "alert_rules": [
+            {
+                "target_type": rule.target_type,
+                "target_id": rule.target_id,
+                "event_type": rule.event_type,
+                "enabled": rule.enabled,
+                "created_at": _iso(rule.created_at),
+            }
+            for rule in rules
+        ],
+        "alert_events": [
+            {
+                "rule_id": event.rule_id,
+                "previous_count": event.previous_count,
+                "observed_count": event.observed_count,
+                "created_at": _iso(event.created_at),
+            }
+            for event in events
+        ],
+        "digests": [
+            {
+                "subject": digest.subject,
+                "body_text": digest.body_text,
+                "event_count": digest.event_count,
+                "created_at": _iso(digest.created_at),
+                "delivered_at": _iso(digest.delivered_at),
+            }
+            for digest in digests
+        ],
+        "preferences": (
+            {
+                "digest_enabled": preference.digest_enabled,
+                "digest_frequency": preference.digest_frequency,
+            }
+            if preference is not None
+            else None
+        ),
+        "subscription": (
+            {
+                "tier": subscription.tier,
+                "status": subscription.status,
+                "current_period_ends_at": _iso(subscription.current_period_ends_at),
+            }
+            if subscription is not None
+            else None
+        ),
+        "quota_usage": [
+            {"period": row.period, "feature": row.feature, "units": row.units}
+            for row in quotas
+        ],
+    }
+
+
+def delete_account(*, db: Session, user: AccountUser) -> AccountDeletionResultData:
+    """Delete an account and every row stored for it.
+
+    Args:
+        db: Database session.
+        user: The authenticated account to delete.
+
+    Returns:
+        Counts of the rows removed, for the audit record.
+    """
+    user_id = user.id
+    rule_ids = [
+        row[0]
+        for row in db.query(AccountAlertRule.id)
+        .filter(AccountAlertRule.user_id == user_id)
+        .all()
+    ]
+    alert_events = (
+        db.query(AccountAlertEvent)
+        .filter(AccountAlertEvent.rule_id.in_(rule_ids))
+        .delete(synchronize_session=False)
+        if rule_ids
+        else 0
+    )
+    alert_rules = (
+        db.query(AccountAlertRule)
+        .filter(AccountAlertRule.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+    digests = (
+        db.query(AccountDigest)
+        .filter(AccountDigest.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+    saves = (
+        db.query(AccountSavedMedia)
+        .filter(AccountSavedMedia.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+    follows = (
+        db.query(AccountFollowedPodcast)
+        .filter(AccountFollowedPodcast.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+    preferences = (
+        db.query(AccountPreference)
+        .filter(AccountPreference.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+    subscriptions = (
+        db.query(AccountSubscription)
+        .filter(AccountSubscription.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+    quotas = (
+        db.query(AccountQuotaUsage)
+        .filter(AccountQuotaUsage.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+    sessions = (
+        db.query(UserSession)
+        .filter(UserSession.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+    tokens = (
+        db.query(MagicLinkToken)
+        .filter(
+            (MagicLinkToken.user_id == user_id) | (MagicLinkToken.email == user.email),
+        )
+        .delete(synchronize_session=False)
+    )
+    db.delete(user)
+    db.flush()
+    return AccountDeletionResultData(
+        user_id=user_id,
+        sessions=sessions,
+        magic_link_tokens=tokens,
+        saves=saves,
+        follows=follows,
+        alert_rules=alert_rules,
+        alert_events=alert_events,
+        digests=digests,
+        preferences=preferences,
+        subscriptions=subscriptions,
+        quota_usage=quotas,
+    )
+
+
+def _iso(value: Any) -> str | None:
+    """Render an optional datetime as ISO-8601."""
+    return value.isoformat() if value is not None else None

--- a/backend/tests/test_account_privacy.py
+++ b/backend/tests/test_account_privacy.py
@@ -1,0 +1,83 @@
+"""Tests for self-serve account export and deletion."""
+
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.models import (
+    AccountAlertEvent,
+    AccountAlertRule,
+    AccountSavedMedia,
+    AccountUser,
+    MagicLinkToken,
+    UserSession,
+)
+from podex.services.account_alerts import create_alert_rule, evaluate_alert_rules
+from podex.services.account_follows import follow_podcast
+from podex.services.account_preferences import get_account_preferences
+from podex.services.account_saves import save_media
+from tests.conftest import seed_catalog_graph
+from tests.test_api_auth import _sign_in
+
+
+def _populate(client: TestClient, db_session: Session) -> dict[str, str]:
+    graph = seed_catalog_graph(db_session)
+    cookie = {"Cookie": f"podex_session={_sign_in(client)}"}
+    user = db_session.query(AccountUser).one()
+    save_media(db=db_session, user_id=user.id, media_id=graph.media_id)
+    follow_podcast(db=db_session, user_id=user.id, podcast_id=graph.podcast_id)
+    create_alert_rule(
+        db=db_session,
+        user_id=user.id,
+        target_type="media",
+        target_id=graph.media_id,
+        event_type="new_mention",
+    )
+    get_account_preferences(db=db_session, user_id=user.id)
+    db_session.commit()
+    return cookie
+
+
+def test_export_returns_all_account_data(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """The export contains identity and every personalization collection."""
+    cookie = _populate(client, db_session)
+
+    response = client.get("/api/v2/me/export", headers=cookie)
+
+    assert_that(response.status_code).is_equal_to(200)
+    export = response.json()
+    assert_that(export["account"]["email"]).is_equal_to("reader@example.com")
+    assert_that(export["saved_media"]).is_length(1)
+    assert_that(export["followed_podcasts"]).is_length(1)
+    assert_that(export["alert_rules"]).is_length(1)
+    assert_that(export["preferences"]["digest_frequency"]).is_equal_to("daily")
+    assert_that(export["subscription"]).is_none()
+    assert_that(client.get("/api/v2/me/export").status_code).is_equal_to(401)
+
+
+def test_delete_account_removes_every_row_and_signs_out(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Deletion clears all account rows, audits, and revokes the session."""
+    cookie = _populate(client, db_session)
+    graph_user = db_session.query(AccountUser).one()
+    evaluate_alert_rules(db=db_session, user_id=graph_user.id)
+    db_session.commit()
+
+    response = client.delete("/api/v2/me", headers=cookie)
+
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()["signed_out"]).is_true()
+    assert_that(db_session.query(AccountUser).count()).is_equal_to(0)
+    assert_that(db_session.query(AccountSavedMedia).count()).is_equal_to(0)
+    assert_that(db_session.query(AccountAlertRule).count()).is_equal_to(0)
+    assert_that(db_session.query(AccountAlertEvent).count()).is_equal_to(0)
+    assert_that(db_session.query(UserSession).count()).is_equal_to(0)
+    assert_that(db_session.query(MagicLinkToken).count()).is_equal_to(0)
+
+    after = client.get("/api/v2/me", headers=cookie)
+    assert_that(after.status_code).is_equal_to(401)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2860,6 +2860,27 @@
       }
     },
     "/api/v2/me": {
+      "delete": {
+        "description": "Delete the account and everything stored for it, then sign out.",
+        "operationId": "delete_current_account_api_v2_me_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthLogoutResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Delete Current Account",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      },
       "get": {
         "description": "Return the account represented by the current browser session.",
         "operationId": "get_current_account_api_v2_me_get",
@@ -3105,6 +3126,31 @@
           }
         },
         "summary": "Send Current Account Digest",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/me/export": {
+      "get": {
+        "description": "Return a machine-readable export of the account's stored data.",
+        "operationId": "export_current_account_api_v2_me_export_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Export Current Account Api V2 Me Export Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Export Current Account",
         "tags": [
           "v2",
           "auth"

--- a/frontend/src/components/AccountPages.test.tsx
+++ b/frontend/src/components/AccountPages.test.tsx
@@ -345,6 +345,39 @@ describe("account pages", () => {
     expect(await screen.findByText("Saved.")).toBeDefined();
   });
 
+  it("AccountSettings exports data and deletes with confirmation", async () => {
+    const fetchMock = mockRoutes(
+      { "/me/preferences": PREFERENCE, "/me": USER, "/me/export": { a: 1 } },
+      {},
+    );
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:x"),
+      revokeObjectURL: vi.fn(),
+    });
+    const assign = vi.fn();
+    vi.stubGlobal("location", { ...window.location, assign });
+
+    render(<AccountSettings />);
+    fireEvent.click(await screen.findByText("Export my data"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url]) =>
+          String(url).endsWith("/me/export"),
+        ),
+      ).toBe(true);
+    });
+
+    fireEvent.click(screen.getByText("Delete account"));
+    fireEvent.click(await screen.findByText("Cancel"));
+    fireEvent.click(screen.getByText("Delete account"));
+    fireEvent.click(await screen.findByText("Yes, delete everything"));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([, init]) => init?.method === "DELETE"),
+      ).toBe(true);
+    });
+  });
+
   it("MagicLinkVerify redeems the token and redirects", async () => {
     mockRoutes({
       "/auth/magic-link/verify": {

--- a/frontend/src/components/AccountSettings.tsx
+++ b/frontend/src/components/AccountSettings.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 
 import {
+  deleteAccount,
+  exportAccountData,
   getPreferences,
   type Preference,
   updatePreferences,
@@ -22,6 +24,7 @@ function SettingsBody() {
   const [preference, setPreference] = useState<Preference | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   useEffect(() => {
     getPreferences()
@@ -91,6 +94,66 @@ function SettingsBody() {
       {saved ? (
         <p className="mt-4 text-sm text-[color:var(--color-accent)]">Saved.</p>
       ) : null}
+
+      <h2 className="font-display mt-10 text-2xl">Your data</h2>
+      <p className="mt-2 text-sm text-[color:var(--color-muted)]">
+        Download everything stored for this account, or delete the account and
+        all of its data permanently.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-3">
+        <button
+          className="rounded border border-[color:var(--color-hairline)] px-4 py-2 text-sm"
+          type="button"
+          onClick={() => {
+            exportAccountData()
+              .then((data) => {
+                const blob = new Blob([JSON.stringify(data, null, 2)], {
+                  type: "application/json",
+                });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement("a");
+                link.href = url;
+                link.download = "podex-account-export.json";
+                link.click();
+                URL.revokeObjectURL(url);
+              })
+              .catch(() => setError("Unable to export your data."));
+          }}
+        >
+          Export my data
+        </button>
+        {confirmingDelete ? (
+          <span className="flex items-center gap-3 text-sm">
+            Delete this account and all of its data permanently?
+            <button
+              className="rounded bg-red-700 px-3 py-1.5 text-white"
+              type="button"
+              onClick={() => {
+                deleteAccount()
+                  .then(() => window.location.assign("/account"))
+                  .catch(() => setError("Unable to delete your account."));
+              }}
+            >
+              Yes, delete everything
+            </button>
+            <button
+              className="underline"
+              type="button"
+              onClick={() => setConfirmingDelete(false)}
+            >
+              Cancel
+            </button>
+          </span>
+        ) : (
+          <button
+            className="rounded border border-red-700 px-4 py-2 text-sm text-red-700"
+            type="button"
+            onClick={() => setConfirmingDelete(true)}
+          >
+            Delete account
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/lib/account.ts
+++ b/frontend/src/lib/account.ts
@@ -125,3 +125,11 @@ export function updatePreferences(input: {
     body: JSON.stringify(input),
   });
 }
+
+export function exportAccountData(): Promise<Record<string, unknown>> {
+  return accountFetch("/me/export");
+}
+
+export function deleteAccount(): Promise<{ signed_out: boolean }> {
+  return accountFetch("/me", { method: "DELETE" });
+}

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -138,7 +138,11 @@ export interface paths {
         get: operations["get_current_account_api_v2_me_get"];
         put?: never;
         post?: never;
-        delete?: never;
+        /**
+         * Delete Current Account
+         * @description Delete the account and everything stored for it, then sign out.
+         */
+        delete: operations["delete_current_account_api_v2_me_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -246,6 +250,26 @@ export interface paths {
          * @description Evaluate alert rules and deliver pending activity by email.
          */
         post: operations["send_current_account_digest_api_v2_me_digests_send_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/me/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export Current Account
+         * @description Return a machine-readable export of the account's stored data.
+         */
+        get: operations["export_current_account_api_v2_me_export_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2114,6 +2138,26 @@ export interface operations {
             };
         };
     };
+    delete_current_account_api_v2_me_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthLogoutResponse"];
+                };
+            };
+        };
+    };
     list_account_alert_rules_api_v2_me_alerts_get: {
         parameters: {
             query?: never;
@@ -2289,6 +2333,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DigestSendResponse"];
+                };
+            };
+        };
+    };
+    export_current_account_api_v2_me_export_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };


### PR DESCRIPTION
## Summary

Closes the GDPR/CCPA gap flagged by #110: authenticated users can download everything stored for their account and permanently delete the account, with an immutable audit record and session revocation. Complements the accounts product (#75–#80) and the privacy scaffolding (#81).

## Type

- [x] `feat` — New feature

## Changes Made

- Add `account_privacy` service: `export_account_data` (identity, saves, follows, alert rules/events, digests, preferences, subscription, quota usage as JSON) and `delete_account` (removes every account-keyed row, then the user; deletion counts returned for auditing) — full deletion, nothing anonymized in place; the audit record retains only the opaque numeric account id
- Add `GET /api/v2/me/export` and `DELETE /api/v2/me` (writes the audit record, expires the session cookie)
- Add export and delete-with-confirmation entry points under `/account/settings`
- Add backend (2) and frontend (1) tests covering export contents, full-cascade deletion with session revocation, and the confirmation flow

## Closes

- Closes #110
- Relates to #108

## Testing

- [x] Full backend suite passes with coverage ≥85% (86.97%)
- [x] Frontend suite passes (71 tests) with all coverage gates; `astro check` clean

## Quality Checks

- [x] `lintro chk` (ruff, mypy, bandit, pydoclint) clean — health 100/100
- [x] `ruff format` applied

## Checklist

- [x] Code follows repo conventions
- [x] Export is available only to the authenticated account; deletion audited without retaining personal data (#108 boundary)