### PR TITLE
feat(observability): add Sentry error tracking for backend and frontend

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "cryptography>=48.0.0",
   "boto3>=1.43.14",
   "email-validator>=2.0.0",
+  "sentry-sdk[fastapi]>=2.0",
 ]
 
 [project.urls]

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -96,6 +96,12 @@ class Settings(BaseSettings):
     scheduler_digest_interval_minutes: int = 1440
     scheduler_retention_interval_minutes: int = 1440
 
+    # Sentry error tracking. Disabled until a DSN is provided by the
+    # deployment environment; defaults are placeholder-free. Error tracking
+    # only — no tracing/profiling sample rates are configured.
+    sentry_dsn: str = ""
+    sentry_environment: str = "production"
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/src/podex/main.py
+++ b/backend/src/podex/main.py
@@ -8,6 +8,7 @@ from podex.api.v2.router import api_v2_router
 from podex.config import Settings, get_settings
 from podex.logging_config import configure_logging
 from podex.middleware import RateLimitMiddleware, RequestContextMiddleware
+from podex.observability import init_sentry
 from podex.services.cache import TTLCache
 from podex.services.limiter_factory import build_rate_limiter
 
@@ -16,6 +17,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     """Build and configure the Podex FastAPI application."""
     resolved = settings or get_settings()
     configure_logging()
+    init_sentry(resolved)
     app = FastAPI(title=resolved.app_name, debug=resolved.debug)
     # Stash the resolved settings on ``app.state`` so route dependencies see
     # the same instance ``create_app`` used to configure middleware — tests

--- a/backend/src/podex/observability.py
+++ b/backend/src/podex/observability.py
@@ -1,0 +1,97 @@
+"""Sentry error tracking, disabled unless a DSN is configured.
+
+``init_sentry`` is called from both deployables — the FastAPI app factory
+(``podex.main.create_app``) and the scheduler runner process
+(``podex.scheduler_runner.main``) — so each process reports independently.
+Events pass through :func:`scrub_event` to strip email addresses before
+leaving the process.
+"""
+
+import re
+
+import sentry_sdk
+from sentry_sdk.types import Event, Hint
+
+from podex import __version__
+from podex.config import Settings
+
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+_REDACTED = "[redacted-email]"
+
+
+def _scrub_text(value: str) -> str:
+    """Replace any email addresses in ``value`` with a redaction marker.
+
+    Args:
+        value: Text that may contain email addresses.
+
+    Returns:
+        The text with every email address replaced by ``[redacted-email]``.
+    """
+    return _EMAIL_RE.sub(_REDACTED, value)
+
+
+def _scrub_mapping(data: dict[str, object]) -> dict[str, object]:
+    """Scrub email addresses from every string value in a mapping.
+
+    Args:
+        data: Mapping whose string values may contain email addresses.
+
+    Returns:
+        A new mapping with email addresses redacted from string values.
+    """
+    return {
+        key: _scrub_text(value) if isinstance(value, str) else value
+        for key, value in data.items()
+    }
+
+
+def scrub_event(event: Event, hint: Hint) -> Event:
+    """``before_send`` hook that strips PII (emails) from an event.
+
+    Scrubs email addresses from the event message and ``extra`` values, and
+    drops ``user.email`` entirely (scrubbing the remaining user fields).
+
+    Args:
+        event: Sentry event payload about to be sent.
+        hint: Additional context from the SDK (unused).
+
+    Returns:
+        The scrubbed event.
+    """
+    del hint
+    message = event.get("message")
+    if isinstance(message, str):
+        event["message"] = _scrub_text(message)
+    extra = event.get("extra")
+    if isinstance(extra, dict):
+        event["extra"] = _scrub_mapping(extra)
+    user = event.get("user")
+    if isinstance(user, dict):
+        user.pop("email", None)
+        event["user"] = _scrub_mapping(user)
+    return event
+
+
+def init_sentry(settings: Settings) -> bool:
+    """Initialize the Sentry SDK when a DSN is configured.
+
+    No-ops (leaving the SDK fully disabled) when ``settings.sentry_dsn`` is
+    empty. Tracing and profiling stay disabled — error tracking only.
+
+    Args:
+        settings: Runtime settings providing the DSN and environment.
+
+    Returns:
+        True when the SDK was initialized, False when disabled.
+    """
+    if not settings.sentry_dsn:
+        return False
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.sentry_environment,
+        release=f"podex@{__version__}",
+        before_send=scrub_event,
+        send_default_pii=False,
+    )
+    return True

--- a/backend/src/podex/scheduler_runner.py
+++ b/backend/src/podex/scheduler_runner.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from podex.config import Settings, get_settings
 from podex.database import SessionLocal
 from podex.logging_config import get_logger
+from podex.observability import init_sentry
 from podex.services.notification_delivery import DigestSender, build_digest_sender
 from podex.services.recurring_discovery import (
     reconcile_recurring_discovery_schedules,
@@ -130,6 +131,9 @@ class SchedulerRunner:
 
 def main() -> None:
     """Entry point for the scheduler deployable."""
+    # The runner is its own process, so it initializes Sentry independently
+    # of the API deployable.
+    init_sentry(get_settings())
     SchedulerRunner().run_forever()
 
 

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,117 @@
+"""Tests for Sentry initialization and PII scrubbing."""
+
+from unittest.mock import patch
+
+from assertpy import assert_that
+from sentry_sdk.types import Event
+
+from podex import __version__
+from podex.config import Settings
+from podex.main import create_app
+from podex.observability import init_sentry, scrub_event
+from podex.scheduler_runner import main as scheduler_main
+
+
+def test_init_sentry_noops_without_dsn() -> None:
+    """The SDK stays fully disabled when no DSN is configured."""
+    settings = Settings(sentry_dsn="")
+    with patch("podex.observability.sentry_sdk.init") as mock_init:
+        result = init_sentry(settings)
+    assert_that(result).is_false()
+    mock_init.assert_not_called()
+
+
+def test_init_sentry_initializes_with_dsn() -> None:
+    """A configured DSN initializes the SDK with environment and release."""
+    settings = Settings(
+        sentry_dsn="https://key@sentry.example/1",
+        sentry_environment="staging",
+    )
+    with patch("podex.observability.sentry_sdk.init") as mock_init:
+        result = init_sentry(settings)
+    assert_that(result).is_true()
+    mock_init.assert_called_once_with(
+        dsn="https://key@sentry.example/1",
+        environment="staging",
+        release=f"podex@{__version__}",
+        before_send=scrub_event,
+        send_default_pii=False,
+    )
+
+
+def test_init_sentry_defaults_keep_sdk_disabled() -> None:
+    """Default settings carry an empty DSN so Sentry never activates."""
+    settings = Settings()
+    assert_that(settings.sentry_dsn).is_empty()
+    assert_that(settings.sentry_environment).is_equal_to("production")
+
+
+def test_scrub_event_redacts_emails_in_message() -> None:
+    """Email addresses in the event message are redacted."""
+    event: Event = {
+        "message": "login failed for alice.smith+test@example.co.uk today",
+    }
+    scrubbed = scrub_event(event, {})
+    assert_that(scrubbed["message"]).is_equal_to(
+        "login failed for [redacted-email] today",
+    )
+
+
+def test_scrub_event_redacts_emails_in_extra() -> None:
+    """String extra values are scrubbed; non-strings pass through unchanged."""
+    event: Event = {
+        "extra": {
+            "recipient": "bob@example.com",
+            "attempts": 3,
+            "note": "cc dana@example.org and eve@example.net",
+        },
+    }
+    scrubbed = scrub_event(event, {})
+    assert_that(scrubbed["extra"]).is_equal_to(
+        {
+            "recipient": "[redacted-email]",
+            "attempts": 3,
+            "note": "cc [redacted-email] and [redacted-email]",
+        },
+    )
+
+
+def test_scrub_event_drops_user_email() -> None:
+    """The user email is dropped and remaining user strings are scrubbed."""
+    event: Event = {
+        "user": {
+            "email": "carol@example.com",
+            "id": "u-1",
+            "username": "carol@example.com",
+        },
+    }
+    scrubbed = scrub_event(event, {})
+    assert_that(scrubbed["user"]).is_equal_to(
+        {"id": "u-1", "username": "[redacted-email]"},
+    )
+
+
+def test_scrub_event_leaves_clean_events_untouched() -> None:
+    """Events without messages, extras, or users pass through unchanged."""
+    event: Event = {"level": "error"}
+    scrubbed = scrub_event(event, {})
+    assert_that(scrubbed).is_equal_to({"level": "error"})
+
+
+def test_create_app_initializes_sentry() -> None:
+    """The API app factory initializes Sentry with the resolved settings."""
+    settings = Settings(rate_limit_enabled=False)
+    with patch("podex.main.init_sentry") as mock_init:
+        create_app(settings)
+    mock_init.assert_called_once_with(settings)
+
+
+def test_scheduler_main_initializes_sentry() -> None:
+    """The scheduler process initializes Sentry independently."""
+    with (
+        patch("podex.scheduler_runner.init_sentry") as mock_init,
+        patch("podex.scheduler_runner.SchedulerRunner") as mock_runner,
+    ):
+        scheduler_main()
+    mock_init.assert_called_once()
+    mock_runner.return_value.run_forever.assert_called_once_with()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1257,6 +1257,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "rapidfuzz" },
     { name = "redis" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "spotipy" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1290,6 +1291,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "rapidfuzz", specifier = ">=3.9" },
     { name = "redis", specifier = ">=5.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0" },
     { name = "spotipy", specifier = ">=2.24" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
@@ -1760,6 +1762,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/ff/670abe04c5072719b5060ed93851d0d69525d60f8f2c5810f8becd58f9c1/sentry_sdk-2.66.0.tar.gz", hash = "sha256:9727d35aa83c56cd53294676fe65b96296a334c9ce107fa2142bd70f47acb265", size = 935745, upload-time = "2026-07-16T12:42:04.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/bb/49b10783f29067da2eec179320617e94faf63196609de47aeab3c26c3325/sentry_sdk-2.66.0-py3-none-any.whl", hash = "sha256:096136c214c602be2b323524d30755dc5b30ec5a218a206207f33b12c05c6f11", size = 504769, upload-time = "2026-07-16T12:42:02.919Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
 ]
 
 [[package]]

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/check": "^0.9.9",
         "@astrojs/node": "^11.0.0",
         "@astrojs/react": "^6.0.0",
+        "@sentry/browser": "^10.66.0",
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^7.0.0",
         "react": "^19.2.6",
@@ -317,6 +318,20 @@
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
+
+    "@sentry/browser": ["@sentry/browser@10.66.0", "", { "dependencies": { "@sentry/browser-utils": "10.66.0", "@sentry/conventions": "^0.16.0", "@sentry/core": "10.66.0", "@sentry/feedback": "10.66.0", "@sentry/replay": "10.66.0", "@sentry/replay-canvas": "10.66.0" } }, "sha512-MaPoBqKvI7O3UhexSJ/KO/o6T4Tr3A+vQWLZYTos0mxd59jVKMKbbJ6LxM/0uWQ5JAO2XYC/kCMRvk6VqQ5QZw=="],
+
+    "@sentry/browser-utils": ["@sentry/browser-utils@10.66.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0", "@sentry/core": "10.66.0" } }, "sha512-sHuALvJMMEilUz84F1ZOQuDoZ3MhjwUHWHkXcElcVMrDIlnTO7Ra0E6Kh0e8JyJaLBMk4Sy9srKSqH9zimQVTQ=="],
+
+    "@sentry/conventions": ["@sentry/conventions@0.16.0", "", {}, "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ=="],
+
+    "@sentry/core": ["@sentry/core@10.66.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0" } }, "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ=="],
+
+    "@sentry/feedback": ["@sentry/feedback@10.66.0", "", { "dependencies": { "@sentry/core": "10.66.0" } }, "sha512-fr69K76Gz7RRyfMerChdNjWIeQdFh+k21GJcmPCqk43dscUChOsLc3cYLS5cK7iZ/XiUmH9lVzf7EYL2kf2qsA=="],
+
+    "@sentry/replay": ["@sentry/replay@10.66.0", "", { "dependencies": { "@sentry/browser-utils": "10.66.0", "@sentry/core": "10.66.0" } }, "sha512-Djb4FxQa9bF8z3PoCO00Nw1u+6hma2YuI8JkMoE+F14KWRfCZKQ28sScsvk+OokbXgjtuIsxDEZj/qFGY0w01w=="],
+
+    "@sentry/replay-canvas": ["@sentry/replay-canvas@10.66.0", "", { "dependencies": { "@sentry/core": "10.66.0", "@sentry/replay": "10.66.0" } }, "sha512-z7fPWEIfAJMJySKXFIqXAzFpkHjp13WGMAmB9+hlHhi9+gjAO8owD9R4XTd86lBswveGwMHKvIx5lFKNVqDcow=="],
 
     "@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@astrojs/check": "^0.9.9",
     "@astrojs/node": "^11.0.0",
     "@astrojs/react": "^6.0.0",
+    "@sentry/browser": "^10.66.0",
     "@tailwindcss/vite": "^4.0.0",
     "astro": "^7.0.0",
     "react": "^19.2.6",

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly PUBLIC_API_URL?: string;
+  readonly PUBLIC_SENTRY_DSN?: string;
 }
 
 interface ImportMeta {

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -77,6 +77,14 @@ const structuredEntries: unknown[] = Array.isArray(jsonLd)
       href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,300..700&family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&display=swap"
     />
 
+    <script>
+      // Sentry error tracking: no-op (and never loaded) unless
+      // PUBLIC_SENTRY_DSN is configured for the deployment.
+      import { initSentry } from "../lib/sentry";
+
+      void initSentry();
+    </script>
+
     {
       structuredEntries.map((entry) => (
         <script

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,3 +1,19 @@
 /** Base URL for the Podex v2 API. */
 export const API_BASE_URL: string =
   import.meta.env.PUBLIC_API_URL ?? "http://localhost:8000/api/v2";
+
+/**
+ * Resolve the Sentry DSN from a raw env value.
+ *
+ * Returns undefined for missing/blank values so Sentry stays fully disabled
+ * unless a DSN is deployed via PUBLIC_SENTRY_DSN.
+ */
+export function resolveSentryDsn(
+  raw: string | undefined = import.meta.env.PUBLIC_SENTRY_DSN,
+): string | undefined {
+  const dsn = raw?.trim();
+  return dsn ? dsn : undefined;
+}
+
+/** Sentry DSN, or undefined when error tracking is disabled (the default). */
+export const SENTRY_DSN: string | undefined = resolveSentryDsn();

--- a/frontend/src/lib/sentry.test.ts
+++ b/frontend/src/lib/sentry.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SENTRY_DSN, resolveSentryDsn } from "./config";
+import { initSentry, scrubEvent } from "./sentry";
+
+const initMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@sentry/browser", () => ({
+  init: initMock,
+}));
+
+describe("resolveSentryDsn", () => {
+  it.each([
+    { label: "undefined", raw: undefined },
+    { label: "empty", raw: "" },
+    { label: "blank", raw: "   " },
+  ])("returns undefined for a $label value", ({ raw }) => {
+    expect(resolveSentryDsn(raw)).toBeUndefined();
+  });
+
+  it("returns a trimmed DSN when configured", () => {
+    expect(resolveSentryDsn(" https://key@sentry.example/1 ")).toBe(
+      "https://key@sentry.example/1",
+    );
+  });
+
+  it("resolves to undefined by default (no PUBLIC_SENTRY_DSN in env)", () => {
+    expect(SENTRY_DSN).toBeUndefined();
+  });
+});
+
+describe("scrubEvent", () => {
+  it("redacts email addresses in the message", () => {
+    const event = { message: "login failed for alice+test@example.co.uk today" };
+    expect(scrubEvent(event).message).toBe(
+      "login failed for [redacted-email] today",
+    );
+  });
+
+  it("redacts email addresses in string extra values only", () => {
+    const event = {
+      extra: { recipient: "bob@example.com", attempts: 3 },
+    };
+    expect(scrubEvent(event).extra).toEqual({
+      recipient: "[redacted-email]",
+      attempts: 3,
+    });
+  });
+
+  it("drops user.email and scrubs remaining user strings", () => {
+    const event = {
+      user: { email: "carol@example.com", id: "u-1", username: "carol@example.com" },
+    };
+    expect(scrubEvent(event).user).toEqual({
+      id: "u-1",
+      username: "[redacted-email]",
+    });
+  });
+
+  it("leaves events without message, extra, or user untouched", () => {
+    const event = {};
+    expect(scrubEvent(event)).toEqual({});
+  });
+});
+
+describe("initSentry", () => {
+  beforeEach(() => {
+    initMock.mockClear();
+  });
+
+  it("does not initialize the SDK when the DSN is missing", async () => {
+    await expect(initSentry(undefined)).resolves.toBe(false);
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  it("initializes the SDK with PII disabled when a DSN is configured", async () => {
+    await expect(initSentry("https://key@sentry.example/1")).resolves.toBe(true);
+    expect(initMock).toHaveBeenCalledExactlyOnceWith({
+      dsn: "https://key@sentry.example/1",
+      sendDefaultPii: false,
+      beforeSend: expect.any(Function),
+    });
+  });
+
+  it("wires a beforeSend hook that scrubs emails", async () => {
+    await initSentry("https://key@sentry.example/1");
+    const options = initMock.mock.calls[0]?.[0] as {
+      beforeSend: (event: { message?: string }) => { message?: string };
+    };
+    expect(options.beforeSend({ message: "hi dana@example.org" })).toEqual({
+      message: "hi [redacted-email]",
+    });
+  });
+});

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -1,0 +1,75 @@
+/**
+ * Browser Sentry error tracking, disabled unless PUBLIC_SENTRY_DSN is set.
+ *
+ * The SDK is lazy-loaded via dynamic import so the bundle carries zero Sentry
+ * cost when no DSN is configured. Events pass through {@link scrubEvent} to
+ * strip email addresses before leaving the browser.
+ */
+import { SENTRY_DSN } from "./config";
+
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const REDACTED = "[redacted-email]";
+
+/** Minimal structural view of a Sentry event for PII scrubbing. */
+export interface ScrubbableEvent {
+  message?: string;
+  extra?: Record<string, unknown>;
+  user?: {
+    email?: string;
+    [key: string]: unknown;
+  };
+}
+
+function scrubText(value: string): string {
+  return value.replace(EMAIL_RE, REDACTED);
+}
+
+function scrubValues(data: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [
+      key,
+      typeof value === "string" ? scrubText(value) : value,
+    ]),
+  );
+}
+
+/**
+ * beforeSend hook that strips PII (emails) from an event: redacts email
+ * addresses in the message and extra values, and drops user.email.
+ */
+export function scrubEvent<T extends ScrubbableEvent>(event: T): T {
+  if (typeof event.message === "string") {
+    event.message = scrubText(event.message);
+  }
+  if (event.extra) {
+    event.extra = scrubValues(event.extra);
+  }
+  if (event.user) {
+    const { email: _email, ...rest } = event.user;
+    event.user = scrubValues(rest);
+  }
+  return event;
+}
+
+/**
+ * Initialize Sentry when a DSN is configured.
+ *
+ * No-ops (never importing the SDK) when the DSN is missing, so the default
+ * deployment has no Sentry activity at all.
+ *
+ * @returns true when the SDK was initialized, false when disabled.
+ */
+export async function initSentry(
+  dsn: string | undefined = SENTRY_DSN,
+): Promise<boolean> {
+  if (!dsn) {
+    return false;
+  }
+  const Sentry = await import("@sentry/browser");
+  Sentry.init({
+    dsn,
+    sendDefaultPii: false,
+    beforeSend: (event) => scrubEvent(event),
+  });
+  return true;
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(observability): add Sentry error tracking for backend and frontend
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds opt-in Sentry error tracking to both apps, fully disabled by default (part of epic #295):

- **Backend** (`backend/src/podex/observability.py`): `init_sentry(settings)` no-ops when `PODEX_SENTRY_DSN` is empty (the default). When set, it initializes `sentry-sdk` with the configured environment (`PODEX_SENTRY_ENVIRONMENT`, default `production`), a release tagged from `podex.__version__`, and a `before_send` hook that scrubs PII: email addresses are redacted from the event message and `extra` values, and `user.email` is dropped. `send_default_pii=False`; no tracing/profiling. Initialized from both deployables — `create_app` (API) and `scheduler_runner.main` (its own process).
- **Frontend** (`frontend/src/lib/sentry.ts` + `config.ts`): `PUBLIC_SENTRY_DSN` typed in `env.d.ts` and resolved via the `config.ts` convention (`resolveSentryDsn`/`SENTRY_DSN`, undefined when unset). `initSentry` lazy-loads `@sentry/browser` via dynamic import only when a DSN is configured — zero bundle cost when disabled — with the same email-scrubbing `beforeSend`. Wired in `Layout.astro`.
- New settings appended to `Settings`: `sentry_dsn=""`, `sentry_environment="production"`. `sentry-sdk[fastapi]` added to backend deps; `@sentry/browser` to frontend deps. No DSNs committed.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #301
- Relates to #295

## Details

- Backend tests (`backend/tests/test_observability.py`): init no-op without DSN; init kwargs with DSN; scrubber (message, extra, user.email drop, clean events); `create_app` and scheduler `main()` both call `init_sentry` (mocked).
- Frontend tests (`frontend/src/lib/sentry.test.ts`): DSN resolver returns undefined for missing/blank env; `initSentry` never imports/calls the SDK without a DSN; init options and `beforeSend` scrubbing with a DSN (mocked `@sentry/browser`).
- Verification: backend `uv run pytest` 391 passed, coverage 87.03% (gate 85); frontend `bun run check` clean and `bun run test:coverage` green with all four thresholds >= 85 (94.07/87.94/89.71/94.63).
