### PR TITLE
feat(auth): add WorkOS AuthKit sign-in with self-host magic-link fallback

### DIFF
--- a/backend/alembic/versions/0018_add_workos_identity.py
+++ b/backend/alembic/versions/0018_add_workos_identity.py
@@ -1,0 +1,40 @@
+"""Add WorkOS identity columns to account users.
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-07-20 09:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0018"
+down_revision: str | None = "0017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    with op.batch_alter_table("account_users") as batch:
+        batch.add_column(sa.Column("workos_id", sa.String(length=64), nullable=True))
+        batch.add_column(sa.Column("first_name", sa.String(length=100), nullable=True))
+        batch.add_column(sa.Column("last_name", sa.String(length=100), nullable=True))
+    op.create_index(
+        op.f("ix_account_users_workos_id"),
+        "account_users",
+        ["workos_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    op.drop_index(op.f("ix_account_users_workos_id"), table_name="account_users")
+    with op.batch_alter_table("account_users") as batch:
+        batch.drop_column("last_name")
+        batch.drop_column("first_name")
+        batch.drop_column("workos_id")

--- a/backend/src/podex/api/v2/auth.py
+++ b/backend/src/podex/api/v2/auth.py
@@ -6,10 +6,12 @@ work. Magic-link and digest email delivery go through injectable sender
 boundaries so tests and deployments without SMTP stay deterministic.
 """
 
+from secrets import compare_digest, token_urlsafe
 from typing import Annotated
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import RedirectResponse
 
 from podex.api.deps import AppSettings, DbSession
 from podex.config import Settings, get_settings
@@ -57,6 +59,7 @@ from podex.services.account_auth import (
     authenticate_magic_link,
     get_authenticated_user,
     issue_magic_link,
+    issue_user_session,
     revoke_user_session,
 )
 from podex.services.account_digests import list_account_digests, send_pending_digest
@@ -95,9 +98,25 @@ from podex.services.magic_link_delivery import (
     build_magic_link_sender,
 )
 from podex.services.notification_delivery import DigestSender, build_digest_sender
+from podex.services.workos_auth import (
+    WorkOSAuthClient,
+    WorkOSAuthError,
+    build_workos_auth_client,
+    upsert_workos_account_user,
+)
 
 router = APIRouter(tags=["auth"])
 logger = get_logger(__name__)
+
+# The OAuth ``state`` value only needs to survive one round-trip through the
+# hosted sign-in screen, so its cookie stays deliberately short-lived.
+WORKOS_STATE_COOKIE = "podex_oauth_state"
+_WORKOS_STATE_TTL_SECONDS = 10 * 60
+
+
+def get_workos_auth_client() -> WorkOSAuthClient | None:
+    """Build the configured WorkOS AuthKit client, if credentials exist."""
+    return build_workos_auth_client(settings=get_settings())
 
 
 def get_auth_magic_link_sender() -> MagicLinkSender | None:
@@ -123,6 +142,10 @@ DigestSenderDep = Annotated[DigestSender | None, Depends(get_digest_sender)]
 BillingProviderDep = Annotated[
     BillingCheckoutProvider | None,
     Depends(get_billing_provider),
+]
+WorkOSClientDep = Annotated[
+    WorkOSAuthClient | None,
+    Depends(get_workos_auth_client),
 ]
 
 
@@ -264,6 +287,81 @@ def verify_auth_magic_link(
         user=AccountUserRead.model_validate(authenticated.user),
         expires_at=authenticated.expires_at,
     )
+
+
+def begin_workos_login(
+    settings: AppSettings,
+    workos: WorkOSClientDep,
+) -> RedirectResponse:
+    """Start hosted WorkOS AuthKit sign-in with a short-lived state cookie."""
+    if workos is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Hosted sign-in is not configured",
+        )
+    state = token_urlsafe(32)
+    redirect = RedirectResponse(
+        url=workos.build_authorization_url(state=state),
+        status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+    )
+    redirect.set_cookie(
+        key=WORKOS_STATE_COOKIE,
+        value=state,
+        max_age=_WORKOS_STATE_TTL_SECONDS,
+        path="/",
+        secure=settings.auth_session_cookie_secure,
+        httponly=True,
+        samesite="lax",
+    )
+    return redirect
+
+
+def complete_workos_callback(
+    code: str,
+    state: str,
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+    workos: WorkOSClientDep,
+) -> RedirectResponse:
+    """Finish hosted sign-in: validate state, exchange the code, set session."""
+    if workos is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Hosted sign-in is not configured",
+        )
+    expected_state = request.cookies.get(WORKOS_STATE_COOKIE)
+    if not state or not expected_state or not compare_digest(expected_state, state):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Sign-in state is invalid or expired",
+        )
+    try:
+        profile = workos.exchange_code(code=code)
+    except WorkOSAuthError as error:
+        logger.warning("workos_code_exchange_failed: %s", error)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Unable to complete hosted sign-in",
+        ) from error
+    user = upsert_workos_account_user(db=db, profile=profile)
+    authenticated = issue_user_session(
+        db=db,
+        user=user,
+        session_ttl_days=settings.auth_session_ttl_days,
+    )
+    redirect = RedirectResponse(
+        url=f"{settings.public_web_url.rstrip('/')}/account",
+        status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+    )
+    _set_session_cookie(
+        response=redirect,
+        token=authenticated.token,
+        settings=settings,
+    )
+    redirect.delete_cookie(key=WORKOS_STATE_COOKIE, path="/")
+    db.commit()
+    return redirect
 
 
 def logout_account_session(
@@ -681,6 +779,20 @@ router.add_api_route(
     verify_auth_magic_link,
     methods=["POST"],
     response_model=AuthSessionRead,
+)
+
+router.add_api_route(
+    "/auth/login",
+    begin_workos_login,
+    methods=["GET"],
+    response_model=None,
+)
+
+router.add_api_route(
+    "/auth/callback",
+    complete_workos_callback,
+    methods=["GET"],
+    response_model=None,
 )
 
 router.add_api_route(

--- a/backend/src/podex/api/v2/router.py
+++ b/backend/src/podex/api/v2/router.py
@@ -2,17 +2,24 @@
 
 from fastapi import APIRouter
 
+from podex.api.deps import AppSettings
 from podex.api.v2 import auth, episodes, media, ops, podcasts, stats, takedowns
+from podex.api.v2.schemas import ApiStatusRead
 
 api_v2_router = APIRouter(tags=["v2"])
 
 
-def read_status() -> dict[str, str]:
-    """Report that the v2 API surface is reachable."""
-    return {"status": "ok", "api": "v2"}
+def read_status(settings: AppSettings) -> ApiStatusRead:
+    """Report that the v2 API surface is reachable and how sign-in works."""
+    return ApiStatusRead(workos_enabled=settings.workos_enabled)
 
 
-api_v2_router.add_api_route("/status", read_status, methods=["GET"])
+api_v2_router.add_api_route(
+    "/status",
+    read_status,
+    methods=["GET"],
+    response_model=ApiStatusRead,
+)
 api_v2_router.include_router(podcasts.router)
 api_v2_router.include_router(episodes.router)
 api_v2_router.include_router(media.router)

--- a/backend/src/podex/api/v2/schemas.py
+++ b/backend/src/podex/api/v2/schemas.py
@@ -93,6 +93,21 @@ class Page(BaseModel, Generic[ItemT]):
     offset: int = Field(ge=0)
 
 
+class ApiStatusRead(BaseModel):
+    """Reachability probe plus the public sign-in configuration flags.
+
+    Attributes:
+        status: Always ``"ok"`` when the surface is reachable.
+        api: The API surface identifier (``"v2"``).
+        workos_enabled: Whether hosted WorkOS AuthKit sign-in is configured,
+            so the frontend can offer it before attempting a redirect.
+    """
+
+    status: str = "ok"
+    api: str = "v2"
+    workos_enabled: bool = False
+
+
 class ErrorDetail(BaseModel):
     """A single field-level validation problem.
 

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -72,6 +72,20 @@ class Settings(BaseSettings):
     smtp_from_email: str = ""
     smtp_starttls: bool = True
 
+    # Hosted sign-in via WorkOS AuthKit. All three values come from the
+    # deployment environment; with any of them missing the feature stays
+    # off and the SMTP magic-link flow remains the only sign-in path.
+    workos_client_id: str = ""
+    workos_api_key: str = ""
+    workos_redirect_uri: str = ""
+
+    @property
+    def workos_enabled(self) -> bool:
+        """Whether hosted WorkOS AuthKit sign-in is fully configured."""
+        return bool(
+            self.workos_client_id and self.workos_api_key and self.workos_redirect_uri,
+        )
+
     # Paid tier and billing. Both gates default off: ``paid_tier_enabled``
     # controls whether checkout can begin, ``paid_tier_enforced`` controls
     # whether personalization writes require entitlement. The checkout URL

--- a/backend/src/podex/models/account_user.py
+++ b/backend/src/podex/models/account_user.py
@@ -15,5 +15,8 @@ class AccountUser(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     email: Mapped[str] = mapped_column(String(320), unique=True, index=True)
+    workos_id: Mapped[str | None] = mapped_column(String(64), unique=True, index=True)
+    first_name: Mapped[str | None] = mapped_column(String(100))
+    last_name: Mapped[str | None] = mapped_column(String(100))
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
     last_signed_in_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/src/podex/schemas/account.py
+++ b/backend/src/podex/schemas/account.py
@@ -16,6 +16,8 @@ class AccountUserRead(BaseModel):
 
     id: int
     email: str
+    first_name: str | None
+    last_name: str | None
     created_at: datetime
     last_signed_in_at: datetime | None
 

--- a/backend/src/podex/services/account_auth.py
+++ b/backend/src/podex/services/account_auth.py
@@ -93,9 +93,40 @@ def authenticate_magic_link(
         db.add(user)
         db.flush()
     challenge.user_id = user.id
+    challenge.consumed_at = effective_now
+    return issue_user_session(
+        db=db,
+        user=user,
+        session_ttl_days=session_ttl_days,
+        now=effective_now,
+    )
+
+
+def issue_user_session(
+    *,
+    db: Session,
+    user: AccountUser,
+    session_ttl_days: int,
+    now: datetime | None = None,
+) -> AuthenticatedSessionData:
+    """Issue a fresh opaque browser session for an authenticated account.
+
+    Shared by every sign-in path (magic link, hosted WorkOS AuthKit) so
+    the session layer stays identical regardless of how the user proved
+    their identity.
+
+    Args:
+        db: Active database session.
+        user: The account that just authenticated.
+        session_ttl_days: Session lifetime in days.
+        now: Optional clock override for deterministic tests.
+
+    Returns:
+        The user together with the raw session token and its expiry.
+    """
+    effective_now = now or datetime.now(UTC)
     raw_session_token = token_urlsafe(32)
     expires_at = effective_now + timedelta(days=session_ttl_days)
-    challenge.consumed_at = effective_now
     user.last_signed_in_at = effective_now
     db.add(
         UserSession(

--- a/backend/src/podex/services/workos_auth.py
+++ b/backend/src/podex/services/workos_auth.py
@@ -1,0 +1,207 @@
+"""WorkOS AuthKit sign-in bridge.
+
+Builds the hosted AuthKit authorization URL, exchanges callback codes via
+the WorkOS User Management API, and upserts the local account identity.
+Only the profile fields we persist (WorkOS user id, email, names) ever
+leave this module — WorkOS access/refresh tokens and session metadata are
+read from the exchange response and discarded, so browser sessions keep
+referencing our own opaque session ids.
+"""
+
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+import httpx
+from sqlalchemy.orm import Session
+
+from podex.config import Settings
+from podex.models import AccountUser
+
+WORKOS_AUTHORIZE_URL = "https://api.workos.com/user_management/authorize"
+WORKOS_AUTHENTICATE_URL = "https://api.workos.com/user_management/authenticate"
+
+_EXCHANGE_TIMEOUT_SECONDS = 10.0
+
+
+class WorkOSAuthError(RuntimeError):
+    """Raised when the WorkOS code exchange fails or yields no usable user."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkOSUserData:
+    """Profile fields returned by a successful WorkOS code exchange."""
+
+    workos_user_id: str
+    email: str
+    first_name: str | None
+    last_name: str | None
+
+
+class WorkOSAuthClient:
+    """Thin client over the two public WorkOS User Management endpoints.
+
+    Args:
+        client_id: WorkOS environment client id.
+        api_key: WorkOS API key used as the client secret.
+        redirect_uri: Callback URL registered with WorkOS.
+        transport: Optional httpx transport override for tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        api_key: str,
+        redirect_uri: str,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._client_id = client_id
+        self._api_key = api_key
+        self._redirect_uri = redirect_uri
+        self._transport = transport
+
+    def build_authorization_url(self, *, state: str) -> str:
+        """Return the AuthKit hosted authorization URL for a login attempt.
+
+        Args:
+            state: Opaque CSRF token also stored in a short-lived cookie.
+
+        Returns:
+            The fully-parameterized authorization URL to redirect to.
+        """
+        query = urlencode(
+            {
+                "client_id": self._client_id,
+                "redirect_uri": self._redirect_uri,
+                "response_type": "code",
+                "provider": "authkit",
+                "prompt": "login",
+                "state": state,
+            },
+        )
+        return f"{WORKOS_AUTHORIZE_URL}?{query}"
+
+    def exchange_code(self, *, code: str) -> WorkOSUserData:
+        """Exchange a callback authorization code for the signed-in profile.
+
+        Args:
+            code: One-time authorization code from the AuthKit callback.
+
+        Returns:
+            The minimal profile fields we persist locally.
+
+        Raises:
+            WorkOSAuthError: If the exchange fails or omits id/email.
+        """
+        try:
+            with httpx.Client(
+                transport=self._transport,
+                timeout=_EXCHANGE_TIMEOUT_SECONDS,
+            ) as http:
+                response = http.post(
+                    WORKOS_AUTHENTICATE_URL,
+                    data={
+                        "client_id": self._client_id,
+                        "client_secret": self._api_key,
+                        "grant_type": "authorization_code",
+                        "code": code,
+                    },
+                )
+        except httpx.HTTPError as error:
+            msg = "WorkOS authentication request failed"
+            raise WorkOSAuthError(msg) from error
+        if response.status_code != httpx.codes.OK:
+            msg = f"WorkOS code exchange rejected with HTTP {response.status_code}"
+            raise WorkOSAuthError(msg)
+        payload = response.json()
+        user = payload.get("user") if isinstance(payload, dict) else None
+        if not isinstance(user, dict):
+            msg = "WorkOS response did not include a user object"
+            raise WorkOSAuthError(msg)
+        workos_user_id = user.get("id")
+        email = user.get("email")
+        if not isinstance(workos_user_id, str) or not workos_user_id:
+            msg = "WorkOS response did not include a user id"
+            raise WorkOSAuthError(msg)
+        if not isinstance(email, str) or not email:
+            msg = "WorkOS response did not include an email address"
+            raise WorkOSAuthError(msg)
+        return WorkOSUserData(
+            workos_user_id=workos_user_id,
+            email=email.strip().casefold(),
+            first_name=_optional_name(user.get("first_name")),
+            last_name=_optional_name(user.get("last_name")),
+        )
+
+
+def build_workos_auth_client(*, settings: Settings) -> WorkOSAuthClient | None:
+    """Build the WorkOS client, or ``None`` when the feature is not configured.
+
+    Args:
+        settings: Application settings supplying the WorkOS credentials.
+
+    Returns:
+        A configured client, or ``None`` when any credential is missing.
+    """
+    if not settings.workos_enabled:
+        return None
+    return WorkOSAuthClient(
+        client_id=settings.workos_client_id,
+        api_key=settings.workos_api_key,
+        redirect_uri=settings.workos_redirect_uri,
+    )
+
+
+def upsert_workos_account_user(
+    *,
+    db: Session,
+    profile: WorkOSUserData,
+) -> AccountUser:
+    """Create or update the local account for a WorkOS-authenticated profile.
+
+    Matching prefers the stable ``workos_id``; an existing email-only account
+    (e.g. created via the magic-link flow) is attached to the WorkOS identity
+    on first hosted sign-in. Email is synced only when it would not collide
+    with a different local account; names are synced whenever provided.
+
+    Args:
+        db: Active database session.
+        profile: Profile fields from a successful code exchange.
+
+    Returns:
+        The persisted, up-to-date account user.
+    """
+    user = (
+        db.query(AccountUser)
+        .filter(AccountUser.workos_id == profile.workos_user_id)
+        .first()
+    )
+    if user is None:
+        user = db.query(AccountUser).filter(AccountUser.email == profile.email).first()
+        if user is not None:
+            user.workos_id = profile.workos_user_id
+    if user is None:
+        user = AccountUser(email=profile.email, workos_id=profile.workos_user_id)
+        db.add(user)
+    elif user.email != profile.email:
+        taken = (
+            db.query(AccountUser)
+            .filter(AccountUser.email == profile.email, AccountUser.id != user.id)
+            .first()
+        )
+        if taken is None:
+            user.email = profile.email
+    if profile.first_name is not None:
+        user.first_name = profile.first_name
+    if profile.last_name is not None:
+        user.last_name = profile.last_name
+    db.flush()
+    return user
+
+
+def _optional_name(value: object) -> str | None:
+    """Normalize an optional profile name field to a non-empty string."""
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None

--- a/backend/tests/test_api_smoke.py
+++ b/backend/tests/test_api_smoke.py
@@ -28,7 +28,9 @@ def test_health_and_status_smoke(client: TestClient) -> None:
 
     status = client.get("/api/v2/status")
     assert_that(status.status_code).is_equal_to(200)
-    assert_that(status.json()).is_equal_to({"status": "ok", "api": "v2"})
+    assert_that(status.json()).is_equal_to(
+        {"status": "ok", "api": "v2", "workos_enabled": False}
+    )
 
 
 def test_empty_catalog_smoke(client: TestClient) -> None:

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -17,4 +17,6 @@ def test_v2_status_returns_ok(client: TestClient) -> None:
     response = client.get("/api/v2/status")
 
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(response.json()).is_equal_to({"status": "ok", "api": "v2"})
+    assert_that(response.json()).is_equal_to(
+        {"status": "ok", "api": "v2", "workos_enabled": False}
+    )

--- a/backend/tests/test_workos_auth.py
+++ b/backend/tests/test_workos_auth.py
@@ -1,0 +1,466 @@
+"""Tests for hosted WorkOS AuthKit sign-in."""
+
+from dataclasses import fields
+from http.cookies import SimpleCookie
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from assertpy import assert_that
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from podex.api.deps import get_app_settings
+from podex.api.v2 import auth as v2_auth_api
+from podex.config import Settings
+from podex.models import AccountUser, UserSession
+from podex.services.workos_auth import (
+    WORKOS_AUTHENTICATE_URL,
+    WorkOSAuthClient,
+    WorkOSAuthError,
+    WorkOSUserData,
+    build_workos_auth_client,
+    upsert_workos_account_user,
+)
+
+_PROFILE = WorkOSUserData(
+    workos_user_id="user_01ABC",
+    email="reader@example.com",
+    first_name="Ada",
+    last_name="Lovelace",
+)
+
+
+def _workos_settings(*, secure_cookies: bool = True) -> Settings:
+    """Return settings with hosted sign-in fully configured.
+
+    Args:
+        secure_cookies: Whether cookies carry the ``Secure`` attribute. Flow
+            tests disable it so the plain-HTTP test client echoes cookies back.
+
+    Returns:
+        Settings enabling the WorkOS feature.
+    """
+    return Settings(
+        workos_client_id="client_123",
+        workos_api_key="sk_test_456",
+        workos_redirect_uri="https://app.example.com/api/v2/auth/callback",
+        auth_session_cookie_secure=secure_cookies,
+    )
+
+
+class StubWorkOSClient:
+    """Deterministic stand-in for the WorkOS client in API tests."""
+
+    def __init__(
+        self,
+        *,
+        profile: WorkOSUserData = _PROFILE,
+        fail: bool = False,
+    ) -> None:
+        self.profile = profile
+        self.fail = fail
+        self.codes: list[str] = []
+
+    def build_authorization_url(self, *, state: str) -> str:
+        """Return a recognizable authorization URL embedding the state."""
+        return f"https://api.workos.com/user_management/authorize?state={state}"
+
+    def exchange_code(self, *, code: str) -> WorkOSUserData:
+        """Return the canned profile, or fail like a rejected exchange."""
+        if self.fail:
+            msg = "exchange rejected"
+            raise WorkOSAuthError(msg)
+        self.codes.append(code)
+        return self.profile
+
+
+def _override(client: TestClient, workos: object) -> None:
+    """Install WorkOS-enabled settings and a client override on the app."""
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    app.dependency_overrides[get_app_settings] = lambda: _workos_settings(
+        secure_cookies=False,
+    )
+    app.dependency_overrides[v2_auth_api.get_workos_auth_client] = lambda: workos
+
+
+def _state_cookie(response: httpx.Response) -> str:
+    """Read the OAuth state value from the login response cookie."""
+    cookie = SimpleCookie()
+    for header in response.headers.get_list("set-cookie"):
+        cookie.load(header)
+    return cookie[v2_auth_api.WORKOS_STATE_COOKIE].value
+
+
+def test_workos_enabled_requires_all_three_settings() -> None:
+    """The feature stays off unless every WorkOS credential is present."""
+    assert_that(Settings().workos_enabled).is_false()
+    assert_that(Settings(workos_client_id="client_123").workos_enabled).is_false()
+    assert_that(
+        Settings(workos_client_id="client_123", workos_api_key="sk").workos_enabled,
+    ).is_false()
+    assert_that(_workos_settings().workos_enabled).is_true()
+
+
+def test_build_workos_auth_client_requires_configuration() -> None:
+    """The builder returns ``None`` without credentials, a client with them."""
+    assert_that(build_workos_auth_client(settings=Settings())).is_none()
+    assert_that(
+        build_workos_auth_client(settings=_workos_settings()),
+    ).is_instance_of(WorkOSAuthClient)
+
+
+def test_authorization_url_carries_authkit_parameters() -> None:
+    """The hosted authorization URL includes every required parameter."""
+    workos = WorkOSAuthClient(
+        client_id="client_123",
+        api_key="sk_test_456",
+        redirect_uri="https://app.example.com/api/v2/auth/callback",
+    )
+
+    url = urlparse(workos.build_authorization_url(state="state-token"))
+    query = parse_qs(url.query)
+
+    assert_that(url.hostname).is_equal_to("api.workos.com")
+    assert_that(url.path).is_equal_to("/user_management/authorize")
+    assert_that(query["client_id"]).is_equal_to(["client_123"])
+    assert_that(query["redirect_uri"]).is_equal_to(
+        ["https://app.example.com/api/v2/auth/callback"],
+    )
+    assert_that(query["response_type"]).is_equal_to(["code"])
+    assert_that(query["provider"]).is_equal_to(["authkit"])
+    assert_that(query["prompt"]).is_equal_to(["login"])
+    assert_that(query["state"]).is_equal_to(["state-token"])
+
+
+def test_exchange_code_returns_profile_and_drops_tokens() -> None:
+    """A successful exchange yields only the fields we persist."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "user": {
+                    "id": "user_01ABC",
+                    "email": " Reader@Example.COM ",
+                    "first_name": "Ada",
+                    "last_name": "",
+                },
+                "access_token": "at_secret",  # nosec B105 - canned test value
+                "refresh_token": "rt_secret",  # nosec B105 - canned test value
+            },
+        )
+
+    workos = WorkOSAuthClient(
+        client_id="client_123",
+        api_key="sk_test_456",
+        redirect_uri="https://app.example.com/api/v2/auth/callback",
+        transport=httpx.MockTransport(handler),
+    )
+
+    profile = workos.exchange_code(code="auth-code")
+
+    assert_that(str(seen[0].url)).is_equal_to(WORKOS_AUTHENTICATE_URL)
+    body = parse_qs(seen[0].content.decode("utf-8"))
+    assert_that(body["client_id"]).is_equal_to(["client_123"])
+    assert_that(body["client_secret"]).is_equal_to(["sk_test_456"])
+    assert_that(body["grant_type"]).is_equal_to(["authorization_code"])
+    assert_that(body["code"]).is_equal_to(["auth-code"])
+    assert_that(profile.workos_user_id).is_equal_to("user_01ABC")
+    assert_that(profile.email).is_equal_to("reader@example.com")
+    assert_that(profile.first_name).is_equal_to("Ada")
+    assert_that(profile.last_name).is_none()
+    # The dataclass has no room for vendor tokens, so none can be persisted.
+    assert_that([field.name for field in fields(WorkOSUserData)]).is_equal_to(
+        ["workos_user_id", "email", "first_name", "last_name"],
+    )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(401, json={"error": "invalid_grant"}),
+        httpx.Response(200, json={"authenticated": True}),
+        httpx.Response(200, json={"user": {"email": "reader@example.com"}}),
+        httpx.Response(200, json={"user": {"id": "user_01ABC"}}),
+    ],
+)
+def test_exchange_code_rejects_bad_responses(response: httpx.Response) -> None:
+    """Failed or incomplete exchanges raise instead of half-signing-in."""
+    workos = WorkOSAuthClient(
+        client_id="client_123",
+        api_key="sk_test_456",
+        redirect_uri="https://app.example.com/api/v2/auth/callback",
+        transport=httpx.MockTransport(lambda _request: response),
+    )
+
+    with pytest.raises(WorkOSAuthError):
+        workos.exchange_code(code="auth-code")
+
+
+def test_exchange_code_wraps_transport_errors() -> None:
+    """Network failures surface as a WorkOSAuthError."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    workos = WorkOSAuthClient(
+        client_id="client_123",
+        api_key="sk_test_456",
+        redirect_uri="https://app.example.com/api/v2/auth/callback",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(WorkOSAuthError):
+        workos.exchange_code(code="auth-code")
+
+
+def test_upsert_creates_new_account(db_session: Session) -> None:
+    """A first-time hosted sign-in mints a local account."""
+    user = upsert_workos_account_user(db=db_session, profile=_PROFILE)
+    db_session.commit()
+
+    stored = db_session.execute(select(AccountUser)).scalar_one()
+    assert_that(stored.id).is_equal_to(user.id)
+    assert_that(stored.workos_id).is_equal_to("user_01ABC")
+    assert_that(stored.email).is_equal_to("reader@example.com")
+    assert_that(stored.first_name).is_equal_to("Ada")
+    assert_that(stored.last_name).is_equal_to("Lovelace")
+
+
+def test_upsert_matches_returning_user_by_workos_id(db_session: Session) -> None:
+    """A returning hosted user is found by workos_id and synced."""
+    first = upsert_workos_account_user(db=db_session, profile=_PROFILE)
+    updated = upsert_workos_account_user(
+        db=db_session,
+        profile=WorkOSUserData(
+            workos_user_id="user_01ABC",
+            email="renamed@example.com",
+            first_name="Augusta",
+            last_name=None,
+        ),
+    )
+    db_session.commit()
+
+    assert_that(updated.id).is_equal_to(first.id)
+    stored = db_session.execute(select(AccountUser)).scalar_one()
+    assert_that(stored.email).is_equal_to("renamed@example.com")
+    assert_that(stored.first_name).is_equal_to("Augusta")
+    assert_that(stored.last_name).is_equal_to("Lovelace")
+
+
+def test_upsert_attaches_workos_id_to_existing_email_account(
+    db_session: Session,
+) -> None:
+    """A magic-link account is linked to its WorkOS identity by email."""
+    db_session.add(AccountUser(email="reader@example.com"))
+    db_session.commit()
+
+    user = upsert_workos_account_user(db=db_session, profile=_PROFILE)
+    db_session.commit()
+
+    stored = db_session.execute(select(AccountUser)).scalar_one()
+    assert_that(stored.id).is_equal_to(user.id)
+    assert_that(stored.workos_id).is_equal_to("user_01ABC")
+
+
+def test_upsert_keeps_email_when_it_would_collide(db_session: Session) -> None:
+    """An email sync never steals another local account's address."""
+    db_session.add(AccountUser(email="taken@example.com"))
+    db_session.commit()
+    upsert_workos_account_user(db=db_session, profile=_PROFILE)
+
+    user = upsert_workos_account_user(
+        db=db_session,
+        profile=WorkOSUserData(
+            workos_user_id="user_01ABC",
+            email="taken@example.com",
+            first_name=None,
+            last_name=None,
+        ),
+    )
+    db_session.commit()
+
+    assert_that(user.email).is_equal_to("reader@example.com")
+
+
+def test_status_reports_workos_disabled_by_default(client: TestClient) -> None:
+    """The public status probe advertises hosted sign-in as off."""
+    response = client.get("/api/v2/status")
+
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()["workos_enabled"]).is_false()
+
+
+def test_status_reports_workos_enabled_when_configured(client: TestClient) -> None:
+    """The public status probe flips once credentials are configured."""
+    _override(client, StubWorkOSClient())
+
+    response = client.get("/api/v2/status")
+
+    assert_that(response.json()["workos_enabled"]).is_true()
+
+
+def test_login_returns_404_when_workos_disabled(client: TestClient) -> None:
+    """Without configuration the hosted login route does not exist."""
+    response = client.get("/api/v2/auth/login", follow_redirects=False)
+
+    assert_that(response.status_code).is_equal_to(404)
+
+
+def test_login_redirects_with_state_cookie(client: TestClient) -> None:
+    """Login sets a short-lived state cookie and redirects to AuthKit."""
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    app.dependency_overrides[get_app_settings] = _workos_settings
+    app.dependency_overrides[v2_auth_api.get_workos_auth_client] = lambda: (
+        build_workos_auth_client(settings=_workos_settings())
+    )
+
+    response = client.get("/api/v2/auth/login", follow_redirects=False)
+
+    assert_that(response.status_code).is_equal_to(307)
+    location = urlparse(response.headers["location"])
+    query = parse_qs(location.query)
+    assert_that(location.hostname).is_equal_to("api.workos.com")
+    assert_that(query["client_id"]).is_equal_to(["client_123"])
+    assert_that(query["provider"]).is_equal_to(["authkit"])
+    assert_that(query["prompt"]).is_equal_to(["login"])
+    assert_that(query["response_type"]).is_equal_to(["code"])
+    state = _state_cookie(response)
+    assert_that(query["state"]).is_equal_to([state])
+    set_cookie = response.headers["set-cookie"]
+    assert_that(set_cookie).contains("HttpOnly", "Max-Age=600", "Secure")
+
+
+def test_callback_rejects_state_mismatch(client: TestClient) -> None:
+    """A state value that does not match the cookie is rejected."""
+    workos = StubWorkOSClient()
+    _override(client, workos)
+    client.get("/api/v2/auth/login", follow_redirects=False)
+
+    response = client.get(
+        "/api/v2/auth/callback",
+        params={"code": "auth-code", "state": "forged-state"},
+        follow_redirects=False,
+    )
+
+    assert_that(response.status_code).is_equal_to(400)
+    assert_that(workos.codes).is_empty()
+
+
+def test_callback_rejects_missing_state_cookie(client: TestClient) -> None:
+    """An expired or absent state cookie fails closed."""
+    workos = StubWorkOSClient()
+    _override(client, workos)
+
+    response = client.get(
+        "/api/v2/auth/callback",
+        params={"code": "auth-code", "state": "anything"},
+        follow_redirects=False,
+    )
+
+    assert_that(response.status_code).is_equal_to(400)
+    assert_that(workos.codes).is_empty()
+
+
+def test_callback_returns_404_when_workos_disabled(client: TestClient) -> None:
+    """Without configuration the callback route does not exist."""
+    response = client.get(
+        "/api/v2/auth/callback",
+        params={"code": "auth-code", "state": "anything"},
+        follow_redirects=False,
+    )
+
+    assert_that(response.status_code).is_equal_to(404)
+
+
+def test_callback_signs_in_new_user(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """A valid callback upserts the account and issues our session cookie."""
+    workos = StubWorkOSClient()
+    _override(client, workos)
+    login = client.get("/api/v2/auth/login", follow_redirects=False)
+    state = _state_cookie(login)
+
+    response = client.get(
+        "/api/v2/auth/callback",
+        params={"code": "auth-code", "state": state},
+        follow_redirects=False,
+    )
+
+    assert_that(response.status_code).is_equal_to(307)
+    assert_that(response.headers["location"]).is_equal_to(
+        "http://localhost:4321/account",
+    )
+    assert_that(workos.codes).is_equal_to(["auth-code"])
+    user = db_session.execute(select(AccountUser)).scalar_one()
+    assert_that(user.workos_id).is_equal_to("user_01ABC")
+    assert_that(user.email).is_equal_to("reader@example.com")
+    session = db_session.execute(select(UserSession)).scalar_one()
+    assert_that(session.user_id).is_equal_to(user.id)
+    cookie = SimpleCookie()
+    for header in response.headers.get_list("set-cookie"):
+        cookie.load(header)
+    session_token = cookie["podex_session"].value
+    assert_that(cookie["podex_session"]["httponly"]).is_not_equal_to("")
+    # Only a digest of our own opaque token is stored — never the raw value
+    # and never anything issued by WorkOS.
+    assert_that(session.token_digest).is_not_equal_to(session_token)
+    # The state cookie is cleared after use.
+    assert_that(cookie[v2_auth_api.WORKOS_STATE_COOKIE].value).is_equal_to("")
+
+    me = client.get(
+        "/api/v2/me",
+        headers={"Cookie": f"podex_session={session_token}"},
+    )
+    assert_that(me.status_code).is_equal_to(200)
+    assert_that(me.json()["email"]).is_equal_to("reader@example.com")
+    assert_that(me.json()["first_name"]).is_equal_to("Ada")
+
+
+def test_callback_reuses_account_for_returning_user(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """A second hosted sign-in reuses the account matched by workos_id."""
+    workos = StubWorkOSClient()
+    _override(client, workos)
+    for _ in range(2):
+        login = client.get("/api/v2/auth/login", follow_redirects=False)
+        response = client.get(
+            "/api/v2/auth/callback",
+            params={"code": "auth-code", "state": _state_cookie(login)},
+            follow_redirects=False,
+        )
+        assert_that(response.status_code).is_equal_to(307)
+
+    users = db_session.execute(select(AccountUser)).scalars().all()
+    assert_that(users).is_length(1)
+    sessions = db_session.execute(select(UserSession)).scalars().all()
+    assert_that(sessions).is_length(2)
+
+
+def test_callback_maps_exchange_failure_to_bad_gateway(
+    client: TestClient,
+) -> None:
+    """A rejected code exchange surfaces as an upstream failure."""
+    _override(client, StubWorkOSClient(fail=True))
+    login = client.get("/api/v2/auth/login", follow_redirects=False)
+
+    response = client.get(
+        "/api/v2/auth/callback",
+        params={"code": "auth-code", "state": _state_cookie(login)},
+        follow_redirects=False,
+    )
+
+    assert_that(response.status_code).is_equal_to(502)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -13,9 +13,31 @@
             "title": "Email",
             "type": "string"
           },
+          "first_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Name"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
+          },
+          "last_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Name"
           },
           "last_signed_in_at": {
             "anyOf": [
@@ -33,6 +55,8 @@
         "required": [
           "id",
           "email",
+          "first_name",
+          "last_name",
           "created_at",
           "last_signed_in_at"
         ],
@@ -222,6 +246,28 @@
           "enabled"
         ],
         "title": "AlertRuleUpdateRequest",
+        "type": "object"
+      },
+      "ApiStatusRead": {
+        "description": "Reachability probe plus the public sign-in configuration flags.\n\nAttributes:\n    status: Always ``\"ok\"`` when the surface is reachable.\n    api: The API surface identifier (``\"v2\"``).\n    workos_enabled: Whether hosted WorkOS AuthKit sign-in is configured,\n        so the frontend can offer it before attempting a redirect.",
+        "properties": {
+          "api": {
+            "default": "v2",
+            "title": "Api",
+            "type": "string"
+          },
+          "status": {
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "workos_enabled": {
+            "default": false,
+            "title": "Workos Enabled",
+            "type": "boolean"
+          }
+        },
+        "title": "ApiStatusRead",
         "type": "object"
       },
       "AuthLogoutResponse": {
@@ -2557,6 +2603,78 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v2/auth/callback": {
+      "get": {
+        "description": "Finish hosted sign-in: validate state, exchange the code, set session.",
+        "operationId": "complete_workos_callback_api_v2_auth_callback_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "schema": {
+              "title": "State",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Complete Workos Callback",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
+    "/api/v2/auth/login": {
+      "get": {
+        "description": "Start hosted WorkOS AuthKit sign-in with a short-lived state cookie.",
+        "operationId": "begin_workos_login_api_v2_auth_login_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Begin Workos Login",
+        "tags": [
+          "v2",
+          "auth"
+        ]
+      }
+    },
     "/api/v2/auth/logout": {
       "post": {
         "description": "Revoke the current account session and expire its browser cookie.",
@@ -4581,18 +4699,14 @@
     },
     "/api/v2/status": {
       "get": {
-        "description": "Report that the v2 API surface is reachable.",
+        "description": "Report that the v2 API surface is reachable and how sign-in works.",
         "operationId": "read_status_api_v2_status_get",
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "title": "Response Read Status Api V2 Status Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/ApiStatusRead"
                 }
               }
             },

--- a/frontend/src/components/AccountPages.test.tsx
+++ b/frontend/src/components/AccountPages.test.tsx
@@ -110,10 +110,22 @@ function mockRoutes(
   return fetchMock;
 }
 
-function mockAnonymous() {
+function mockAnonymous(workosEnabled = false) {
   vi.stubGlobal(
     "fetch",
     vi.fn((url: string, init?: RequestInit) => {
+      if (String(url).endsWith("/status")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              status: "ok",
+              api: "v2",
+              workos_enabled: workosEnabled,
+            }),
+        } as unknown as Response);
+      }
       if (String(url).endsWith("/me")) {
         return Promise.resolve({
           ok: false,
@@ -153,6 +165,28 @@ describe("account pages", () => {
     fireEvent.click(screen.getByText("Email me a link"));
 
     expect(await screen.findByText(/Check your email/)).toBeDefined();
+  });
+
+  it("AccountShell keeps the email form primary when WorkOS is off", async () => {
+    mockAnonymous(false);
+
+    render(<AccountShell active="/account">{() => <p>body</p>}</AccountShell>);
+
+    expect(await screen.findByLabelText("Email address")).toBeDefined();
+    expect(screen.queryByRole("link", { name: "Sign in" })).toBeNull();
+  });
+
+  it("AccountShell offers hosted WorkOS sign-in when enabled", async () => {
+    mockAnonymous(true);
+
+    render(<AccountShell active="/account">{() => <p>body</p>}</AccountShell>);
+
+    const signIn = await screen.findByRole("link", { name: "Sign in" });
+    expect(signIn.getAttribute("href")).toContain("/auth/login");
+    expect(screen.queryByLabelText("Email address")).toBeNull();
+
+    fireEvent.click(screen.getByText("Use an email link instead"));
+    expect(await screen.findByLabelText("Email address")).toBeDefined();
   });
 
   it("AccountShell reports unavailable sign-in delivery", async () => {
@@ -215,10 +249,7 @@ describe("account pages", () => {
   });
 
   it("AccountSaved lists and removes saved media", async () => {
-    const fetchMock = mockRoutes(
-      { "/me/saves": SAVED, "/me": USER },
-      {},
-    );
+    const fetchMock = mockRoutes({ "/me/saves": SAVED, "/me": USER }, {});
 
     render(<AccountSaved />);
     expect(await screen.findByText("Dune")).toBeDefined();

--- a/frontend/src/components/AccountShell.tsx
+++ b/frontend/src/components/AccountShell.tsx
@@ -3,10 +3,12 @@ import { type ReactNode, useEffect, useState } from "react";
 import {
   AccountApiError,
   type AccountUser,
+  getAuthStatus,
   getMe,
   logout,
   requestMagicLink,
 } from "../lib/account";
+import { API_BASE_URL } from "../lib/config";
 
 const NAV = [
   { href: "/account", label: "Overview" },
@@ -29,14 +31,21 @@ export default function AccountShell({
   children: (user: AccountUser) => ReactNode;
 }) {
   const [user, setUser] = useState<AccountUser | null>(null);
-  const [state, setState] = useState<"loading" | "anonymous" | "ready" | "error">(
-    "loading",
-  );
+  const [state, setState] = useState<
+    "loading" | "anonymous" | "ready" | "error"
+  >("loading");
   const [email, setEmail] = useState("");
   const [requested, setRequested] = useState(false);
   const [signInError, setSignInError] = useState<string | null>(null);
+  const [workosEnabled, setWorkosEnabled] = useState(false);
+  const [showEmailForm, setShowEmailForm] = useState(false);
 
   useEffect(() => {
+    // Hosted sign-in availability is advisory chrome: if the probe fails we
+    // simply keep the self-host email form as the only option.
+    getAuthStatus()
+      .then((apiStatus) => setWorkosEnabled(apiStatus.workos_enabled))
+      .catch(() => setWorkosEnabled(false));
     getMe()
       .then((me) => {
         setUser(me);
@@ -64,7 +73,7 @@ export default function AccountShell({
   }
 
   if (state === "anonymous" || user === null) {
-    return (
+    const emailForm = (
       <form
         className="max-w-md rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-6"
         onSubmit={(event) => {
@@ -113,6 +122,35 @@ export default function AccountShell({
           </>
         )}
       </form>
+    );
+
+    if (!workosEnabled) {
+      return emailForm;
+    }
+
+    return (
+      <div className="max-w-md">
+        <div className="rounded-lg border border-[color:var(--color-hairline)] bg-[color:var(--color-surface)] p-6">
+          <h2 className="font-display text-2xl">Sign in</h2>
+          <p className="mt-2 text-sm text-[color:var(--color-muted)]">
+            Continue with our hosted sign-in. No password needed.
+          </p>
+          <a
+            className="mt-4 inline-block rounded bg-[color:var(--color-accent)] px-4 py-2 text-sm text-white"
+            href={`${API_BASE_URL}/auth/login`}
+          >
+            Sign in
+          </a>
+          <button
+            className="mt-4 ml-4 text-xs text-[color:var(--color-muted)] underline"
+            type="button"
+            onClick={() => setShowEmailForm((current) => !current)}
+          >
+            Use an email link instead
+          </button>
+        </div>
+        {showEmailForm ? <div className="mt-4">{emailForm}</div> : null}
+      </div>
     );
   }
 

--- a/frontend/src/lib/account.ts
+++ b/frontend/src/lib/account.ts
@@ -10,6 +10,7 @@ export type AlertRuleList = components["schemas"]["AlertRuleListRead"];
 export type DigestList = components["schemas"]["DigestListRead"];
 export type Preference = components["schemas"]["PreferenceRead"];
 export type AuthSession = components["schemas"]["AuthSessionRead"];
+export type ApiStatus = components["schemas"]["ApiStatusRead"];
 
 /** Error carrying the HTTP status so callers can branch on 401/503. */
 export class AccountApiError extends Error {
@@ -40,6 +41,11 @@ async function accountFetch<T>(
     );
   }
   return (await response.json()) as T;
+}
+
+/** Public API status, including whether hosted WorkOS sign-in is offered. */
+export function getAuthStatus(): Promise<ApiStatus> {
+  return accountFetch("/status");
 }
 
 export function requestMagicLink(

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -4,6 +4,46 @@
  */
 
 export interface paths {
+    "/api/v2/auth/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Complete Workos Callback
+         * @description Finish hosted sign-in: validate state, exchange the code, set session.
+         */
+        get: operations["complete_workos_callback_api_v2_auth_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v2/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Begin Workos Login
+         * @description Start hosted WorkOS AuthKit sign-in with a short-lived state cookie.
+         */
+        get: operations["begin_workos_login_api_v2_auth_login_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/auth/logout": {
         parameters: {
             query?: never;
@@ -830,7 +870,7 @@ export interface paths {
         };
         /**
          * Read Status
-         * @description Report that the v2 API surface is reachable.
+         * @description Report that the v2 API surface is reachable and how sign-in works.
          */
         get: operations["read_status_api_v2_status_get"];
         put?: never;
@@ -897,8 +937,12 @@ export interface components {
             created_at: string;
             /** Email */
             email: string;
+            /** First Name */
+            first_name: string | null;
             /** Id */
             id: number;
+            /** Last Name */
+            last_name: string | null;
             /** Last Signed In At */
             last_signed_in_at: string | null;
         };
@@ -991,6 +1035,33 @@ export interface components {
         AlertRuleUpdateRequest: {
             /** Enabled */
             enabled: boolean;
+        };
+        /**
+         * ApiStatusRead
+         * @description Reachability probe plus the public sign-in configuration flags.
+         *
+         *     Attributes:
+         *         status: Always ``"ok"`` when the surface is reachable.
+         *         api: The API surface identifier (``"v2"``).
+         *         workos_enabled: Whether hosted WorkOS AuthKit sign-in is configured,
+         *             so the frontend can offer it before attempting a redirect.
+         */
+        ApiStatusRead: {
+            /**
+             * Api
+             * @default v2
+             */
+            api: string;
+            /**
+             * Status
+             * @default ok
+             */
+            status: string;
+            /**
+             * Workos Enabled
+             * @default false
+             */
+            workos_enabled: boolean;
         };
         /**
          * AuthLogoutResponse
@@ -1930,6 +2001,58 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    complete_workos_callback_api_v2_auth_callback_get: {
+        parameters: {
+            query: {
+                code: string;
+                state: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    begin_workos_login_api_v2_auth_login_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     logout_account_session_api_v2_auth_logout_post: {
         parameters: {
             query?: never;
@@ -3279,9 +3402,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: string;
-                    };
+                    "application/json": components["schemas"]["ApiStatusRead"];
                 };
             };
         };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(auth): add WorkOS AuthKit sign-in with self-host magic-link fallback
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds WorkOS AuthKit as the hosted sign-in path while keeping the SMTP magic-link flow as the self-host fallback (epic #295).

- `GET /api/v2/auth/login`: 404 when WorkOS is unconfigured; otherwise sets a ~10-minute http-only random `state` cookie and 307-redirects to the AuthKit authorization URL (`provider=authkit`, `prompt=login`).
- `GET /api/v2/auth/callback`: constant-time state validation against the cookie, code exchange via the WorkOS User Management API (plain `httpx`, no WorkOS SDK), `AccountUser` upsert (match by `workos_id`, then normalized email, else create; sync email and first/last name when provided), then issues the existing opaque `UserSession` cookie via the shared session-issuance path and redirects to `/account`. No WorkOS tokens or session metadata are ever persisted.
- Settings: `PODEX_WORKOS_CLIENT_ID`, `PODEX_WORKOS_API_KEY`, `PODEX_WORKOS_REDIRECT_URI` (empty defaults keep the feature off; `Settings.workos_enabled` helper).
- Migration `0018`: nullable unique-indexed `workos_id` plus nullable `first_name`/`last_name` on `account_users` (needed for the name sync required by the callback upsert).
- `GET /api/v2/status` now returns a typed body including `workos_enabled` so the frontend can offer hosted sign-in.
- Frontend: `AccountShell` probes the status endpoint; when enabled it shows a primary "Sign in" button linking to `${API_BASE_URL}/auth/login` with the magic-link email form behind a "Use an email link instead" toggle; when disabled the email form renders unchanged (#113 hardening semantics untouched).

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #296
- Relates to #295

## Details

- Session layer untouched: only a sha256 digest of our own random session token is stored; the WorkOS exchange response's `access_token`/`refresh_token` are read and discarded (the profile dataclass has no token fields, asserted in tests).
- Session issuance was extracted from `authenticate_magic_link` into `issue_user_session` and reused by the callback, so both sign-in paths share identical session semantics.
- Email sync on returning users skips addresses already owned by a different local account to avoid unique-constraint theft.
- `frontend/openapi.json` and `types.gen.ts` regenerated (`python -m podex.openapi` + `bun run generate:api`).

Verification:

- Backend: `uv run pytest` — 405 passed, coverage 87.14% (gate 85). New `tests/test_workos_auth.py` covers login redirect params + state cookie, disabled 404s, state mismatch/expiry rejection, new-user upsert, returning-user by `workos_id`, email-match attach, email-collision guard, session cookie issuance, exchange failure mapping, and no-token-persistence.
- Frontend: `bun run test:coverage` — 73 passed; statements 93.89 / branches 87.38 / functions 89.59 / lines 94.45. `bun run check` (astro check + generated-types drift) passes.
- Lint: `uv run lintro fmt` + `uv run lintro chk` — all code tools pass (ruff, black, mypy, bandit, pydoclint, prettier, tsc, semgrep, gitleaks). Remaining local `chk` noise is environmental only: markdownlint flagging lintro's own transient `run-*/report.md` artifacts, a broken local `pip-audit` install (ensurepip SIGABRT), and `oxfmt` disagreeing with the repo's committed prettier style across pre-existing files — relying on the CI Lintro job as the gate for those.