### PR TITLE
fix(extraction): resolve post-merge review findings in extraction_review

### DIFF
--- a/backend/src/podex/services/extraction_review.py
+++ b/backend/src/podex/services/extraction_review.py
@@ -478,7 +478,8 @@ def _update_candidate(
     """
     candidate.raw_title = item.title
     candidate.normalized_title = normalized_title
-    candidate.suggested_author = item.creator
+    if _normalize_value(value=item.creator) is not None:
+        candidate.suggested_author = item.creator
     candidate.confidence = item.confidence
     candidate.extraction_source = extraction_source
     candidate.timestamp_seconds = timestamp_seconds or candidate.timestamp_seconds

--- a/backend/src/podex/services/extraction_review.py
+++ b/backend/src/podex/services/extraction_review.py
@@ -261,24 +261,48 @@ def _find_matching_media(
     db: Session,
     media_type: str,
     normalized_title: str | None,
+    normalized_creator: str | None,
+    year: int | None,
 ) -> Media | None:
     """Resolve an extracted title against existing canonical media records.
+
+    When several records share the same type and normalized title, the
+    extracted creator and year narrow the matches; an ambiguous result
+    yields no link rather than a guess.
 
     Args:
         db: Database session.
         media_type: Extracted media type value.
         normalized_title: Normalized extracted title.
+        normalized_creator: Normalized extracted author/creator.
+        year: Extracted publication year, if any.
 
     Returns:
-        Matching canonical media record when found.
+        Matching canonical media record when exactly one remains.
     """
     if normalized_title is None:
         return None
 
     candidates = db.query(Media).filter(Media.type == media_type).all()
-    for media in candidates:
-        if _normalize_value(value=media.title) == normalized_title:
-            return media
+    matches = [
+        media
+        for media in candidates
+        if _normalize_value(value=media.title) == normalized_title
+    ]
+    if len(matches) <= 1:
+        return matches[0] if matches else None
+
+    if normalized_creator is not None:
+        matches = [
+            media
+            for media in matches
+            if _normalize_value(value=media.author) == normalized_creator
+        ]
+    if len(matches) > 1 and year is not None:
+        matches = [media for media in matches if media.year == year]
+
+    if len(matches) == 1:
+        return matches[0]
     return None
 
 
@@ -563,6 +587,8 @@ def persist_extracted_candidates(
             db=db,
             media_type=item.media_type.value,
             normalized_title=normalized_title,
+            normalized_creator=normalized_author,
+            year=item.year,
         )
 
         if matched_media is not None and matched_media.id in existing_media_mentions:

--- a/backend/src/podex/services/extraction_review.py
+++ b/backend/src/podex/services/extraction_review.py
@@ -462,12 +462,12 @@ def _ensure_review_item(
     priority = _priority_for_confidence(confidence=confidence)
 
     if candidate.review_item is None:
-        db.add(
-            ReviewItem(
-                mention_candidate_id=candidate.id,
-                priority=priority.value,
-            )
+        review_item = ReviewItem(
+            mention_candidate_id=candidate.id,
+            priority=priority.value,
         )
+        candidate.review_item = review_item
+        db.add(review_item)
         return True
 
     if candidate.review_item.status in {

--- a/backend/src/podex/services/extraction_review.py
+++ b/backend/src/podex/services/extraction_review.py
@@ -674,13 +674,14 @@ def persist_extracted_candidates(
             before=before_snapshot,
             after=after_snapshot,
         )
-        _record_candidate_provenance(
-            db=db,
-            candidate=candidate,
-            event_type=MentionCandidateProvenanceEventType.UPDATED,
-            change_summary=_build_change_summary(changed_fields=changed_fields),
-            changed_fields=changed_fields,
-        )
+        if changed_fields:
+            _record_candidate_provenance(
+                db=db,
+                candidate=candidate,
+                event_type=MentionCandidateProvenanceEventType.UPDATED,
+                change_summary=_build_change_summary(changed_fields=changed_fields),
+                changed_fields=changed_fields,
+            )
         review_item_created = _ensure_review_item(
             db=db,
             candidate=candidate,
@@ -688,7 +689,7 @@ def persist_extracted_candidates(
         )
         summary = PersistedExtractionReviewData(
             candidates_created=summary.candidates_created,
-            candidates_updated=summary.candidates_updated + 1,
+            candidates_updated=summary.candidates_updated + int(bool(changed_fields)),
             review_items_created=(
                 summary.review_items_created + int(review_item_created)
             ),

--- a/backend/src/podex/services/extraction_review.py
+++ b/backend/src/podex/services/extraction_review.py
@@ -115,6 +115,32 @@ def _priority_for_confidence(*, confidence: float) -> ReviewPriority:
     return ReviewPriority.LOW
 
 
+def _phrase_in_tokens(*, phrase: str, segment: str) -> bool:
+    """Check whether a phrase appears as contiguous tokens in a segment.
+
+    Both inputs are expected to be pre-normalized via ``_normalize_value``
+    (lowercase, punctuation-stripped, whitespace-collapsed), so token-level
+    comparison avoids substring false positives such as ``it`` in ``italy``.
+
+    Args:
+        phrase: Normalized phrase to look for.
+        segment: Normalized segment text to search within.
+
+    Returns:
+        ``True`` when the phrase tokens appear contiguously and in order.
+    """
+    phrase_tokens = phrase.split()
+    segment_tokens = segment.split()
+    if not phrase_tokens or len(phrase_tokens) > len(segment_tokens):
+        return False
+
+    span = len(phrase_tokens)
+    return any(
+        segment_tokens[start : start + span] == phrase_tokens
+        for start in range(len(segment_tokens) - span + 1)
+    )
+
+
 def _segment_text(*, segment: dict[str, Any]) -> str | None:
     """Extract normalized text content from a transcript segment.
 
@@ -209,9 +235,12 @@ def _find_segment_context(
             continue
 
         score = 0
-        if normalized_title in normalized_segment:
+        if _phrase_in_tokens(phrase=normalized_title, segment=normalized_segment):
             score += 2
-        if normalized_creator is not None and normalized_creator in normalized_segment:
+        if normalized_creator is not None and _phrase_in_tokens(
+            phrase=normalized_creator,
+            segment=normalized_segment,
+        ):
             score += 1
 
         if score > best_score:

--- a/backend/tests/test_extraction_review.py
+++ b/backend/tests/test_extraction_review.py
@@ -281,6 +281,82 @@ def test_persist_leaves_ambiguous_duplicate_titles_unlinked(
     assert_that(candidate.media_id).is_none()
 
 
+def test_persist_preserves_known_author_on_sparse_replay(
+    db_session: Session,
+) -> None:
+    """A replay without a creator keeps the previously known author."""
+    episode = _episode(db_session)
+    rich = ExtractedMedia(
+        title="Dune",
+        media_type=MediaType.BOOK,
+        creator="Frank Herbert",
+        confidence=0.9,
+    )
+    sparse = ExtractedMedia(title="Dune", media_type=MediaType.BOOK, confidence=0.7)
+
+    persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[rich],
+        segments=None,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+    persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[sparse],
+        segments=None,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+
+    candidate = db_session.execute(select(MentionCandidate)).scalar_one()
+    assert_that(candidate.suggested_author).is_equal_to("Frank Herbert")
+    events = db_session.execute(select(MentionCandidateProvenance)).scalars().all()
+    for event in events:
+        changed_fields = (event.metadata_json or {}).get("changed_fields", [])
+        assert_that(changed_fields).does_not_contain("suggested_author")
+
+
+def test_persist_updates_author_on_replay_with_new_creator(
+    db_session: Session,
+) -> None:
+    """A replay with a new non-empty creator still updates the author."""
+    episode = _episode(db_session)
+    first = ExtractedMedia(title="Dune", media_type=MediaType.BOOK, confidence=0.9)
+    corrected = ExtractedMedia(
+        title="Dune",
+        media_type=MediaType.BOOK,
+        creator="Frank Herbert",
+        confidence=0.9,
+    )
+
+    persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[first],
+        segments=None,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+    persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[corrected],
+        segments=None,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+
+    candidate = db_session.execute(select(MentionCandidate)).scalar_one()
+    assert_that(candidate.suggested_author).is_equal_to("Frank Herbert")
+
+
 def test_persist_skips_items_with_existing_published_mentions(
     db_session: Session,
 ) -> None:

--- a/backend/tests/test_extraction_review.py
+++ b/backend/tests/test_extraction_review.py
@@ -16,7 +16,10 @@ from podex.models import (
     ReviewPriority,
 )
 from podex.models.media import MediaType
-from podex.services.extraction_review import persist_extracted_candidates
+from podex.services.extraction_review import (
+    _find_segment_context,
+    persist_extracted_candidates,
+)
 from podex.services.llm_extraction import ExtractedMedia
 from tests.conftest import seed_catalog_graph
 
@@ -129,6 +132,45 @@ def test_persist_is_replay_safe_and_records_update_provenance(
         .all()
     )
     assert_that(len(events)).is_greater_than(1)
+
+
+def test_segment_context_rejects_substring_title_matches() -> None:
+    """A short title must not match inside an unrelated longer word."""
+    item = ExtractedMedia(title="It", media_type=MediaType.BOOK, confidence=0.9)
+    segments = [{"text": "italy is beautiful", "start": 10}]
+
+    match = _find_segment_context(item=item, segments=segments)
+
+    assert_that(match.timestamp_seconds).is_none()
+    assert_that(match.context).is_none()
+
+
+def test_segment_context_matches_standalone_token_title() -> None:
+    """A short title matches when it appears as a standalone token."""
+    item = ExtractedMedia(title="It", media_type=MediaType.BOOK, confidence=0.9)
+    segments = [{"text": "we read it last night", "start": 12}]
+
+    match = _find_segment_context(item=item, segments=segments)
+
+    assert_that(match.timestamp_seconds).is_equal_to(12)
+    assert_that(match.context).contains("we read it last night")
+
+
+def test_segment_context_requires_contiguous_ordered_title_tokens() -> None:
+    """Multi-word titles match only contiguous, in-order token runs."""
+    item = ExtractedMedia(
+        title="War and Peace",
+        media_type=MediaType.BOOK,
+        confidence=0.9,
+    )
+    scattered = [{"text": "peace talks and the war effort", "start": 5}]
+    contiguous = [{"text": "reading war and peace tonight", "start": 7}]
+
+    scattered_match = _find_segment_context(item=item, segments=scattered)
+    contiguous_match = _find_segment_context(item=item, segments=contiguous)
+
+    assert_that(scattered_match.timestamp_seconds).is_none()
+    assert_that(contiguous_match.timestamp_seconds).is_equal_to(7)
 
 
 def test_persist_repeated_match_in_one_batch_creates_single_review_item(

--- a/backend/tests/test_extraction_review.py
+++ b/backend/tests/test_extraction_review.py
@@ -12,6 +12,7 @@ from podex.models import (
     Mention,
     MentionCandidate,
     MentionCandidateProvenance,
+    MentionCandidateProvenanceEventType,
     MentionCandidateState,
     Podcast,
     ReviewItem,
@@ -355,6 +356,82 @@ def test_persist_updates_author_on_replay_with_new_creator(
 
     candidate = db_session.execute(select(MentionCandidate)).scalar_one()
     assert_that(candidate.suggested_author).is_equal_to("Frank Herbert")
+
+
+def test_persist_identical_replay_is_a_no_op(db_session: Session) -> None:
+    """Replaying identical inputs records no update and no provenance."""
+    episode = _episode(db_session)
+    item = ExtractedMedia(
+        title="Dune",
+        media_type=MediaType.BOOK,
+        creator="Frank Herbert",
+        confidence=0.9,
+    )
+
+    persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[item],
+        segments=_SEGMENTS,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+    result = persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[item],
+        segments=_SEGMENTS,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+
+    assert_that(result.candidates_created).is_equal_to(0)
+    assert_that(result.candidates_updated).is_equal_to(0)
+    events = db_session.execute(select(MentionCandidateProvenance)).scalars().all()
+    assert_that(events).is_length(1)
+    assert_that(events[0].event_type).is_equal_to(
+        MentionCandidateProvenanceEventType.CREATED.value,
+    )
+
+
+def test_persist_changed_replay_records_single_update_event(
+    db_session: Session,
+) -> None:
+    """A replay that changes a field counts and records exactly one update."""
+    episode = _episode(db_session)
+    first = ExtractedMedia(title="Dune", media_type=MediaType.BOOK, confidence=0.7)
+    changed = ExtractedMedia(title="Dune", media_type=MediaType.BOOK, confidence=0.9)
+
+    persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[first],
+        segments=None,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+    result = persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[changed],
+        segments=None,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+
+    assert_that(result.candidates_updated).is_equal_to(1)
+    updated_events = [
+        event
+        for event in (
+            db_session.execute(select(MentionCandidateProvenance)).scalars().all()
+        )
+        if event.event_type == MentionCandidateProvenanceEventType.UPDATED.value
+    ]
+    assert_that(updated_events).is_length(1)
 
 
 def test_persist_skips_items_with_existing_published_mentions(

--- a/backend/tests/test_extraction_review.py
+++ b/backend/tests/test_extraction_review.py
@@ -131,6 +131,39 @@ def test_persist_is_replay_safe_and_records_update_provenance(
     assert_that(len(events)).is_greater_than(1)
 
 
+def test_persist_repeated_match_in_one_batch_creates_single_review_item(
+    db_session: Session,
+) -> None:
+    """Two batch items resolving to one candidate create one review item."""
+    episode = _episode(db_session)
+    items = [
+        ExtractedMedia(title="Dune", media_type=MediaType.BOOK, confidence=0.7),
+        ExtractedMedia(
+            title="Dune",
+            media_type=MediaType.BOOK,
+            creator="Frank Herbert",
+            confidence=0.9,
+        ),
+    ]
+
+    result = persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=items,
+        segments=_SEGMENTS,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+
+    assert_that(result.candidates_created).is_equal_to(1)
+    assert_that(result.review_items_created).is_equal_to(1)
+    candidate = db_session.execute(select(MentionCandidate)).scalar_one()
+    review_items = db_session.execute(select(ReviewItem)).scalars().all()
+    assert_that(review_items).is_length(1)
+    assert_that(review_items[0].mention_candidate_id).is_equal_to(candidate.id)
+
+
 def test_persist_skips_items_with_existing_published_mentions(
     db_session: Session,
 ) -> None:

--- a/backend/tests/test_extraction_review.py
+++ b/backend/tests/test_extraction_review.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Session
 
 from podex.models import (
     Episode,
+    Media,
+    Mention,
     MentionCandidate,
     MentionCandidateProvenance,
     MentionCandidateState,
@@ -204,6 +206,79 @@ def test_persist_repeated_match_in_one_batch_creates_single_review_item(
     review_items = db_session.execute(select(ReviewItem)).scalars().all()
     assert_that(review_items).is_length(1)
     assert_that(review_items[0].mention_candidate_id).is_equal_to(candidate.id)
+
+
+def _duplicate_dune_media(db_session: Session) -> tuple[Media, Media]:
+    frank = Media(
+        type=MediaType.BOOK,
+        title="Dune",
+        author="Frank Herbert",
+        year=1965,
+    )
+    brian = Media(type=MediaType.BOOK, title="Dune", author="Brian Herbert")
+    db_session.add_all([frank, brian])
+    db_session.commit()
+    return frank, brian
+
+
+def test_persist_disambiguates_duplicate_titles_by_creator(
+    db_session: Session,
+) -> None:
+    """A matching creator links the right record among duplicate titles."""
+    frank, _ = _duplicate_dune_media(db_session)
+    episode = _episode(db_session)
+
+    persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[
+            ExtractedMedia(
+                title="Dune",
+                media_type=MediaType.BOOK,
+                creator="Frank Herbert",
+                confidence=0.9,
+            ),
+        ],
+        segments=None,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+
+    candidate = db_session.execute(select(MentionCandidate)).scalar_one()
+    assert_that(candidate.media_id).is_equal_to(frank.id)
+
+
+def test_persist_leaves_ambiguous_duplicate_titles_unlinked(
+    db_session: Session,
+) -> None:
+    """Duplicate titles without a discriminating creator stay unlinked."""
+    frank, _ = _duplicate_dune_media(db_session)
+    episode = _episode(db_session)
+    mention = Mention(episode_id=episode.id, media_id=frank.id, confidence=0.9)
+    db_session.add(mention)
+    db_session.commit()
+
+    result = persist_extracted_candidates(
+        db=db_session,
+        episode=episode,
+        items=[
+            ExtractedMedia(
+                title="Dune",
+                media_type=MediaType.BOOK,
+                confidence=0.9,
+            ),
+        ],
+        segments=None,
+        min_confidence=0.5,
+        extraction_source="llm",
+    )
+    db_session.commit()
+
+    assert_that(result.skipped_existing_mentions).is_equal_to(0)
+    assert_that(result.candidates_created).is_equal_to(1)
+    candidate = db_session.execute(select(MentionCandidate)).scalar_one()
+    assert_that(candidate.media_id).is_none()
 
 
 def test_persist_skips_items_with_existing_published_mentions(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `fix(extraction): resolve post-merge review findings in extraction_review`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Five post-merge CodeRabbit findings in `backend/src/podex/services/extraction_review.py`, bundled into one PR because they all touch the same file. One commit per issue, each with regression tests.

### #305 — duplicate ReviewItem insert in one batch (Critical)

`_ensure_review_item` created the new `ReviewItem` detached (`db.add` only), so `candidate.review_item` stayed `None` for a second match of the same candidate within one batch, inserting a duplicate row that violates the unique `mention_candidate_id` constraint on flush. The new item is now assigned to the `candidate.review_item` relationship; the second call takes the priority-update branch. Regression test: two batch items resolving to one candidate commit cleanly with exactly one `ReviewItem` and `review_items_created == 1`.

### #306 — substring false positives in transcript matching

`_find_segment_context` used raw `in` substring checks, so title "It" matched inside "italy". Added `_phrase_in_tokens` (token-contiguous, in-order matching over the already-normalized text); scoring weights (+2 title, +1 creator) and first-best tie behavior unchanged.

### #307 — canonical media ambiguity

`_find_matching_media` returned the first title match regardless of duplicates. It now collects all type+normalized-title matches and narrows duplicates by normalized author and year from the extracted item; if ambiguity persists it returns `None` instead of guessing, so the published-mention skip cannot fire against the wrong record.

### #308 — sparse replay erased suggested_author

`_update_candidate` unconditionally overwrote `suggested_author`. The assignment is now guarded by `_normalize_value(value=item.creator) is not None`, so a replay without a creator preserves the known author (and does not appear in provenance `changed_fields`), while a new non-empty creator still updates it.

### #309 — identical replays were not no-ops

The update path always recorded an UPDATED provenance event and incremented `candidates_updated`. Both now happen only when `changed_fields` is non-empty; `_ensure_review_item` is still called unconditionally so priority refresh keeps working.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #305
- Closes #306
- Closes #307
- Closes #308
- Closes #309

## Details

- Verification: full backend suite `uv run pytest` — 392 passed; coverage 87.01% (threshold 85%). `uv run lintro fmt` + `uv run lintro chk`: all Python tools clean (black/ruff 0 issues); remaining lintro failures are self-scan noise on gitignored `.lintro/` report artifacts plus one tool whose venv bootstrap fails in this environment (ensurepip SIGABRT), unrelated to this change.
- #305 regression test was verified red against the pre-fix code (IntegrityError on commit) before the fix.
- Note: the last three commits are currently unsigned — the 1Password SSH signing agent is returning errors locally; they can be re-signed with an autosquash rebase once the agent is available again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript matching to avoid false matches from partial or out-of-order titles.
  * Improved media linking by disambiguating duplicate titles using creator and publication year.
  * Prevented sparse updates from clearing an existing suggested author.
  * Avoided recording unnecessary candidate updates for identical extraction results.
  * Prevented duplicate review items when the same candidate appears multiple times.

* **Tests**
  * Expanded coverage for matching, media disambiguation, replay behavior, and update tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->