### PR TITLE
fix(enrichment): harden provider modules per post-merge review (#312-#316, #322)

### DIFF
--- a/backend/src/podex/services/enrichment/base.py
+++ b/backend/src/podex/services/enrichment/base.py
@@ -14,6 +14,41 @@ import httpx
 if TYPE_CHECKING:
     from podex.models.media import Media
 
+#: Prefixes stripped from DOI values, matched case-insensitively.
+_DOI_PREFIXES = (
+    "https://doi.org/",
+    "http://doi.org/",
+    "doi.org/",
+    "doi:",
+)
+
+
+def canonicalize_doi(value: str) -> str:
+    """Canonicalize a DOI by stripping URL/scheme prefixes and whitespace.
+
+    Strips ``https://doi.org/``, ``http://doi.org/``, ``doi.org/``, and
+    ``doi:`` prefixes (case-insensitively, repeatedly) so the bare DOI can
+    be used in provider-specific query syntax. The DOI body's case is
+    preserved.
+
+    Args:
+        value: Raw DOI value, possibly prefixed (e.g. from user input).
+
+    Returns:
+        The bare DOI (e.g. ``10.1000/x``).
+    """
+    doi = value.strip()
+    stripped = True
+    while stripped:
+        stripped = False
+        lowered = doi.lower()
+        for prefix in _DOI_PREFIXES:
+            if lowered.startswith(prefix):
+                doi = doi[len(prefix) :].strip()
+                stripped = True
+                break
+    return doi
+
 
 def describe_http_error(e: httpx.HTTPError) -> str:
     """Describe an HTTP error without leaking URLs or credentials.

--- a/backend/src/podex/services/enrichment/base.py
+++ b/backend/src/podex/services/enrichment/base.py
@@ -9,8 +9,28 @@ from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import httpx
+
 if TYPE_CHECKING:
     from podex.models.media import Media
+
+
+def describe_http_error(e: httpx.HTTPError) -> str:
+    """Describe an HTTP error without leaking URLs or credentials.
+
+    ``str(e)`` on httpx errors can include the full request URL, which may
+    carry API keys in query parameters. This helper returns only the status
+    code or the exception class name.
+
+    Args:
+        e: The httpx error to describe.
+
+    Returns:
+        ``"HTTP <status>"`` for status errors, else the exception class name.
+    """
+    if isinstance(e, httpx.HTTPStatusError):
+        return f"HTTP {e.response.status_code}"
+    return type(e).__name__
 
 
 class EnrichmentSource(StrEnum):

--- a/backend/src/podex/services/enrichment/crossref.py
+++ b/backend/src/podex/services/enrichment/crossref.py
@@ -12,6 +12,7 @@ from podex.services.enrichment.base import (
     EnrichmentProvider,
     EnrichmentResult,
     EnrichmentSource,
+    canonicalize_doi,
 )
 
 if TYPE_CHECKING:
@@ -102,12 +103,9 @@ class CrossRefProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         Returns:
             Work data or None.
         """
-        # Normalize DOI - remove common prefixes
-        normalized_doi = doi.lower().strip()
-        for prefix in ["https://doi.org/", "http://doi.org/", "doi:"]:
-            if normalized_doi.startswith(prefix):
-                normalized_doi = normalized_doi[len(prefix) :]
-                break
+        # Normalize DOI - remove common prefixes (CrossRef DOIs are
+        # case-insensitive, so lowercase for a canonical path)
+        normalized_doi = canonicalize_doi(doi).lower()
 
         try:
             response = self.client.get(f"/works/{normalized_doi}")

--- a/backend/src/podex/services/enrichment/google_books.py
+++ b/backend/src/podex/services/enrichment/google_books.py
@@ -11,6 +11,7 @@ from podex.services.enrichment.base import (
     EnrichmentProvider,
     EnrichmentResult,
     EnrichmentSource,
+    describe_http_error,
 )
 
 if TYPE_CHECKING:
@@ -129,7 +130,7 @@ class GoogleBooksProvider(EnrichmentProvider):  # type: ignore[misc, unused-igno
             result: list[dict[str, Any]] = data.get("items", [])
             return result
         except httpx.HTTPError as e:
-            logger.warning(f"Google Books search error: {e}")
+            logger.warning(f"Google Books search error: {describe_http_error(e)}")
             return []
 
     def _get_volume(self, volume_id: str) -> dict[str, Any] | None:
@@ -147,7 +148,9 @@ class GoogleBooksProvider(EnrichmentProvider):  # type: ignore[misc, unused-igno
             result: dict[str, Any] = response.json()
             return result
         except httpx.HTTPError as e:
-            logger.warning(f"Google Books volume error for {volume_id}: {e}")
+            logger.warning(
+                f"Google Books volume error for {volume_id}: {describe_http_error(e)}",
+            )
             return None
 
     def _find_best_match(

--- a/backend/src/podex/services/enrichment/omdb.py
+++ b/backend/src/podex/services/enrichment/omdb.py
@@ -32,7 +32,7 @@ class OMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         requests_per_second: Rate limit for API calls.
     """
 
-    BASE_URL = "http://www.omdbapi.com"
+    BASE_URL = "https://www.omdbapi.com"
 
     source = EnrichmentSource.OMDB
 

--- a/backend/src/podex/services/enrichment/omdb.py
+++ b/backend/src/podex/services/enrichment/omdb.py
@@ -16,6 +16,7 @@ from podex.services.enrichment.base import (
     EnrichmentProvider,
     EnrichmentResult,
     EnrichmentSource,
+    describe_http_error,
 )
 
 if TYPE_CHECKING:
@@ -133,7 +134,9 @@ class OMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
             result: dict[str, Any] = response.json()
             return result
         except httpx.HTTPError as e:
-            logger.warning(f"OMDB error for IMDB ID {imdb_id}: {e}")
+            logger.warning(
+                f"OMDB error for IMDB ID {imdb_id}: {describe_http_error(e)}",
+            )
             return None
 
     def _search_by_title(
@@ -167,7 +170,9 @@ class OMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
             result: dict[str, Any] = response.json()
             return result
         except httpx.HTTPError as e:
-            logger.warning(f"OMDB search error for '{title}': {e}")
+            logger.warning(
+                f"OMDB search error for '{title}': {describe_http_error(e)}",
+            )
             return None
 
     def _build_result(

--- a/backend/src/podex/services/enrichment/omdb.py
+++ b/backend/src/podex/services/enrichment/omdb.py
@@ -66,8 +66,6 @@ class OMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         if not self.supports_media_type(media.type):
             return None
 
-        self.rate_limiter.wait_sync()
-
         # If we have an IMDB ID, use it directly
         if media.imdb_id:
             data = self._get_by_imdb_id(media.imdb_id)
@@ -121,6 +119,7 @@ class OMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         Returns:
             OMDB response dict or None.
         """
+        self.rate_limiter.wait_sync()
         try:
             response = self.client.get(
                 "/",
@@ -155,6 +154,7 @@ class OMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         Returns:
             OMDB response dict or None.
         """
+        self.rate_limiter.wait_sync()
         try:
             params: dict[str, str | int] = {
                 "apikey": self.api_key,

--- a/backend/src/podex/services/enrichment/pubmed.py
+++ b/backend/src/podex/services/enrichment/pubmed.py
@@ -12,6 +12,7 @@ from podex.services.enrichment.base import (
     EnrichmentProvider,
     EnrichmentResult,
     EnrichmentSource,
+    canonicalize_doi,
 )
 
 if TYPE_CHECKING:
@@ -111,7 +112,7 @@ class PubMedProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         """
         params: dict[str, str | int] = {
             "db": "pubmed",
-            "term": f"{doi}[doi]",
+            "term": f"{canonicalize_doi(doi)}[doi]",
             "retmode": "json",
             "retmax": 1,
         }

--- a/backend/src/podex/services/enrichment/pubmed.py
+++ b/backend/src/podex/services/enrichment/pubmed.py
@@ -273,9 +273,15 @@ class PubMedProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
             title_elem = article_data.find("ArticleTitle")
             title = title_elem.text if title_elem is not None else ""
 
-            # Extract abstract
-            abstract_elem = article_data.find(".//AbstractText")
-            abstract = abstract_elem.text if abstract_elem is not None else ""
+            # Extract abstract (structured abstracts have multiple sections)
+            abstract_sections: list[str] = []
+            for abstract_elem in article_data.findall(".//AbstractText"):
+                text = (abstract_elem.text or "").strip()
+                if not text:
+                    continue
+                label = (abstract_elem.get("Label") or "").strip()
+                abstract_sections.append(f"{label}: {text}" if label else text)
+            abstract = " ".join(abstract_sections)
 
             # Extract authors
             authors: list[str] = []

--- a/backend/src/podex/services/enrichment/pubmed.py
+++ b/backend/src/podex/services/enrichment/pubmed.py
@@ -193,6 +193,7 @@ class PubMedProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         if self.api_key:
             params["api_key"] = self.api_key
 
+        self.rate_limiter.wait_sync()
         try:
             response = self.client.get(self.SUMMARY_URL, params=params)
             response.raise_for_status()

--- a/backend/src/podex/services/enrichment/semantic_scholar.py
+++ b/backend/src/podex/services/enrichment/semantic_scholar.py
@@ -84,21 +84,28 @@ class SemanticScholarProvider(EnrichmentProvider):  # type: ignore[misc, unused-
         if not self.supports_media_type(media.type):
             return None
 
-        # 1. Direct lookup by DOI
+        # 1. Direct lookup by stored Semantic Scholar ID
+        if media.semantic_scholar_id:
+            self.rate_limiter.wait_sync()
+            paper = self._get_paper_by_id(media.semantic_scholar_id)
+            if paper:
+                return self._build_result(paper, confidence=1.0)
+
+        # 2. Direct lookup by DOI
         if media.doi:
             self.rate_limiter.wait_sync()
             paper = self._get_paper_by_id(f"DOI:{canonicalize_doi(media.doi)}")
             if paper:
                 return self._build_result(paper, confidence=1.0)
 
-        # 2. Direct lookup by PMID
+        # 3. Direct lookup by PMID
         if media.pubmed_id:
             self.rate_limiter.wait_sync()
             paper = self._get_paper_by_id(f"PMID:{media.pubmed_id}")
             if paper:
                 return self._build_result(paper, confidence=0.95)
 
-        # 3. Search by title
+        # 4. Search by title
         self.rate_limiter.wait_sync()
         results = self._search(media.title)
 

--- a/backend/src/podex/services/enrichment/semantic_scholar.py
+++ b/backend/src/podex/services/enrichment/semantic_scholar.py
@@ -11,6 +11,7 @@ from podex.services.enrichment.base import (
     EnrichmentProvider,
     EnrichmentResult,
     EnrichmentSource,
+    canonicalize_doi,
 )
 
 if TYPE_CHECKING:
@@ -86,7 +87,7 @@ class SemanticScholarProvider(EnrichmentProvider):  # type: ignore[misc, unused-
         # 1. Direct lookup by DOI
         if media.doi:
             self.rate_limiter.wait_sync()
-            paper = self._get_paper_by_id(f"DOI:{media.doi}")
+            paper = self._get_paper_by_id(f"DOI:{canonicalize_doi(media.doi)}")
             if paper:
                 return self._build_result(paper, confidence=1.0)
 

--- a/backend/src/podex/services/enrichment/tmdb.py
+++ b/backend/src/podex/services/enrichment/tmdb.py
@@ -71,6 +71,13 @@ class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         # Determine primary search type (TV shows try TV first, others try movie first)
         search_types = ["tv", "movie"] if media.type == "tv_show" else ["movie", "tv"]
 
+        # Direct lookup by stored TMDB ID before any title search
+        if media.tmdb_id:
+            for search_type in search_types:
+                details = self._get_details(media.tmdb_id, search_type)
+                if details:
+                    return self._build_result(details, search_type, confidence=1.0)
+
         # Generate search variations
         variations = generate_search_variations(media.title, media.author)
 

--- a/backend/src/podex/services/enrichment/tmdb.py
+++ b/backend/src/podex/services/enrichment/tmdb.py
@@ -12,6 +12,7 @@ from podex.services.enrichment.base import (
     EnrichmentProvider,
     EnrichmentResult,
     EnrichmentSource,
+    describe_http_error,
 )
 from podex.services.enrichment.search_utils import (
     calculate_similarity,
@@ -144,7 +145,9 @@ class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
             result: list[dict[str, Any]] = data.get("results", [])
             return result
         except httpx.HTTPError as e:
-            logger.warning(f"TMDB search error for '{title}': {e}")
+            logger.warning(
+                f"TMDB search error for '{title}': {describe_http_error(e)}",
+            )
             return []
 
     def _find_best_match(
@@ -241,7 +244,9 @@ class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
             result: dict[str, Any] = response.json()
             return result
         except httpx.HTTPError as e:
-            logger.warning(f"TMDB details error for ID {tmdb_id}: {e}")
+            logger.warning(
+                f"TMDB details error for ID {tmdb_id}: {describe_http_error(e)}",
+            )
             return None
 
     def _build_result(

--- a/backend/src/podex/services/enrichment/tmdb.py
+++ b/backend/src/podex/services/enrichment/tmdb.py
@@ -78,8 +78,6 @@ class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         for search_type in search_types:
             # Try each title variation
             for variation in variations:
-                self.rate_limiter.wait_sync()
-
                 # Clean the query for API
                 query = clean_for_api_search(variation)
                 if not query:
@@ -103,7 +101,6 @@ class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
                         tmdb_id, confidence = best_match
 
                         # Fetch full details
-                        self.rate_limiter.wait_sync()
                         details = self._get_details(tmdb_id, search_type)
                         if details:
                             logger.debug(
@@ -131,6 +128,7 @@ class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         Returns:
             List of search results.
         """
+        self.rate_limiter.wait_sync()
         try:
             params: dict[str, str | int] = {"query": title}
             if year:
@@ -237,6 +235,7 @@ class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
         Returns:
             Details dict or None.
         """
+        self.rate_limiter.wait_sync()
         try:
             params = {"append_to_response": "credits,external_ids"}
             response = self.client.get(f"/{media_type}/{tmdb_id}", params=params)

--- a/backend/src/podex/services/enrichment/tmdb_person.py
+++ b/backend/src/podex/services/enrichment/tmdb_person.py
@@ -11,6 +11,7 @@ from podex.services.enrichment.base import (
     EnrichmentProvider,
     EnrichmentResult,
     EnrichmentSource,
+    describe_http_error,
 )
 
 if TYPE_CHECKING:
@@ -133,7 +134,9 @@ class TMDBPersonProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignor
             result: list[dict[str, Any]] = data.get("results", [])
             return result
         except httpx.HTTPError as e:
-            logger.warning(f"TMDB person search error for '{query}': {e}")
+            logger.warning(
+                f"TMDB person search error for '{query}': {describe_http_error(e)}",
+            )
             return []
 
     def _find_best_match(
@@ -210,7 +213,10 @@ class TMDBPersonProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignor
             result: dict[str, Any] = response.json()
             return result
         except httpx.HTTPError as e:
-            logger.warning(f"TMDB person details error for ID {person_id}: {e}")
+            logger.warning(
+                f"TMDB person details error for ID {person_id}: "
+                f"{describe_http_error(e)}",
+            )
             return None
 
     def _build_result(

--- a/backend/tests/test_enrichment_providers.py
+++ b/backend/tests/test_enrichment_providers.py
@@ -348,6 +348,22 @@ def test_rate_limiter_and_context_managers() -> None:
         assert_that(wiki.supports_media_type("book")).is_true()
 
 
+def test_canonicalize_doi_strips_prefixes() -> None:
+    """Bare DOIs pass through; every prefix form is stripped."""
+    from podex.services.enrichment.base import canonicalize_doi
+
+    assert_that(canonicalize_doi("10.1000/x")).is_equal_to("10.1000/x")
+    assert_that(canonicalize_doi("https://doi.org/10.1000/x")).is_equal_to("10.1000/x")
+    assert_that(canonicalize_doi("http://doi.org/10.1000/x")).is_equal_to("10.1000/x")
+    assert_that(canonicalize_doi("doi.org/10.1000/x")).is_equal_to("10.1000/x")
+    assert_that(canonicalize_doi("doi:10.1000/x")).is_equal_to("10.1000/x")
+    assert_that(canonicalize_doi("DOI:10.1000/x")).is_equal_to("10.1000/x")
+    assert_that(canonicalize_doi("  doi:https://doi.org/10.1000/x  ")).is_equal_to(
+        "10.1000/x",
+    )
+    assert_that(canonicalize_doi("10.1000/MixedCase")).is_equal_to("10.1000/MixedCase")
+
+
 def test_describe_http_error_redacts_details() -> None:
     """Status errors report the code; transport errors report the class."""
     from podex.services.enrichment.base import describe_http_error

--- a/backend/tests/test_enrichment_providers.py
+++ b/backend/tests/test_enrichment_providers.py
@@ -348,6 +348,24 @@ def test_rate_limiter_and_context_managers() -> None:
         assert_that(wiki.supports_media_type("book")).is_true()
 
 
+def test_describe_http_error_redacts_details() -> None:
+    """Status errors report the code; transport errors report the class."""
+    from podex.services.enrichment.base import describe_http_error
+
+    request = httpx.Request("GET", "https://api.invalid/?apikey=sekret")
+    response = httpx.Response(500, request=request)
+    status_error = httpx.HTTPStatusError(
+        "boom",
+        request=request,
+        response=response,
+    )
+    assert_that(describe_http_error(status_error)).is_equal_to("HTTP 500")
+    assert_that(describe_http_error(httpx.ConnectError("refused"))).is_equal_to(
+        "ConnectError",
+    )
+    assert_that(describe_http_error(status_error)).does_not_contain("sekret")
+
+
 def test_provider_mismatch_and_variation_paths() -> None:
     """Low-similarity docs are rejected; movie-type variations execute."""
     mismatch = OpenLibraryProvider(requests_per_second=1000)

--- a/backend/tests/test_media_enricher.py
+++ b/backend/tests/test_media_enricher.py
@@ -1480,6 +1480,13 @@ def test_pubmed_and_semantic_scholar_reject_paths() -> None:
     ss.close()
 
 
+def test_omdb_uses_https_base_url() -> None:
+    """The OMDB base URL uses the https scheme (api key in query)."""
+    from podex.services.enrichment import OMDBProvider
+
+    assert_that(OMDBProvider.BASE_URL).starts_with("https://")
+
+
 def test_provider_context_managers_close_clients() -> None:
     """Context-manager protocol closes every API-key provider."""
     from podex.services.enrichment import (

--- a/backend/tests/test_media_enricher.py
+++ b/backend/tests/test_media_enricher.py
@@ -1766,6 +1766,53 @@ def test_omdb_uses_https_base_url() -> None:
     assert_that(OMDBProvider.BASE_URL).starts_with("https://")
 
 
+def test_pubmed_structured_abstract_joins_sections() -> None:
+    """Structured abstracts keep every AbstractText section."""
+    from podex.services.enrichment import PubMedProvider
+
+    xml = """<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>4242</PMID>
+      <Article>
+        <ArticleTitle>Structured abstract study</ArticleTitle>
+        <Abstract>
+          <AbstractText Label="BACKGROUND">Sleep matters.</AbstractText>
+          <AbstractText Label="CONCLUSIONS">Rest improves recall.</AbstractText>
+        </Abstract>
+        <AuthorList>
+          <Author><LastName>Doe</LastName><ForeName>Jane</ForeName></Author>
+        </AuthorList>
+        <Journal>
+          <Title>Journal</Title>
+          <JournalIssue><PubDate><Year>2021</Year></PubDate></JournalIssue>
+        </Journal>
+      </Article>
+    </MedlineCitation>
+  </PubmedArticle>
+</PubmedArticleSet>"""
+    provider = PubMedProvider()
+    provider.rate_limiter = _CountingLimiter()
+    provider.client = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, text=xml),
+        ),
+    )
+    media = _media("Structured abstract study", MediaType.STUDY)
+    media.pubmed_id = "4242"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        description = result.description or ""
+        assert_that(description).contains("Sleep matters.")
+        assert_that(description).contains("Rest improves recall.")
+        assert_that(description).contains("BACKGROUND")
+        assert_that(description).contains("CONCLUSIONS")
+
+
 def test_provider_context_managers_close_clients() -> None:
     """Context-manager protocol closes every API-key provider."""
     from podex.services.enrichment import (

--- a/backend/tests/test_media_enricher.py
+++ b/backend/tests/test_media_enricher.py
@@ -1491,6 +1491,52 @@ class _CountingLimiter:
         self.waits += 1
 
 
+def test_pubmed_doi_search_canonicalizes_prefixed_doi() -> None:
+    """A prefixed DOI is canonicalized before the [doi] search term."""
+    from podex.services.enrichment import PubMedProvider
+
+    seen_terms: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_terms.append(request.url.params.get("term", ""))
+        return httpx.Response(200, json={"esearchresult": {"idlist": []}})
+
+    provider = PubMedProvider()
+    provider.rate_limiter = _CountingLimiter()
+    provider.client = httpx.Client(transport=httpx.MockTransport(handler))
+    media = _media("Sleep study", MediaType.STUDY)
+    media.doi = "https://doi.org/10.1000/x"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_none()
+    assert_that(seen_terms[0]).is_equal_to("10.1000/x[doi]")
+
+
+def test_semantic_scholar_canonicalizes_prefixed_doi() -> None:
+    """A prefixed DOI is canonicalized before the DOI: paper lookup."""
+    from podex.services.enrichment import SemanticScholarProvider
+
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path.startswith("/paper/DOI:"):
+            return httpx.Response(404, text="not found")
+        return httpx.Response(200, json={"data": []})
+
+    provider = SemanticScholarProvider()
+    provider.rate_limiter = _CountingLimiter()
+    _swap_client_matrix(provider, handler)
+    media = _media("Sleep study", MediaType.STUDY)
+    media.doi = "doi:10.1000/x"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_none()
+    assert_that(seen_paths[0]).is_equal_to("/paper/DOI:10.1000/x")
+
+
 def test_provider_error_logs_redact_api_key(caplog: Any) -> None:
     """A 401 response log line never contains the api key value."""
     import logging as _logging

--- a/backend/tests/test_media_enricher.py
+++ b/backend/tests/test_media_enricher.py
@@ -1537,6 +1537,134 @@ def test_semantic_scholar_canonicalizes_prefixed_doi() -> None:
     assert_that(seen_paths[0]).is_equal_to("/paper/DOI:10.1000/x")
 
 
+def test_pubmed_waits_before_every_request() -> None:
+    """The esearch + esummary flow waits once per HTTP request."""
+    from podex.services.enrichment import PubMedProvider
+
+    requests_seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(request.url.path)
+        if "esearch" in request.url.path:
+            return httpx.Response(
+                200,
+                json={"esearchresult": {"idlist": ["555"]}},
+            )
+        return httpx.Response(
+            200,
+            json={
+                "result": {
+                    "uids": ["555"],
+                    "555": {
+                        "uid": "555",
+                        "title": "A Totally Unrelated Paper",
+                        "pubdate": "1999",
+                    },
+                },
+            },
+        )
+
+    provider = PubMedProvider()
+    limiter = _CountingLimiter()
+    provider.rate_limiter = limiter
+    provider.client = httpx.Client(transport=httpx.MockTransport(handler))
+    result = provider.search_and_enrich(_media("Sleep study", MediaType.STUDY))
+    provider.close()
+
+    assert_that(result).is_none()
+    assert_that(len(requests_seen)).is_equal_to(2)
+    assert_that(limiter.waits).is_equal_to(len(requests_seen))
+
+
+def test_tmdb_waits_before_every_request() -> None:
+    """Search-with-year, search-without-year, and details each wait once."""
+    from podex.services.enrichment import TMDBProvider
+
+    requests_seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(str(request.url))
+        if "/search/" in request.url.path:
+            if request.url.params.get("year"):
+                return httpx.Response(200, json={"results": []})
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "id": 2,
+                            "title": "Dune",
+                            "release_date": "2021-10-22",
+                            "popularity": 100.0,
+                        },
+                    ],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "id": 2,
+                "title": "Dune",
+                "overview": "Desert planet epic.",
+                "release_date": "2021-10-22",
+            },
+        )
+
+    provider = TMDBProvider("key")
+    limiter = _CountingLimiter()
+    provider.rate_limiter = limiter
+    _swap_client_matrix(provider, handler)
+    media = Media(type=MediaType.MOVIE, title="Dune", year=2021)
+    media.id = 20
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_not_none()
+    assert_that(len(requests_seen)).is_equal_to(3)
+    assert_that(limiter.waits).is_equal_to(len(requests_seen))
+
+
+def test_omdb_waits_before_every_request() -> None:
+    """A failed IMDB-ID lookup plus title search wait once per request."""
+    from podex.services.enrichment import OMDBProvider
+
+    requests_seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(str(request.url))
+        if request.url.params.get("i"):
+            return httpx.Response(
+                200,
+                json={"Response": "False", "Error": "Incorrect IMDb ID."},
+            )
+        return httpx.Response(
+            200,
+            json={
+                "Response": "True",
+                "Title": "Dune",
+                "Year": "2021",
+                "imdbID": "tt1160419",
+                "Plot": "Found by title.",
+                "imdbRating": "8.0",
+                "imdbVotes": "1",
+            },
+        )
+
+    provider = OMDBProvider("key")
+    limiter = _CountingLimiter()
+    provider.rate_limiter = limiter
+    _swap_client_matrix(provider, handler)
+    media = Media(type=MediaType.MOVIE, title="Dune")
+    media.id = 21
+    media.imdb_id = "tt0000000"
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_not_none()
+    assert_that(len(requests_seen)).is_equal_to(2)
+    assert_that(limiter.waits).is_equal_to(len(requests_seen))
+
+
 def test_provider_error_logs_redact_api_key(caplog: Any) -> None:
     """A 401 response log line never contains the api key value."""
     import logging as _logging

--- a/backend/tests/test_media_enricher.py
+++ b/backend/tests/test_media_enricher.py
@@ -1480,6 +1480,40 @@ def test_pubmed_and_semantic_scholar_reject_paths() -> None:
     ss.close()
 
 
+class _CountingLimiter:
+    """Rate-limiter double counting wait_sync calls without sleeping."""
+
+    def __init__(self) -> None:
+        self.waits = 0
+
+    def wait_sync(self) -> None:
+        """Count the wait instead of sleeping."""
+        self.waits += 1
+
+
+def test_provider_error_logs_redact_api_key(caplog: Any) -> None:
+    """A 401 response log line never contains the api key value."""
+    import logging as _logging
+
+    from podex.services.enrichment import OMDBProvider
+
+    provider = OMDBProvider("sekret-key")
+    provider.rate_limiter = _CountingLimiter()
+    _swap_client_matrix(
+        provider,
+        lambda request: httpx.Response(401, text="unauthorized"),
+    )
+    media = Media(type=MediaType.MOVIE, title="Dune")
+    media.id = 24
+    with caplog.at_level(_logging.WARNING):
+        result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_none()
+    assert_that(caplog.text).contains("HTTP 401")
+    assert_that(caplog.text).does_not_contain("sekret-key")
+
+
 def test_omdb_uses_https_base_url() -> None:
     """The OMDB base URL uses the https scheme (api key in query)."""
     from podex.services.enrichment import OMDBProvider

--- a/backend/tests/test_media_enricher.py
+++ b/backend/tests/test_media_enricher.py
@@ -419,18 +419,23 @@ def test_semantic_scholar_direct_paper_id() -> None:
         "url": "https://ss.invalid/abc123",
         "venue": "Journal of Sleep",
     }
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        return httpx.Response(200, json=paper)
+
     provider = SemanticScholarProvider()
-    _swap_client_matrix(
-        provider,
-        lambda request: httpx.Response(200, json=paper),
-    )
+    _swap_client_matrix(provider, handler)
     media = _media("Sleep and memory consolidation", MediaType.STUDY)
     media.semantic_scholar_id = "abc123"
     result = provider.search_and_enrich(media)
     provider.close()
 
+    assert_that(seen_paths).is_equal_to(["/paper/abc123"])
+    assert_that(result).is_not_none()
     if result is not None:
-        assert_that(result.confidence).is_greater_than(0.8)
+        assert_that(result.confidence).is_equal_to(1.0)
 
 
 def test_pubmed_direct_pmid_fetch() -> None:
@@ -1663,6 +1668,72 @@ def test_omdb_waits_before_every_request() -> None:
     assert_that(result).is_not_none()
     assert_that(len(requests_seen)).is_equal_to(2)
     assert_that(limiter.waits).is_equal_to(len(requests_seen))
+
+
+def test_tmdb_direct_id_lookup_skips_search() -> None:
+    """A stored tmdb_id fetches details directly without any search."""
+    from podex.services.enrichment import TMDBProvider
+
+    seen_paths: list[str] = []
+    detail_payload = {
+        "id": 438631,
+        "title": "Dune",
+        "overview": "Desert planet epic.",
+        "release_date": "2021-10-22",
+        "poster_path": "/dune.jpg",
+        "external_ids": {"imdb_id": "tt1160419"},
+        "credits": {"cast": [], "crew": []},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path == "/movie/438631":
+            return httpx.Response(200, json=detail_payload)
+        return httpx.Response(404, text="not found")
+
+    provider = TMDBProvider("key")
+    provider.rate_limiter = _CountingLimiter()
+    _swap_client_matrix(provider, handler)
+    media = Media(type=MediaType.MOVIE, title="Dune")
+    media.id = 22
+    media.tmdb_id = 438631
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(seen_paths).is_equal_to(["/movie/438631"])
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.confidence).is_equal_to(1.0)
+        assert_that(str(result.external_ids)).contains("438631")
+
+
+def test_tmdb_direct_id_404_falls_back_to_search() -> None:
+    """A 404 on the stored tmdb_id falls back to title search."""
+    from podex.services.enrichment import TMDBProvider
+
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if "/search/" in request.url.path:
+            return httpx.Response(200, json={"results": []})
+        return httpx.Response(404, text="not found")
+
+    provider = TMDBProvider("key")
+    provider.rate_limiter = _CountingLimiter()
+    _swap_client_matrix(provider, handler)
+    media = Media(type=MediaType.MOVIE, title="Dune")
+    media.id = 23
+    media.tmdb_id = 999999
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(result).is_none()
+    assert_that(seen_paths[0]).is_equal_to("/movie/999999")
+    assert_that(seen_paths[1]).is_equal_to("/tv/999999")
+    assert_that(
+        [p for p in seen_paths if p.startswith("/search/")],
+    ).is_not_empty()
 
 
 def test_provider_error_logs_redact_api_key(caplog: Any) -> None:


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(enrichment): harden provider modules per post-merge review
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Post-merge review fixes across the enrichment provider modules, bundled into one PR because the files overlap.

### #312 — OMDB over HTTPS

`OMDBProvider.BASE_URL` moves from `http://www.omdbapi.com` to `https://www.omdbapi.com`, so the API key in the query string is no longer sent in cleartext. No test mocks referenced the http scheme (all tests swap in a MockTransport with a `mock.invalid` base URL); a regression test asserts the https scheme.

### #313 — Shared DOI canonicalization

New `canonicalize_doi()` helper in `enrichment/base.py` strips `https://doi.org/`, `http://doi.org/`, `doi.org/`, and case-insensitive `doi:` prefixes (repeatedly) and trims whitespace. PubMed now builds `"<bare-doi>[doi]"` and Semantic Scholar builds `"DOI:<bare-doi>"` from the canonical form; CrossRef's inline prefix stripping is refactored onto the same helper (it additionally lowercases, unchanged behavior).

### #314 — Rate limit every outgoing request

`rate_limiter.wait_sync()` moves into the request helpers so each HTTP call is gated exactly once, with no double waits: PubMed `_get_summaries` (esummary previously piggybacked on the esearch wait), TMDB `_search`/`_get_details` (outer waits removed — one wait previously covered a with-year + without-year search pair), OMDB `_get_by_imdb_id`/`_search_by_title` (one wait previously covered up to two requests). Limiter rates and constructor signatures unchanged.

### #315 — Prefer stored provider IDs

`SemanticScholarProvider.search_and_enrich` tries `media.semantic_scholar_id` via `/paper/<id>` before the DOI/PMID/title flows; `TMDBProvider.search_and_enrich` tries `media.tmdb_id` via `/{tv|movie}/<id>` (type-ordered, tv first for tv_show) before generating title variations. Direct hits return confidence 1.0; misses (e.g. 404) fall through to the existing search flows.

### #316 — Redact credentials from HTTP error logs

New `describe_http_error()` helper in `enrichment/base.py` returns `"HTTP <status>"` for `httpx.HTTPStatusError` and the exception class name otherwise — never `str(e)`, which embeds the full request URL including api-key query params. Applied at all eight log sites in `tmdb.py`, `tmdb_person.py`, `omdb.py`, and `google_books.py`; contextual identifiers (title, ids) are kept.

### #322 — Preserve all PubMed abstract sections

`_parse_pubmed_xml` now uses `findall(".//AbstractText")` and joins every non-empty section, prefixing each with its `Label` attribute (`"BACKGROUND: ..."`) when present. Empty-abstract fallback (`""`) preserved.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #312
- Closes #313
- Closes #314
- Closes #315
- Closes #316
- Closes #322

## Details

- One commit per issue (6 commits), each gated on the full backend suite.
- New tests: helper unit tests (`canonicalize_doi`, `describe_http_error`), DOI-canonicalization request-shape tests for PubMed and Semantic Scholar, wait-count == request-count tests for PubMed/TMDB/OMDB via a counting rate-limiter double, TMDB direct-ID hit and 404-fallback tests, a strengthened Semantic Scholar direct-ID test (asserts `/paper/<id>` path and confidence 1.0), a `caplog` test proving a 401 log line never contains the api key, and a structured-abstract fixture with two labeled sections.
- Validation: `uv run pytest --cov` — 394 passed, coverage 87.14% (>= 85 gate); `uv run lintro chk` — health 100/100 (pip-audit reports a local tool-execution error — ensurepip SIGABRT in its isolated env — unrelated to this diff and present on a clean tree).