### PR TITLE
feat(observability): expose gated Prometheus /metrics endpoint

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "cryptography>=48.0.0",
   "boto3>=1.43.14",
   "email-validator>=2.0.0",
+  "prometheus-client>=0.21",
   "sentry-sdk[fastapi]>=2.0",
 ]
 

--- a/backend/src/podex/main.py
+++ b/backend/src/podex/main.py
@@ -7,6 +7,7 @@ from podex.api.v2.errors import install_exception_handlers
 from podex.api.v2.router import api_v2_router
 from podex.config import Settings, get_settings
 from podex.logging_config import configure_logging
+from podex.metrics import MetricsMiddleware, build_metrics, get_prometheus_metrics
 from podex.middleware import RateLimitMiddleware, RequestContextMiddleware
 from podex.observability import init_sentry
 from podex.services.cache import TTLCache
@@ -28,6 +29,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # across requests (and workers within this process) so the aggregation
     # queries only run once per TTL window.
     app.state.cache = TTLCache()
+    # Fresh registry per app instance so repeated create_app calls (tests)
+    # never trip duplicate-registration errors or share samples.
+    metrics = build_metrics()
+    app.state.metrics = metrics
 
     install_exception_handlers(app)
 
@@ -43,6 +48,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             exempt_paths=tuple(resolved.rate_limit_exempt_paths),
         )
     app.add_middleware(RequestContextMiddleware)
+    # Registered after the limiter/context middleware so it observes every
+    # request that reaches the app — including rate-limited 429s (which are
+    # labelled ``unmatched`` because they short-circuit before routing).
+    app.add_middleware(MetricsMiddleware, metrics=metrics)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=resolved.cors_origins,
@@ -65,6 +74,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return {"status": "ok"}
 
     app.add_api_route("/health", health, methods=["GET"])
+    # Internal-only Prometheus exposition (X-Ops-Key gated). Deliberately on
+    # the app root — not the public read-only /api/v2 surface — and excluded
+    # from the OpenAPI schema so the published API contract is unchanged.
+    app.add_api_route(
+        "/metrics",
+        get_prometheus_metrics,
+        methods=["GET"],
+        include_in_schema=False,
+    )
 
     return app
 

--- a/backend/src/podex/metrics.py
+++ b/backend/src/podex/metrics.py
@@ -1,0 +1,328 @@
+"""Prometheus instrumentation: registry factory, middleware, and /metrics.
+
+Each :func:`podex.main.create_app` call builds a fresh
+:class:`AppMetrics` (its own ``CollectorRegistry``) so repeated app
+construction in tests never trips duplicate-registration errors and
+samples never cross-contaminate between test apps. Production runs
+uvicorn single-process on Railway, so a plain per-process registry is
+sufficient — no multiprocess mode.
+
+The scheduler runner process reuses the same factory for its tick
+instrumentation (see :mod:`podex.scheduler_runner`).
+"""
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from fastapi import HTTPException, Request, Response, status
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+from sqlalchemy.orm import Session
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from podex.api.deps import AppSettings, DbSession
+from podex.config import Settings
+from podex.services.ops_metrics import get_operational_metrics
+
+UNMATCHED_ROUTE = "unmatched"
+
+RequestResponder = Callable[[Request], Awaitable[Response]]
+
+
+@dataclass(frozen=True, slots=True)
+class AppMetrics:
+    """Prometheus collectors bound to one registry.
+
+    Attributes:
+        registry: The isolated registry all collectors are registered on.
+        http_requests_total: Request counter labelled by method, route
+            template, and status code.
+        http_request_duration_seconds: Request latency histogram with the
+            same labels as the counter.
+        scheduler_ticks_total: Scheduler tick counter labelled by outcome
+            (``success``/``error``).
+        scheduler_tick_duration_seconds: Scheduler tick duration histogram.
+        review_pending_items: Review items awaiting a decision.
+        review_decisions_last_24h: Review decisions made in the last 24h.
+        review_median_decision_minutes: Median minutes-to-decision over the
+            last 24h (NaN when no decisions were made).
+        alert_generated_events_last_24h: Alert events generated in the
+            last 24h.
+        alert_delivered_digests_last_24h: Digests delivered in the last 24h.
+        alert_delivered_events_last_24h: Alert events delivered via digests
+            in the last 24h.
+        alert_pending_events: Alert events not yet attached to a digest.
+    """
+
+    registry: CollectorRegistry
+    http_requests_total: Counter
+    http_request_duration_seconds: Histogram
+    scheduler_ticks_total: Counter
+    scheduler_tick_duration_seconds: Histogram
+    review_pending_items: Gauge
+    review_decisions_last_24h: Gauge
+    review_median_decision_minutes: Gauge
+    alert_generated_events_last_24h: Gauge
+    alert_delivered_digests_last_24h: Gauge
+    alert_delivered_events_last_24h: Gauge
+    alert_pending_events: Gauge
+
+
+def build_metrics() -> AppMetrics:
+    """Create all Podex collectors on a fresh, isolated registry.
+
+    Returns:
+        The collectors plus the registry they are registered on.
+    """
+    registry = CollectorRegistry()
+    return AppMetrics(
+        registry=registry,
+        http_requests_total=Counter(
+            "podex_http_requests_total",
+            "HTTP requests processed, by method, route template, and status.",
+            labelnames=("method", "route", "status"),
+            registry=registry,
+        ),
+        http_request_duration_seconds=Histogram(
+            "podex_http_request_duration_seconds",
+            "HTTP request latency, by method, route template, and status.",
+            labelnames=("method", "route", "status"),
+            registry=registry,
+        ),
+        scheduler_ticks_total=Counter(
+            "podex_scheduler_ticks_total",
+            "Scheduler ticks executed, by outcome.",
+            labelnames=("outcome",),
+            registry=registry,
+        ),
+        scheduler_tick_duration_seconds=Histogram(
+            "podex_scheduler_tick_duration_seconds",
+            "Scheduler tick duration in seconds.",
+            registry=registry,
+        ),
+        review_pending_items=Gauge(
+            "podex_review_pending_items",
+            "Review items currently awaiting a decision.",
+            registry=registry,
+        ),
+        review_decisions_last_24h=Gauge(
+            "podex_review_decisions_last_24h",
+            "Review decisions made in the last 24 hours.",
+            registry=registry,
+        ),
+        review_median_decision_minutes=Gauge(
+            "podex_review_median_decision_minutes_last_24h",
+            "Median minutes from creation to decision over the last 24 hours.",
+            registry=registry,
+        ),
+        alert_generated_events_last_24h=Gauge(
+            "podex_alert_generated_events_last_24h",
+            "Account alert events generated in the last 24 hours.",
+            registry=registry,
+        ),
+        alert_delivered_digests_last_24h=Gauge(
+            "podex_alert_delivered_digests_last_24h",
+            "Account digests delivered in the last 24 hours.",
+            registry=registry,
+        ),
+        alert_delivered_events_last_24h=Gauge(
+            "podex_alert_delivered_events_last_24h",
+            "Account alert events delivered via digests in the last 24 hours.",
+            registry=registry,
+        ),
+        alert_pending_events=Gauge(
+            "podex_alert_pending_events",
+            "Account alert events not yet attached to a digest.",
+            registry=registry,
+        ),
+    )
+
+
+def observe_scheduler_tick(
+    metrics: AppMetrics,
+    *,
+    duration_seconds: float,
+    outcome: str,
+) -> None:
+    """Record one scheduler tick sample.
+
+    Args:
+        metrics: The collectors to record the sample on.
+        duration_seconds: Wall-clock duration of the tick.
+        outcome: ``"success"`` or ``"error"``.
+    """
+    metrics.scheduler_ticks_total.labels(outcome=outcome).inc()
+    metrics.scheduler_tick_duration_seconds.observe(duration_seconds)
+
+
+def update_operational_gauges(*, metrics: AppMetrics, db: Session) -> None:
+    """Refresh the ops gauges from the operational-metrics service.
+
+    Called at scrape time so gauge values always reflect the current
+    database state rather than a stale snapshot.
+
+    Args:
+        metrics: The collectors whose gauges are refreshed.
+        db: Database session used to compute the operational metrics.
+    """
+    operational = get_operational_metrics(db=db)
+    metrics.review_pending_items.set(operational.review.pending_items)
+    metrics.review_decisions_last_24h.set(operational.review.decisions_last_24h)
+    median_minutes = operational.review.median_decision_minutes_last_24h
+    metrics.review_median_decision_minutes.set(
+        median_minutes if median_minutes is not None else float("nan"),
+    )
+    metrics.alert_generated_events_last_24h.set(
+        operational.alerts.generated_events_last_24h,
+    )
+    metrics.alert_delivered_digests_last_24h.set(
+        operational.alerts.delivered_digests_last_24h,
+    )
+    metrics.alert_delivered_events_last_24h.set(
+        operational.alerts.delivered_events_last_24h,
+    )
+    metrics.alert_pending_events.set(operational.alerts.pending_events)
+
+
+def _route_template(request: Request) -> str:
+    """Return the full route template for a matched request.
+
+    ``scope["route"].path_format`` on recent FastAPI versions only covers
+    the innermost router (included routers are mounted, so ``/api/v2`` is
+    absent from ``/podcasts/{podcast_id}``). The mount prefix is recovered
+    by rendering the template with the matched path params and stripping
+    that suffix from the raw request path.
+
+    Args:
+        request: The processed request (after routing).
+
+    Returns:
+        The full path template (e.g. ``/api/v2/podcasts/{podcast_id}``),
+        or ``unmatched`` when no route matched.
+    """
+    route = request.scope.get("route")
+    path_format: str | None = getattr(route, "path_format", None)
+    if not path_format:
+        return UNMATCHED_ROUTE
+    path = str(request.scope.get("path", ""))
+    rendered = path_format
+    path_params = request.scope.get("path_params") or {}
+    for name, value in path_params.items():
+        rendered = rendered.replace("{" + name + "}", str(value))
+    if path != rendered and path.endswith(rendered):
+        return path[: -len(rendered)] + path_format
+    return path_format
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Record a counter increment and latency sample per HTTP request.
+
+    The route label uses the matched route's path template (e.g.
+    ``/api/v2/podcasts/{podcast_id}``) — never the raw request path — so
+    label cardinality stays bounded. Requests that finish without a route
+    match (404s, rate-limited rejections) are labelled ``unmatched``.
+
+    Args:
+        app: The wrapped ASGI application.
+        metrics: The collectors samples are recorded on.
+    """
+
+    def __init__(
+        self,
+        app: Callable[..., Awaitable[None]],
+        *,
+        metrics: AppMetrics,
+    ) -> None:
+        super().__init__(app)
+        self._metrics = metrics
+
+    async def dispatch(self, request: Request, call_next: RequestResponder) -> Response:
+        """Time the downstream handler and record request samples.
+
+        Args:
+            request: The incoming request being processed.
+            call_next: Callable that invokes the remaining middleware/handler
+                chain.
+
+        Returns:
+            Response: The downstream response, unchanged.
+        """
+        start = time.perf_counter()
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        finally:
+            duration = time.perf_counter() - start
+            labels = {
+                "method": request.method,
+                "route": _route_template(request),
+                "status": str(status_code),
+            }
+            self._metrics.http_requests_total.labels(**labels).inc()
+            self._metrics.http_request_duration_seconds.labels(**labels).observe(
+                duration,
+            )
+
+
+def _require_internal_access(*, request: Request, settings: Settings) -> None:
+    """Reject the request unless the configured ops key is presented.
+
+    Mirrors the gating used by the ops console endpoints
+    (:mod:`podex.api.v2.ops`): the surface is disabled (503) until
+    ``PODEX_OPS_API_KEY`` is configured, and requires the key in the
+    ``X-Ops-Key`` header (401 otherwise).
+
+    Args:
+        request: The incoming request carrying the ``X-Ops-Key`` header.
+        settings: Runtime settings providing the expected key.
+
+    Raises:
+        HTTPException: 503 when unconfigured, 401 on a missing/wrong key.
+    """
+    if not settings.ops_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Metrics endpoint is not configured",
+        )
+    if request.headers.get("X-Ops-Key") != settings.ops_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Ops authentication required",
+        )
+
+
+def get_prometheus_metrics(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> Response:
+    """Serve the Prometheus text exposition for this process.
+
+    Internally gated: never publicly reachable unauthenticated. Ops
+    gauges are recomputed from the database at scrape time.
+
+    Args:
+        request: The incoming scrape request.
+        db: Request-scoped database session for the gauge computation.
+        settings: Resolved application settings (provides the ops key).
+
+    Returns:
+        Response: Prometheus text-format exposition of the app registry.
+    """
+    _require_internal_access(request=request, settings=settings)
+    metrics: AppMetrics = request.app.state.metrics
+    update_operational_gauges(metrics=metrics, db=db)
+    db.commit()
+    return Response(
+        content=generate_latest(metrics.registry),
+        media_type=CONTENT_TYPE_LATEST,
+    )

--- a/backend/src/podex/scheduler_runner.py
+++ b/backend/src/podex/scheduler_runner.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from podex.config import Settings, get_settings
 from podex.database import SessionLocal
 from podex.logging_config import get_logger
+from podex.metrics import AppMetrics, build_metrics, observe_scheduler_tick
 from podex.observability import init_sentry
 from podex.services.notification_delivery import DigestSender, build_digest_sender
 from podex.services.recurring_discovery import (
@@ -78,11 +79,54 @@ def run_tick(
     )
 
 
+def run_instrumented_tick(
+    *,
+    db: Session,
+    settings: Settings,
+    digest_sender: DigestSender | None,
+    metrics: AppMetrics,
+) -> TickSummaryData:
+    """Run one tick, recording its duration and outcome as metrics.
+
+    Failures are recorded with outcome ``error`` and re-raised unchanged so
+    the caller's rollback/log handling still applies.
+
+    Args:
+        db: Database session.
+        settings: Runtime settings controlling cadences.
+        digest_sender: Configured digest delivery boundary, if any.
+        metrics: Collectors the tick sample is recorded on.
+
+    Returns:
+        Summary of the work performed this tick.
+    """
+    start = time.perf_counter()
+    outcome = "error"
+    try:
+        summary = run_tick(db=db, settings=settings, digest_sender=digest_sender)
+        outcome = "success"
+        return summary
+    finally:
+        observe_scheduler_tick(
+            metrics,
+            duration_seconds=time.perf_counter() - start,
+            outcome=outcome,
+        )
+
+
 class SchedulerRunner:
     """Long-running loop that executes scheduler ticks until stopped."""
 
-    def __init__(self, *, settings: Settings | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        settings: Settings | None = None,
+        metrics: AppMetrics | None = None,
+    ) -> None:
         self.settings = settings or get_settings()
+        # The runner is its own process, so it owns its own registry; the
+        # samples are process-local (see podex.metrics module docstring).
+        self.metrics = metrics or build_metrics()
         self._stopping = False
 
     def request_stop(self, signum: int, frame: FrameType | None) -> None:
@@ -101,10 +145,11 @@ class SchedulerRunner:
         while not self._stopping:
             db = SessionLocal()
             try:
-                summary = run_tick(
+                summary = run_instrumented_tick(
                     db=db,
                     settings=self.settings,
                     digest_sender=build_digest_sender(settings=self.settings),
+                    metrics=self.metrics,
                 )
                 logger.info(
                     "scheduler_tick planned=%s discovery=%s digests=%s retention=%s",

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,239 @@
+"""Tests for Prometheus instrumentation and the gated /metrics endpoint."""
+
+from datetime import UTC, datetime
+
+import pytest
+from assertpy import assert_that
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from prometheus_client import CollectorRegistry
+from sqlalchemy.orm import Session
+
+import podex.metrics
+from podex.api.deps import get_app_settings
+from podex.config import Settings
+from podex.metrics import build_metrics, observe_scheduler_tick
+from podex.scheduler_runner import run_instrumented_tick
+from podex.services.ops_metrics import (
+    AlertDeliveryData,
+    OperationalMetricsData,
+    ReviewThroughputData,
+)
+
+_OPS_KEY = "test-ops-key"
+_HEADERS = {"X-Ops-Key": _OPS_KEY}
+
+
+def _enable_ops(client: TestClient) -> None:
+    """Configure the internal ops key for a test app."""
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    app.dependency_overrides[get_app_settings] = lambda: Settings(
+        ops_api_key=_OPS_KEY,
+    )
+
+
+def _registry(client: TestClient) -> CollectorRegistry:
+    """Return the app's isolated metrics registry."""
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    registry: CollectorRegistry = app.state.metrics.registry
+    return registry
+
+
+def test_metrics_endpoint_requires_internal_access(client: TestClient) -> None:
+    """Unconfigured reports 503; missing/wrong key reports 401; key gets 200."""
+    assert_that(client.get("/metrics").status_code).is_equal_to(503)
+
+    _enable_ops(client)
+    assert_that(client.get("/metrics").status_code).is_equal_to(401)
+    wrong = client.get("/metrics", headers={"X-Ops-Key": "wrong"})
+    assert_that(wrong.status_code).is_equal_to(401)
+
+    ok = client.get("/metrics", headers=_HEADERS)
+    assert_that(ok.status_code).is_equal_to(200)
+    assert_that(ok.headers["content-type"]).contains("text/plain")
+    for family in (
+        "podex_http_requests_total",
+        "podex_http_request_duration_seconds",
+        "podex_scheduler_ticks_total",
+        "podex_scheduler_tick_duration_seconds",
+        "podex_review_pending_items",
+        "podex_alert_pending_events",
+    ):
+        assert_that(ok.text).contains(family)
+
+
+def test_metrics_endpoint_absent_from_openapi_schema(client: TestClient) -> None:
+    """/metrics stays out of the published OpenAPI contract."""
+    schema = client.get("/openapi.json").json()
+    assert_that(schema["paths"]).does_not_contain_key("/metrics")
+
+
+def test_request_middleware_labels_route_template(
+    client: TestClient,
+    seeded_graph: object,
+) -> None:
+    """Requests count under the route template, never the raw path."""
+    del seeded_graph
+    _enable_ops(client)
+    client.get("/health")
+    client.get("/api/v2/podcasts/1")
+
+    registry = _registry(client)
+    health_count = registry.get_sample_value(
+        "podex_http_requests_total",
+        {"method": "GET", "route": "/health", "status": "200"},
+    )
+    assert_that(health_count).is_equal_to(1.0)
+    templated_count = registry.get_sample_value(
+        "podex_http_requests_total",
+        {
+            "method": "GET",
+            "route": "/api/v2/podcasts/{podcast_id}",
+            "status": "200",
+        },
+    )
+    assert_that(templated_count).is_equal_to(1.0)
+    latency_count = registry.get_sample_value(
+        "podex_http_request_duration_seconds_count",
+        {"method": "GET", "route": "/health", "status": "200"},
+    )
+    assert_that(latency_count).is_equal_to(1.0)
+
+
+def test_request_middleware_labels_unmatched_routes(client: TestClient) -> None:
+    """Requests that never match a route are labelled ``unmatched``."""
+    client.get("/no-such-path")
+
+    count = _registry(client).get_sample_value(
+        "podex_http_requests_total",
+        {"method": "GET", "route": "unmatched", "status": "404"},
+    )
+    assert_that(count).is_equal_to(1.0)
+
+
+def test_scheduler_tick_instrumentation_records_success(
+    db_session: Session,
+) -> None:
+    """A successful instrumented tick records a duration and outcome sample."""
+    metrics = build_metrics()
+    settings = Settings(
+        scheduler_digest_interval_minutes=60,
+        scheduler_retention_interval_minutes=60,
+    )
+
+    summary = run_instrumented_tick(
+        db=db_session,
+        settings=settings,
+        digest_sender=None,
+        metrics=metrics,
+    )
+
+    assert_that(summary.planned).is_greater_than_or_equal_to(2)
+    success = metrics.registry.get_sample_value(
+        "podex_scheduler_ticks_total",
+        {"outcome": "success"},
+    )
+    assert_that(success).is_equal_to(1.0)
+    duration_count = metrics.registry.get_sample_value(
+        "podex_scheduler_tick_duration_seconds_count",
+    )
+    assert_that(duration_count).is_equal_to(1.0)
+
+
+def test_scheduler_tick_instrumentation_records_error(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing tick records an error sample and re-raises the exception."""
+    metrics = build_metrics()
+
+    def explode(**kwargs: object) -> object:
+        """Simulate a tick failure."""
+        del kwargs
+        raise RuntimeError("tick failed")
+
+    monkeypatch.setattr("podex.scheduler_runner.run_tick", explode)
+
+    with pytest.raises(RuntimeError, match="tick failed"):
+        run_instrumented_tick(
+            db=db_session,
+            settings=Settings(),
+            digest_sender=None,
+            metrics=metrics,
+        )
+
+    errors = metrics.registry.get_sample_value(
+        "podex_scheduler_ticks_total",
+        {"outcome": "error"},
+    )
+    assert_that(errors).is_equal_to(1.0)
+
+
+def test_observe_scheduler_tick_records_duration() -> None:
+    """The tick observer records both the counter and histogram sample."""
+    metrics = build_metrics()
+
+    observe_scheduler_tick(metrics, duration_seconds=0.25, outcome="success")
+
+    duration_sum = metrics.registry.get_sample_value(
+        "podex_scheduler_tick_duration_seconds_sum",
+    )
+    assert_that(duration_sum).is_equal_to(0.25)
+
+
+def test_ops_gauges_reflect_operational_metrics(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scrape-time gauges mirror the operational-metrics service output."""
+    _enable_ops(client)
+    fake = OperationalMetricsData(
+        measured_at=datetime(2026, 7, 19, 12, 0, tzinfo=UTC),
+        review=ReviewThroughputData(
+            pending_items=7,
+            decisions_last_24h=3,
+            median_decision_minutes_last_24h=12.5,
+        ),
+        alerts=AlertDeliveryData(
+            generated_events_last_24h=9,
+            delivered_digests_last_24h=4,
+            delivered_events_last_24h=6,
+            pending_events=2,
+        ),
+    )
+    monkeypatch.setattr(
+        podex.metrics,
+        "get_operational_metrics",
+        lambda *, db: fake,
+    )
+
+    response = client.get("/metrics", headers=_HEADERS)
+
+    assert_that(response.status_code).is_equal_to(200)
+    registry = _registry(client)
+    expected = {
+        "podex_review_pending_items": 7.0,
+        "podex_review_decisions_last_24h": 3.0,
+        "podex_review_median_decision_minutes_last_24h": 12.5,
+        "podex_alert_generated_events_last_24h": 9.0,
+        "podex_alert_delivered_digests_last_24h": 4.0,
+        "podex_alert_delivered_events_last_24h": 6.0,
+        "podex_alert_pending_events": 2.0,
+    }
+    for name, value in expected.items():
+        assert_that(registry.get_sample_value(name)).is_equal_to(value)
+
+
+def test_registry_is_isolated_per_app() -> None:
+    """Each create_app call builds its own registry; no cross-contamination."""
+    from podex.main import create_app
+
+    first = create_app()
+    second = create_app()
+    assert_that(first.state.metrics.registry).is_not_same_as(
+        second.state.metrics.registry,
+    )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1252,6 +1252,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "feedparser" },
     { name = "httpx" },
+    { name = "prometheus-client" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1286,6 +1287,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "feedparser", specifier = ">=6.0" },
     { name = "httpx", specifier = ">=0.28" },
+    { name = "prometheus-client", specifier = ">=0.21" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.6" },
@@ -1307,6 +1309,15 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=6.0" },
     { name = "types-assertpy", specifier = ">=1.1.0.20260518" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

> [!WARNING]
> **Commits unsigned — 1Password agent refused approvals.** The 1Password SSH signing agent (`op-ssh-sign`) returned errors for every signing attempt during this session, so this branch's commit is unsigned (orchestrator-approved override; main's `required_signatures` ruleset is satisfied by the GitHub web-flow-signed squash-merge commit). To re-sign locally once 1Password is unlocked:
>
> ```bash
> git rebase origin/main --exec 'git commit --amend --no-edit -S'
> git push --force-with-lease
> ```

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(observability): expose gated Prometheus /metrics endpoint
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Expose a Prometheus `/metrics` endpoint from the backend (epic #295):

- **`podex.metrics` module** — per-app `CollectorRegistry` factory (fresh registry per `create_app` call, so tests never cross-contaminate; production runs uvicorn single-process on Railway, so the plain per-process registry is sufficient), HTTP request counter + latency histogram labelled by `method`/`route` (path template, never raw path)/`status`, scheduler tick counter (by outcome) + duration histogram, and ops gauges (review throughput, alert delivery) recomputed at scrape time from `services.ops_metrics.get_operational_metrics`.
- **`MetricsMiddleware`** — records every request under its full route template; FastAPI 0.139 mounts included routers, so the `/api/v2` mount prefix is reconstructed from public scope data. Requests that never match a route (404s, rate-limited 429s) are labelled `unmatched` to keep cardinality bounded.
- **`GET /metrics`** — on the app root (not the public read-only `/api/v2` surface), gated by the same `X-Ops-Key` mechanism as the ops console: `503` until `PODEX_OPS_API_KEY` is configured, `401` on missing/wrong key. Excluded from the OpenAPI schema — `frontend/openapi.json` is unchanged (verified by regenerating), so no frontend type regeneration is needed.
- **Scheduler instrumentation** — `SchedulerRunner` ticks run through `run_instrumented_tick`, recording duration and `success`/`error` outcome; failures re-raise unchanged so the existing rollback/log handling still applies. The runner owns its own registry (separate process).
- Adds `prometheus-client>=0.21` to backend dependencies.

**Human gate (not closed by this PR):** Grafana Cloud provisioning — creating the stack, minting the metrics token, and deploying the Alloy agent on Railway — is a manual step. The shipping config, starter dashboard, and alert rules land in podex-ops (lgtm-hq/podex-ops PR, `grafana/`).

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing (internal endpoint; documented in podex-ops `grafana/README.md`)

## Related Issues

Refs #302

(`Refs`, not `Closes` — the Grafana Cloud provisioning half of the issue is a human gate; see above.)

## Details

- Tests: `backend/tests/test_metrics.py` — auth gating (503/401/200), exposition contains the expected metric families, route-template labelling (templated + unmatched), scheduler tick success/error samples, scrape-time gauges mirroring a mocked `get_operational_metrics`, registry isolation across `create_app` calls, and `/metrics` absent from the OpenAPI schema.
- Full suite: 400 passed, coverage 87.14% (gate ≥ 85). `lintro fmt`/`chk` clean for project files (mypy strict included).
