### PR TITLE
feat(billing): add Paddle checkout and signed webhook entitlement

### DIFF
--- a/backend/alembic/versions/0019_add_billing_webhook_events.py
+++ b/backend/alembic/versions/0019_add_billing_webhook_events.py
@@ -1,0 +1,50 @@
+"""Add the billing webhook event ledger for idempotent processing.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-07-20 10:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "0019"
+down_revision: str | None = "0018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+    op.create_table(
+        "billing_webhook_events",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.String(length=40), nullable=False),
+        sa.Column("event_id", sa.String(length=255), nullable=False),
+        sa.Column("event_type", sa.String(length=100), nullable=False),
+        sa.Column("processed_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "provider",
+            "event_id",
+            name="uq_billing_webhook_events_provider_event",
+        ),
+    )
+    op.create_index(
+        op.f("ix_billing_webhook_events_event_id"),
+        "billing_webhook_events",
+        ["event_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+    op.drop_index(
+        op.f("ix_billing_webhook_events_event_id"),
+        table_name="billing_webhook_events",
+    )
+    op.drop_table("billing_webhook_events")

--- a/backend/src/podex/api/v2/billing.py
+++ b/backend/src/podex/api/v2/billing.py
@@ -1,0 +1,119 @@
+"""Signed billing webhook intake for the Paddle provider.
+
+The route verifies Paddle's ``ts``/``h1`` HMAC signature over the exact raw
+body before touching the payload, stores processed event ids so replays are
+acknowledged without reprocessing, and applies subscription lifecycle events
+to the provider-neutral ``AccountSubscription`` entitlement.
+"""
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from podex.api.deps import AppSettings, DbSession
+from podex.schemas.billing import BillingWebhookAck
+from podex.services.billing_checkout import PADDLE_PROVIDER_NAME
+from podex.services.billing_webhooks import (
+    PADDLE_SIGNATURE_HEADER,
+    PaddleSignatureFormatError,
+    PaddleSignatureVerificationError,
+    apply_paddle_subscription_event,
+    record_billing_webhook_event,
+    verify_paddle_signature,
+)
+
+router = APIRouter(tags=["billing"])
+
+_ACK_PROCESSED = "processed"
+_ACK_DUPLICATE = "duplicate"
+_ACK_IGNORED = "ignored"
+
+
+def _parse_event(raw_body: bytes) -> tuple[str, str, dict[str, Any]]:
+    """Decode a verified webhook body into event id, type, and data."""
+    try:
+        payload = json.loads(raw_body)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Webhook payload is not valid JSON",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Webhook payload must be a JSON object",
+        )
+    event_id = payload.get("event_id")
+    event_type = payload.get("event_type")
+    if not isinstance(event_id, str) or not event_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Webhook payload is missing event_id",
+        )
+    if not isinstance(event_type, str) or not event_type:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Webhook payload is missing event_type",
+        )
+    data = payload.get("data")
+    return event_id, event_type, data if isinstance(data, dict) else {}
+
+
+async def receive_paddle_webhook(
+    request: Request,
+    db: DbSession,
+    settings: AppSettings,
+) -> BillingWebhookAck:
+    """Verify, dedupe, and apply one signed Paddle webhook delivery."""
+    if not settings.paddle_webhook_secret:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Paddle webhooks are not configured",
+        )
+    signature_header = request.headers.get(PADDLE_SIGNATURE_HEADER, "")
+    if not signature_header:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Paddle signature",
+        )
+    raw_body = await request.body()
+    try:
+        verify_paddle_signature(
+            signature_header=signature_header,
+            raw_body=raw_body,
+            secret=settings.paddle_webhook_secret,
+        )
+    except PaddleSignatureFormatError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Malformed Paddle signature",
+        ) from exc
+    except PaddleSignatureVerificationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Paddle signature",
+        ) from exc
+    event_id, event_type, data = _parse_event(raw_body)
+    if not record_billing_webhook_event(
+        db=db,
+        provider=PADDLE_PROVIDER_NAME,
+        event_id=event_id,
+        event_type=event_type,
+    ):
+        return BillingWebhookAck(status=_ACK_DUPLICATE)
+    applied = apply_paddle_subscription_event(
+        db=db,
+        event_type=event_type,
+        data=data,
+    )
+    db.commit()
+    return BillingWebhookAck(status=_ACK_PROCESSED if applied else _ACK_IGNORED)
+
+
+router.add_api_route(
+    "/billing/webhooks/paddle",
+    receive_paddle_webhook,
+    methods=["POST"],
+    response_model=BillingWebhookAck,
+)

--- a/backend/src/podex/api/v2/router.py
+++ b/backend/src/podex/api/v2/router.py
@@ -3,7 +3,16 @@
 from fastapi import APIRouter
 
 from podex.api.deps import AppSettings
-from podex.api.v2 import auth, episodes, media, ops, podcasts, stats, takedowns
+from podex.api.v2 import (
+    auth,
+    billing,
+    episodes,
+    media,
+    ops,
+    podcasts,
+    stats,
+    takedowns,
+)
 from podex.api.v2.schemas import ApiStatusRead
 
 api_v2_router = APIRouter(tags=["v2"])
@@ -25,5 +34,6 @@ api_v2_router.include_router(episodes.router)
 api_v2_router.include_router(media.router)
 api_v2_router.include_router(stats.router)
 api_v2_router.include_router(auth.router)
+api_v2_router.include_router(billing.router)
 api_v2_router.include_router(ops.router)
 api_v2_router.include_router(takedowns.router)

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -97,6 +97,20 @@ class Settings(BaseSettings):
     billing_provider_name: str = ""
     billing_checkout_url: str = ""
 
+    # Paddle Merchant of Record. Every identifier defaults to an empty
+    # string so the Paddle provider stays disabled until the deployment
+    # environment configures it; the webhook route rejects requests until
+    # the signing secret is set.
+    paddle_api_key: str = ""
+    paddle_webhook_secret: str = ""
+    paddle_price_id: str = ""
+    paddle_checkout_url: str = ""
+
+    @property
+    def paddle_checkout_enabled(self) -> bool:
+        """Whether Paddle-hosted checkout is fully configured."""
+        return bool(self.paddle_checkout_url and self.paddle_price_id)
+
     # Ops console API. The ops surface stays disabled until a key is
     # configured by the deployment environment; requests must present it in
     # the X-Ops-Key header.

--- a/backend/src/podex/models/__init__.py
+++ b/backend/src/podex/models/__init__.py
@@ -15,6 +15,7 @@ from podex.models.account_subscription import AccountSubscription
 from podex.models.account_user import AccountUser
 from podex.models.audit_log import AuditAction, AuditLog
 from podex.models.base import Base
+from podex.models.billing_webhook_event import BillingWebhookEvent
 from podex.models.derivative_generation_run import (
     DerivativeGenerationRun,
     DerivativeGenerationRunStatus,
@@ -77,6 +78,7 @@ __all__ = [
     "AuditAction",
     "AuditLog",
     "Base",
+    "BillingWebhookEvent",
     "DerivativeGenerationRun",
     "DerivativeGenerationRunStatus",
     "DerivativeSummaryKind",

--- a/backend/src/podex/models/billing_webhook_event.py
+++ b/backend/src/podex/models/billing_webhook_event.py
@@ -1,0 +1,29 @@
+"""Processed billing webhook event ledger for idempotent delivery."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from podex.models.base import Base
+
+
+class BillingWebhookEvent(Base):
+    """One processed provider webhook event, keyed for replay suppression."""
+
+    __tablename__ = "billing_webhook_events"
+    __table_args__ = (
+        UniqueConstraint(
+            "provider",
+            "event_id",
+            name="uq_billing_webhook_events_provider_event",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    provider: Mapped[str] = mapped_column(String(40))
+    event_id: Mapped[str] = mapped_column(String(255), index=True)
+    event_type: Mapped[str] = mapped_column(String(100))
+    processed_at: Mapped[datetime] = mapped_column(
+        default=lambda: datetime.now(UTC),
+    )

--- a/backend/src/podex/schemas/billing.py
+++ b/backend/src/podex/schemas/billing.py
@@ -1,0 +1,9 @@
+"""Pydantic schemas for the billing webhook surface."""
+
+from pydantic import BaseModel
+
+
+class BillingWebhookAck(BaseModel):
+    """Acknowledgement returned to the billing provider's webhook sender."""
+
+    status: str

--- a/backend/src/podex/services/billing_checkout.py
+++ b/backend/src/podex/services/billing_checkout.py
@@ -6,6 +6,12 @@ from urllib.parse import urlencode
 
 from podex.config import Settings
 
+PADDLE_PROVIDER_NAME = "paddle"
+"""Provider label recorded on checkouts and subscriptions handled by Paddle."""
+
+ACCOUNT_REFERENCE_KEY = "account_reference"
+"""Query/custom-data key carrying the opaque account reference end to end."""
+
 
 @dataclass(frozen=True)
 class BillingCheckout:
@@ -49,11 +55,51 @@ class HostedBillingCheckoutProvider:
         )
 
 
+class PaddleBillingCheckoutProvider:
+    """Paddle-hosted checkout bridge carrying an opaque account reference.
+
+    The generated link prefills the customer's email and threads the opaque
+    account reference (never the email) through Paddle's ``custom_data`` so
+    the signed webhook can attribute subscription events back to an account.
+    """
+
+    provider = PADDLE_PROVIDER_NAME
+
+    def __init__(self, *, checkout_url: str, price_id: str) -> None:
+        self.checkout_url = checkout_url
+        self.price_id = price_id
+
+    def create_checkout(
+        self,
+        *,
+        email: str,
+        account_reference: str,
+    ) -> BillingCheckout:
+        """Build a Paddle-hosted checkout link for the configured price."""
+        separator = "&" if "?" in self.checkout_url else "?"
+        query = urlencode(
+            {
+                "price_id": self.price_id,
+                "prefilled_email": email,
+                ACCOUNT_REFERENCE_KEY: account_reference,
+            },
+        )
+        return BillingCheckout(
+            provider=self.provider,
+            checkout_url=f"{self.checkout_url}{separator}{query}",
+        )
+
+
 def build_billing_checkout_provider(
     *,
     settings: Settings,
 ) -> BillingCheckoutProvider | None:
     """Build the configured provider bridge only when checkout is configured."""
+    if settings.paddle_checkout_enabled:
+        return PaddleBillingCheckoutProvider(
+            checkout_url=settings.paddle_checkout_url,
+            price_id=settings.paddle_price_id,
+        )
     if not settings.billing_provider_name or not settings.billing_checkout_url:
         return None
     return HostedBillingCheckoutProvider(

--- a/backend/src/podex/services/billing_webhooks.py
+++ b/backend/src/podex/services/billing_webhooks.py
@@ -1,0 +1,202 @@
+"""Paddle webhook signature verification and idempotent entitlement updates.
+
+This module (together with the checkout provider) is the only place that
+knows Paddle's wire formats: the ``Paddle-Signature`` header scheme and the
+subscription event payload shape. Everything it writes goes through the
+provider-neutral ``AccountSubscription`` model.
+"""
+
+import hashlib
+import hmac
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from podex.models import AccountUser, BillingWebhookEvent
+from podex.services.account_subscriptions import get_account_subscription
+from podex.services.billing_checkout import (
+    ACCOUNT_REFERENCE_KEY,
+    PADDLE_PROVIDER_NAME,
+)
+
+PADDLE_SIGNATURE_HEADER = "Paddle-Signature"
+"""Header carrying Paddle's ``ts=...;h1=...`` webhook signature."""
+
+SIGNATURE_TOLERANCE_SECONDS = 300
+"""Maximum accepted skew between the signed timestamp and receipt time."""
+
+_ACTIVE_PADDLE_STATUSES = frozenset({"active", "trialing"})
+_SUBSCRIPTION_EVENT_PREFIX = "subscription."
+
+
+class PaddleSignatureFormatError(Exception):
+    """Raised when the signature header cannot be parsed at all."""
+
+
+class PaddleSignatureVerificationError(Exception):
+    """Raised when a parsed signature is stale or fails the HMAC check."""
+
+
+def verify_paddle_signature(
+    *,
+    signature_header: str,
+    raw_body: bytes,
+    secret: str,
+    now: datetime | None = None,
+) -> None:
+    """Verify a Paddle ``ts``/``h1`` HMAC-SHA256 webhook signature.
+
+    Args:
+        signature_header: Raw ``Paddle-Signature`` header value.
+        raw_body: Exact request body bytes the signature covers.
+        secret: Shared webhook signing secret from settings.
+        now: Injection point for the current time in tests.
+
+    Raises:
+        PaddleSignatureFormatError: When the header is not ``ts=...;h1=...``.
+        PaddleSignatureVerificationError: When the timestamp is stale or no
+            provided ``h1`` digest matches the computed one.
+    """
+    timestamp: int | None = None
+    digests: list[str] = []
+    for element in signature_header.split(";"):
+        key, separator, value = element.strip().partition("=")
+        if not separator:
+            continue
+        if key == "ts":
+            try:
+                timestamp = int(value)
+            except ValueError as exc:
+                raise PaddleSignatureFormatError from exc
+        elif key == "h1":
+            digests.append(value)
+    if timestamp is None or not digests:
+        raise PaddleSignatureFormatError
+    received_at = (now or datetime.now(UTC)).timestamp()
+    if abs(received_at - timestamp) > SIGNATURE_TOLERANCE_SECONDS:
+        raise PaddleSignatureVerificationError
+    expected = hmac.new(
+        key=secret.encode("utf-8"),
+        msg=f"{timestamp}:".encode() + raw_body,
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+    if not any(hmac.compare_digest(expected, digest) for digest in digests):
+        raise PaddleSignatureVerificationError
+
+
+def record_billing_webhook_event(
+    *,
+    db: Session,
+    provider: str,
+    event_id: str,
+    event_type: str,
+) -> bool:
+    """Record a webhook event id, reporting whether it is new.
+
+    Args:
+        db: Database session shared with the request.
+        provider: Billing provider label (for example ``paddle``).
+        event_id: Provider-unique event identifier.
+        event_type: Provider event type, stored for observability.
+
+    Returns:
+        ``True`` when the event was recorded now, ``False`` on replay.
+    """
+    already_processed = (
+        db.query(BillingWebhookEvent)
+        .filter(
+            BillingWebhookEvent.provider == provider,
+            BillingWebhookEvent.event_id == event_id,
+        )
+        .first()
+    )
+    if already_processed is not None:
+        return False
+    db.add(
+        BillingWebhookEvent(
+            provider=provider,
+            event_id=event_id,
+            event_type=event_type,
+        ),
+    )
+    db.flush()
+    return True
+
+
+def _parse_account_id(data: dict[str, Any]) -> int | None:
+    """Extract the opaque account reference threaded through checkout."""
+    custom_data = data.get("custom_data")
+    if not isinstance(custom_data, dict):
+        return None
+    reference = custom_data.get(ACCOUNT_REFERENCE_KEY)
+    try:
+        return int(str(reference))
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_period_end(data: dict[str, Any]) -> datetime | None:
+    """Extract the current billing period end, if the payload carries one."""
+    period = data.get("current_billing_period")
+    if not isinstance(period, dict):
+        return None
+    ends_at = period.get("ends_at")
+    if not isinstance(ends_at, str):
+        return None
+    try:
+        return datetime.fromisoformat(ends_at)
+    except ValueError:
+        return None
+
+
+def apply_paddle_subscription_event(
+    *,
+    db: Session,
+    event_type: str,
+    data: dict[str, Any],
+) -> bool:
+    """Apply one Paddle subscription lifecycle event to an entitlement.
+
+    Unknown event types, missing/unparseable account references, and
+    references that match no account are acked without effect.
+
+    Args:
+        db: Database session shared with the request.
+        event_type: Paddle event type (for example ``subscription.activated``).
+        data: The event's ``data`` object.
+
+    Returns:
+        ``True`` when an ``AccountSubscription`` was updated.
+    """
+    if not event_type.startswith(_SUBSCRIPTION_EVENT_PREFIX):
+        return False
+    user_id = _parse_account_id(data)
+    if user_id is None:
+        return False
+    user_exists = db.query(AccountUser.id).filter(AccountUser.id == user_id).first()
+    if user_exists is None:
+        return False
+    subscription = get_account_subscription(db=db, user_id=user_id)
+    paddle_status = str(data.get("status") or "")
+    is_canceled = event_type == "subscription.canceled"
+    is_active = not is_canceled and paddle_status in _ACTIVE_PADDLE_STATUSES
+    subscription.billing_provider = PADDLE_PROVIDER_NAME
+    customer_id = data.get("customer_id")
+    if isinstance(customer_id, str) and customer_id:
+        subscription.provider_customer_id = customer_id
+    subscription_id = data.get("id")
+    if isinstance(subscription_id, str) and subscription_id:
+        subscription.provider_subscription_id = subscription_id
+    subscription.current_period_ends_at = _parse_period_end(data)
+    if is_active:
+        subscription.tier = "paid"
+        subscription.status = "active"
+    elif is_canceled:
+        subscription.tier = "free"
+        subscription.status = "canceled"
+    else:
+        subscription.tier = "free"
+        subscription.status = paddle_status or "inactive"
+    db.flush()
+    return True

--- a/backend/tests/test_acceptance_catalog.py
+++ b/backend/tests/test_acceptance_catalog.py
@@ -213,6 +213,7 @@ def test_openapi_surface_is_read_only_get() -> None:
     catalog_prefix = "/api/v2/"
     account_prefixes = (
         "/api/v2/auth",
+        "/api/v2/billing",
         "/api/v2/me",
         "/api/v2/ops",
         "/api/v2/takedowns",
@@ -240,7 +241,13 @@ def test_openapi_response_schemas_reference_read_dtos() -> None:
         if not path.startswith("/api/v2/") or path.endswith("/status"):
             continue
         if path.startswith(
-            ("/api/v2/auth", "/api/v2/me", "/api/v2/ops", "/api/v2/takedowns"),
+            (
+                "/api/v2/auth",
+                "/api/v2/billing",
+                "/api/v2/me",
+                "/api/v2/ops",
+                "/api/v2/takedowns",
+            ),
         ):
             continue
         success = operations["get"]["responses"]["200"]["content"]["application/json"][

--- a/backend/tests/test_billing_paddle.py
+++ b/backend/tests/test_billing_paddle.py
@@ -1,0 +1,340 @@
+"""Tests for the Paddle checkout provider and signed webhook route."""
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+import pytest
+from assertpy import assert_that
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from podex.api.deps import get_app_settings
+from podex.config import Settings
+from podex.models import AccountSubscription, AccountUser, BillingWebhookEvent
+from podex.services.billing_checkout import (
+    HostedBillingCheckoutProvider,
+    PaddleBillingCheckoutProvider,
+    build_billing_checkout_provider,
+)
+from podex.services.billing_webhooks import (
+    PaddleSignatureFormatError,
+    PaddleSignatureVerificationError,
+    verify_paddle_signature,
+)
+
+_SECRET = "whsec_test_secret"  # nosec B105 - test-only signing secret
+_WEBHOOK_PATH = "/api/v2/billing/webhooks/paddle"
+
+
+def _sign(body: bytes, *, secret: str = _SECRET, ts: int | None = None) -> str:
+    """Build a valid ``ts=...;h1=...`` Paddle signature header for a body."""
+    timestamp = int(time.time()) if ts is None else ts
+    digest = hmac.new(
+        key=secret.encode("utf-8"),
+        msg=f"{timestamp}:".encode() + body,
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+    return f"ts={timestamp};h1={digest}"
+
+
+def _configure_paddle(client: TestClient) -> None:
+    """Point the app's settings dependency at a Paddle-enabled config."""
+    app = client.app
+    if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
+        raise AssertionError
+    app.dependency_overrides[get_app_settings] = lambda: Settings(
+        paddle_webhook_secret=_SECRET,
+    )
+
+
+def _create_user(db_session: Session) -> AccountUser:
+    """Persist one account user for entitlement assertions."""
+    user = AccountUser(email="reader@example.com")
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _subscription_event(
+    *,
+    user_id: int,
+    event_id: str = "evt_001",
+    event_type: str = "subscription.activated",
+    paddle_status: str = "active",
+) -> dict[str, Any]:
+    """Build a minimal Paddle subscription event payload."""
+    return {
+        "event_id": event_id,
+        "event_type": event_type,
+        "data": {
+            "id": "sub_123",
+            "customer_id": "ctm_456",
+            "status": paddle_status,
+            "custom_data": {"account_reference": str(user_id)},
+            "current_billing_period": {
+                "starts_at": "2026-07-20T00:00:00+00:00",
+                "ends_at": "2026-08-20T00:00:00+00:00",
+            },
+        },
+    }
+
+
+def _post_event(client: TestClient, payload: dict[str, Any]) -> Any:
+    """Sign and deliver one webhook payload to the Paddle route."""
+    body = json.dumps(payload).encode("utf-8")
+    return client.post(
+        _WEBHOOK_PATH,
+        content=body,
+        headers={"Paddle-Signature": _sign(body)},
+    )
+
+
+def test_paddle_provider_builds_prefilled_checkout() -> None:
+    """The Paddle bridge carries email and an opaque account reference."""
+    provider = build_billing_checkout_provider(
+        settings=Settings(
+            paddle_checkout_url="https://buy.paddle.example/checkout",
+            paddle_price_id="pri_123",
+        ),
+    )
+    assert_that(provider).is_instance_of(PaddleBillingCheckoutProvider)
+    if provider is None:  # pragma: no cover - narrowed above
+        raise AssertionError
+
+    checkout = provider.create_checkout(
+        email="reader@example.com",
+        account_reference="7",
+    )
+
+    assert_that(checkout.provider).is_equal_to("paddle")
+    assert_that(checkout.checkout_url).contains(
+        "price_id=pri_123",
+        "prefilled_email=reader%40example.com",
+        "account_reference=7",
+    )
+    assert_that(checkout.checkout_url).does_not_contain(
+        "account_reference=reader",
+    )
+
+
+def test_provider_builder_prefers_paddle_then_hosted() -> None:
+    """Paddle settings win; the hosted bridge and None fallback remain."""
+    assert_that(build_billing_checkout_provider(settings=Settings())).is_none()
+    hosted = build_billing_checkout_provider(
+        settings=Settings(
+            billing_provider_name="hosted-test",
+            billing_checkout_url="https://billing.example/upgrade",
+        ),
+    )
+    assert_that(hosted).is_instance_of(HostedBillingCheckoutProvider)
+    paddle = build_billing_checkout_provider(
+        settings=Settings(
+            billing_provider_name="hosted-test",
+            billing_checkout_url="https://billing.example/upgrade",
+            paddle_checkout_url="https://buy.paddle.example/checkout",
+            paddle_price_id="pri_123",
+        ),
+    )
+    assert_that(paddle).is_instance_of(PaddleBillingCheckoutProvider)
+
+
+def test_verify_signature_accepts_valid_header() -> None:
+    """A freshly signed body passes verification."""
+    body = b'{"event_id": "evt"}'
+    verify_paddle_signature(
+        signature_header=_sign(body),
+        raw_body=body,
+        secret=_SECRET,
+    )
+
+
+@pytest.mark.parametrize(
+    "header",
+    ["", "ts=abc;h1=deadbeef", "h1=deadbeef", "ts=123", "nonsense"],
+    ids=["empty", "non_int_ts", "missing_ts", "missing_h1", "no_pairs"],
+)
+def test_verify_signature_rejects_malformed_header(header: str) -> None:
+    """Headers without a parseable ts/h1 pair raise a format error."""
+    with pytest.raises(PaddleSignatureFormatError):
+        verify_paddle_signature(
+            signature_header=header,
+            raw_body=b"{}",
+            secret=_SECRET,
+        )
+
+
+def test_verify_signature_rejects_bad_digest_and_stale_ts() -> None:
+    """Wrong digests and out-of-tolerance timestamps fail verification."""
+    body = b'{"event_id": "evt"}'
+    bad_sig = _sign(body, secret="wrong-secret")  # nosec B106 - wrong on purpose
+    with pytest.raises(PaddleSignatureVerificationError):
+        verify_paddle_signature(
+            signature_header=bad_sig,
+            raw_body=body,
+            secret=_SECRET,
+        )
+    with pytest.raises(PaddleSignatureVerificationError):
+        verify_paddle_signature(
+            signature_header=_sign(body, ts=int(time.time()) - 3600),
+            raw_body=body,
+            secret=_SECRET,
+        )
+
+
+def test_webhook_route_unconfigured_returns_503(client: TestClient) -> None:
+    """Without a webhook secret the route refuses deliveries."""
+    response = client.post(_WEBHOOK_PATH, content=b"{}")
+
+    assert_that(response.status_code).is_equal_to(503)
+
+
+def test_webhook_route_rejects_missing_and_bad_signatures(
+    client: TestClient,
+) -> None:
+    """Missing headers, bad digests, and stale timestamps never process."""
+    _configure_paddle(client)
+    body = b'{"event_id": "evt_sig", "event_type": "subscription.activated"}'
+
+    missing = client.post(_WEBHOOK_PATH, content=body)
+    assert_that(missing.status_code).is_equal_to(401)
+
+    bad_sig = _sign(body, secret="wrong-secret")  # nosec B106 - wrong on purpose
+    bad_digest = client.post(
+        _WEBHOOK_PATH,
+        content=body,
+        headers={"Paddle-Signature": bad_sig},
+    )
+    assert_that(bad_digest.status_code).is_equal_to(401)
+
+    stale = client.post(
+        _WEBHOOK_PATH,
+        content=body,
+        headers={"Paddle-Signature": _sign(body, ts=int(time.time()) - 3600)},
+    )
+    assert_that(stale.status_code).is_equal_to(401)
+
+    malformed = client.post(
+        _WEBHOOK_PATH,
+        content=body,
+        headers={"Paddle-Signature": "not-a-signature"},
+    )
+    assert_that(malformed.status_code).is_equal_to(400)
+
+
+def test_webhook_route_rejects_invalid_payloads(client: TestClient) -> None:
+    """Signed but unusable bodies are rejected with 400."""
+    _configure_paddle(client)
+    for body in (b"not json", b'{"event_type": "x"}', b'{"event_id": "evt"}'):
+        response = client.post(
+            _WEBHOOK_PATH,
+            content=body,
+            headers={"Paddle-Signature": _sign(body)},
+        )
+        assert_that(response.status_code).is_equal_to(400)
+
+
+def test_webhook_activates_subscription(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """An activation event upgrades the entitlement with provider ids."""
+    _configure_paddle(client)
+    user = _create_user(db_session)
+
+    response = _post_event(client, _subscription_event(user_id=user.id))
+
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()["status"]).is_equal_to("processed")
+    subscription = db_session.query(AccountSubscription).one()
+    assert_that(subscription.tier).is_equal_to("paid")
+    assert_that(subscription.status).is_equal_to("active")
+    assert_that(subscription.billing_provider).is_equal_to("paddle")
+    assert_that(subscription.provider_customer_id).is_equal_to("ctm_456")
+    assert_that(subscription.provider_subscription_id).is_equal_to("sub_123")
+    assert_that(subscription.current_period_ends_at).is_not_none()
+
+
+def test_webhook_replay_is_acked_without_reprocessing(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """A replayed event id is acknowledged but applied only once."""
+    _configure_paddle(client)
+    user = _create_user(db_session)
+    payload = _subscription_event(user_id=user.id, event_id="evt_replay")
+
+    first = _post_event(client, payload)
+    assert_that(first.status_code).is_equal_to(200)
+    subscription = db_session.query(AccountSubscription).one()
+    subscription.tier = "free"
+    subscription.status = "canceled"
+    db_session.commit()
+
+    replay = _post_event(client, payload)
+
+    assert_that(replay.status_code).is_equal_to(200)
+    assert_that(replay.json()["status"]).is_equal_to("duplicate")
+    db_session.expire_all()
+    subscription = db_session.query(AccountSubscription).one()
+    assert_that(subscription.tier).is_equal_to("free")
+    assert_that(subscription.status).is_equal_to("canceled")
+    assert_that(db_session.query(BillingWebhookEvent).count()).is_equal_to(1)
+
+
+def test_webhook_cancellation_revokes_access(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """A cancellation event ends paid access."""
+    _configure_paddle(client)
+    user = _create_user(db_session)
+    _post_event(client, _subscription_event(user_id=user.id))
+
+    response = _post_event(
+        client,
+        _subscription_event(
+            user_id=user.id,
+            event_id="evt_cancel",
+            event_type="subscription.canceled",
+            paddle_status="canceled",
+        ),
+    )
+
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.json()["status"]).is_equal_to("processed")
+    db_session.expire_all()
+    subscription = db_session.query(AccountSubscription).one()
+    assert_that(subscription.tier).is_equal_to("free")
+    assert_that(subscription.status).is_equal_to("canceled")
+
+
+def test_webhook_unknown_event_and_unknown_account_are_acked(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Non-subscription events and unmatched references ack as ignored."""
+    _configure_paddle(client)
+
+    unknown_type = _post_event(
+        client,
+        {
+            "event_id": "evt_txn",
+            "event_type": "transaction.completed",
+            "data": {"id": "txn_1"},
+        },
+    )
+    assert_that(unknown_type.status_code).is_equal_to(200)
+    assert_that(unknown_type.json()["status"]).is_equal_to("ignored")
+
+    unknown_account = _post_event(
+        client,
+        _subscription_event(user_id=999_999, event_id="evt_ghost"),
+    )
+    assert_that(unknown_account.status_code).is_equal_to(200)
+    assert_that(unknown_account.json()["status"]).is_equal_to("ignored")
+    assert_that(db_session.query(AccountSubscription).count()).is_equal_to(0)
+    assert_that(db_session.query(BillingWebhookEvent).count()).is_equal_to(2)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -358,6 +358,20 @@
         "title": "AuthSessionRead",
         "type": "object"
       },
+      "BillingWebhookAck": {
+        "description": "Acknowledgement returned to the billing provider's webhook sender.",
+        "properties": {
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "BillingWebhookAck",
+        "type": "object"
+      },
       "CatalogStats": {
         "description": "Top-level catalog counters plus a small top-list breakdown.\n\nAttributes:\n    podcasts: Total podcast sources in the catalog.\n    episodes: Total episodes across all sources.\n    media: Total canonical media items in the catalog. Counts every\n        ``Media`` row, not just those referenced by a mention.\n    mentions: Total episode<->media mention links.\n    top_media_types: Up to five media types ordered by descending count,\n        with ties broken alphabetically by type name for stability.",
         "properties": {
@@ -2781,6 +2795,29 @@
         "tags": [
           "v2",
           "auth"
+        ]
+      }
+    },
+    "/api/v2/billing/webhooks/paddle": {
+      "post": {
+        "description": "Verify, dedupe, and apply one signed Paddle webhook delivery.",
+        "operationId": "receive_paddle_webhook_api_v2_billing_webhooks_paddle_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingWebhookAck"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Receive Paddle Webhook",
+        "tags": [
+          "v2",
+          "billing"
         ]
       }
     },

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -104,6 +104,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/billing/webhooks/paddle": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Receive Paddle Webhook
+         * @description Verify, dedupe, and apply one signed Paddle webhook delivery.
+         */
+        post: operations["receive_paddle_webhook_api_v2_billing_webhooks_paddle_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/episodes": {
         parameters: {
             query?: never;
@@ -1114,6 +1134,14 @@ export interface components {
              */
             expires_at: string;
             user: components["schemas"]["AccountUserRead"];
+        };
+        /**
+         * BillingWebhookAck
+         * @description Acknowledgement returned to the billing provider's webhook sender.
+         */
+        BillingWebhookAck: {
+            /** Status */
+            status: string;
         };
         /**
          * CatalogStats
@@ -2135,6 +2163,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    receive_paddle_webhook_api_v2_billing_webhooks_paddle_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingWebhookAck"];
                 };
             };
         };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Title: `feat(billing): add Paddle checkout and signed webhook entitlement`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adopts Paddle as Merchant of Record behind the existing provider-neutral billing boundary (epic #295):

- `PaddleBillingCheckoutProvider` implementing the `BillingCheckoutProvider` protocol: hosted checkout link carrying the configured `price_id`, a prefilled customer email, and an opaque `account_reference` (the account user id — never the email).
- `build_billing_checkout_provider` returns the Paddle provider when Paddle settings are configured, keeps the hosted bridge otherwise, and still returns `None` when nothing is configured. Checkout remains behind `paid_tier_enabled`/`paid_tier_enforced`.
- New `POST /api/v2/billing/webhooks/paddle` route (registered via `router.add_api_route`): verifies the `Paddle-Signature` `ts`/`h1` HMAC-SHA256 over `{ts}:{raw_body}` with constant-time compare and a 300s staleness window (400 malformed header, 401 bad/stale signature, 503 when unconfigured).
- Idempotency: new `billing_webhook_events` table (unique `provider` + `event_id`); replayed event ids are acked 200 as `duplicate` without reprocessing.
- Subscription lifecycle: activation/update/cancellation events set `AccountSubscription` tier, status, `current_period_ends_at`, and provider customer/subscription ids. Unknown event types and unmatched account references are acked as `ignored`.
- Settings: `paddle_api_key`, `paddle_webhook_secret`, `paddle_price_id`, `paddle_checkout_url` — all empty-string defaults; provider disabled when unset. No secrets in repo.
- No Paddle knowledge outside `services/billing_checkout.py`, `services/billing_webhooks.py`, and the webhook route module.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #297
- Relates to #295

## Details

- Migration `0019_add_billing_webhook_events` chains on #296's `0018`; `AccountSubscription` provider-id columns already exist from `0014`, so only the ledger table is added. Verified `alembic upgrade head` and `downgrade 0018` round-trip.
- `frontend/openapi.json` + `types.gen.ts` regenerated (`python -m podex.openapi` / `bun run generate:api`).
- Catalog acceptance tests: `/api/v2/billing` added to the non-catalog write-surface exemption list (same pattern as `/api/v2/takedowns`).
- Verification: backend `uv run pytest` 430 passed, coverage 87.28% (>= 85); new tests cover signature rejection (missing/bad/stale/malformed), idempotent replay, activation and cancellation transitions, unknown-event ack, and checkout provider prefill/opaque-reference behavior. Frontend `bun run check` and `bun run test:coverage` (85 passed) green. `uv run lintro fmt`/`chk` clean for all lanes touched by this change; `markdownlint` and `pip-audit` failures are pre-existing on `main` (verified against a stashed clean tree).