### PR TITLE
fix(enrichment): resolve post-merge review findings in the enrichment service layer

### DIFF
--- a/backend/src/podex/services/academic_enrichment.py
+++ b/backend/src/podex/services/academic_enrichment.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, wait
 from typing import TYPE_CHECKING, Any
 
 from podex.services.enrichment.base import (
     EnrichmentResult,
     EnrichmentSource,
     VerifiedEnrichmentResult,
+    canonicalize_doi,
 )
 from podex.services.enrichment.crossref import CrossRefProvider
 from podex.services.enrichment.pubmed import PubMedProvider
@@ -23,6 +25,9 @@ if TYPE_CHECKING:
     from podex.models.media import Media
 
 logger = logging.getLogger(__name__)
+
+#: Default aggregate deadline for the concurrent provider fan-out.
+DEFAULT_AGGREGATE_TIMEOUT_SECONDS = 30.0
 
 
 class AcademicEnricher:
@@ -35,6 +40,8 @@ class AcademicEnricher:
     Args:
         ncbi_api_key: Optional NCBI API key for PubMed (higher rate limits).
         crossref_mailto: Optional email for CrossRef polite pool.
+        aggregate_timeout_seconds: Aggregate deadline for the concurrent
+            provider fan-out; providers still running past it are dropped.
     """
 
     SUPPORTED_TYPES = {"study", "article"}
@@ -43,7 +50,9 @@ class AcademicEnricher:
         self,
         ncbi_api_key: str | None = None,
         crossref_mailto: str | None = None,
+        aggregate_timeout_seconds: float = DEFAULT_AGGREGATE_TIMEOUT_SECONDS,
     ) -> None:
+        self.aggregate_timeout_seconds = aggregate_timeout_seconds
         self.providers = {
             EnrichmentSource.PUBMED: PubMedProvider(api_key=ncbi_api_key),
             EnrichmentSource.SEMANTIC_SCHOLAR: SemanticScholarProvider(),
@@ -73,20 +82,8 @@ class AcademicEnricher:
         if not self.supports_media_type(media.type):
             return None
 
-        # 1. Collect results from all providers
-        results: dict[EnrichmentSource, EnrichmentResult] = {}
-        for source, provider in self.providers.items():
-            try:
-                result = provider.search_and_enrich(media)
-                if result and result.confidence >= 0.5:
-                    results[source] = result
-                    logger.debug(
-                        f"Got result from {source.value} for '{media.title}' "
-                        f"(confidence: {result.confidence:.2f})"
-                    )
-            except Exception:
-                logger.exception(f"Error querying {source.value}")
-                continue
+        # 1. Collect results from all providers concurrently
+        results = self._collect_provider_results(media)
 
         if not results:
             logger.debug(f"No academic enrichment results for: {media.title}")
@@ -147,6 +144,63 @@ class AcademicEnricher:
 
         return None
 
+    def _collect_provider_results(
+        self,
+        media: Media,
+    ) -> dict[EnrichmentSource, EnrichmentResult]:
+        """Query all providers concurrently under an aggregate deadline.
+
+        Provider failures stay isolated: a raising provider is logged and
+        skipped, and a provider still running past the aggregate timeout is
+        dropped, while remaining results are still collected. Providers'
+        internal rate limiters are per-provider, so cross-provider
+        concurrency does not violate per-API cadence.
+
+        Args:
+            media: The media item to enrich.
+
+        Returns:
+            Results keyed by source, filtered to confidence >= 0.5.
+        """
+        results: dict[EnrichmentSource, EnrichmentResult] = {}
+        if not self.providers:
+            return results
+
+        executor = ThreadPoolExecutor(max_workers=len(self.providers))
+        try:
+            futures = {
+                executor.submit(provider.search_and_enrich, media): source
+                for source, provider in self.providers.items()
+            }
+            done, not_done = wait(
+                futures,
+                timeout=self.aggregate_timeout_seconds,
+            )
+            for future in not_done:
+                logger.warning(
+                    "Provider %s timed out after %.1fs for '%s'; dropping",
+                    futures[future].value,
+                    self.aggregate_timeout_seconds,
+                    media.title,
+                )
+            for future in done:
+                source = futures[future]
+                try:
+                    result = future.result()
+                except Exception:
+                    logger.exception(f"Error querying {source.value}")
+                    continue
+                if result and result.confidence >= 0.5:
+                    results[source] = result
+                    logger.debug(
+                        f"Got result from {source.value} for '{media.title}' "
+                        f"(confidence: {result.confidence:.2f})"
+                    )
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+
+        return results
+
     def _verify_by_doi(
         self,
         results: dict[EnrichmentSource, EnrichmentResult],
@@ -189,33 +243,28 @@ class AcademicEnricher:
         self,
         results: dict[EnrichmentSource, EnrichmentResult],
     ) -> dict[EnrichmentSource, EnrichmentResult]:
-        """Verify results by title similarity.
+        """Verify results by provider-reported title similarity.
 
-        Uses the fact that all results came from the same query,
-        so we check if titles are similar enough across sources.
+        Only ``result.metadata["title"]`` values are compared; results
+        without an explicit provider title cannot participate in title
+        verification. At least two title-bearing results are required,
+        otherwise an empty dict is returned so callers fall back to
+        single-source behavior.
 
         Args:
             results: Results from multiple sources.
 
         Returns:
-            Dict of sources with similar titles.
+            Dict of sources with similar titles, or empty if unverified.
         """
-        if len(results) < 2:
-            return results
-
-        # Get titles from metadata or descriptions
         titles: dict[EnrichmentSource, str] = {}
         for source, result in results.items():
             title = result.metadata.get("title")
-            if not title and result.description:
-                # Use first sentence of description as pseudo-title
-                title = result.description.split(".")[0][:100]
             if title:
                 titles[source] = self._normalize_title(str(title))
 
-        if not titles:
-            # All results came from same search, assume they match
-            return results
+        if len(titles) < 2:
+            return {}
 
         # Check pairwise title similarity
         sources = list(titles.keys())
@@ -252,12 +301,8 @@ class AcademicEnricher:
         Returns:
             Normalized DOI.
         """
-        doi = doi.lower().strip()
-        # Remove common prefixes
-        for prefix in ["https://doi.org/", "http://doi.org/", "doi:"]:
-            if doi.startswith(prefix):
-                doi = doi[len(prefix) :]
-        return doi
+        canonical: str = canonicalize_doi(doi)
+        return canonical.lower()
 
     def _normalize_title(self, title: str) -> str:
         """Normalize title for comparison.

--- a/backend/src/podex/services/enrichment/crossref.py
+++ b/backend/src/podex/services/enrichment/crossref.py
@@ -251,6 +251,11 @@ class CrossRefProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
 
         metadata: dict[str, Any] = {}
 
+        # Title (explicit contract for cross-source title verification)
+        titles = work.get("title", [])
+        if titles:
+            metadata["title"] = titles[0]
+
         # Authors
         authors = work.get("author", [])
         if authors:

--- a/backend/src/podex/services/enrichment/pubmed.py
+++ b/backend/src/podex/services/enrichment/pubmed.py
@@ -421,6 +421,10 @@ class PubMedProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
 
         metadata: dict[str, Any] = {}
 
+        # Title (explicit contract for cross-source title verification)
+        if article.get("title"):
+            metadata["title"] = article["title"]
+
         if article.get("authors"):
             metadata["authors"] = article["authors"]
         if article.get("journal"):

--- a/backend/src/podex/services/enrichment/semantic_scholar.py
+++ b/backend/src/podex/services/enrichment/semantic_scholar.py
@@ -254,6 +254,10 @@ class SemanticScholarProvider(EnrichmentProvider):  # type: ignore[misc, unused-
 
         metadata: dict[str, Any] = {}
 
+        # Title (explicit contract for cross-source title verification)
+        if paper.get("title"):
+            metadata["title"] = paper["title"]
+
         # Authors
         authors = paper.get("authors", [])
         if authors:

--- a/backend/src/podex/services/media_enrichment.py
+++ b/backend/src/podex/services/media_enrichment.py
@@ -58,6 +58,57 @@ PROVIDER_PRIORITY: dict[str, list[EnrichmentSource]] = {
     "place": [],  # Wikipedia only
 }
 
+# External-ID keys persisted to dedicated Media columns (string-valued).
+# ``tmdb_id`` is handled separately because its column is an integer.
+_EXTERNAL_ID_COLUMNS: frozenset[str] = frozenset(
+    {
+        "imdb_id",
+        "google_books_id",
+        "open_library_id",
+        "wikipedia_id",
+        "doi",
+        "pubmed_id",
+        "semantic_scholar_id",
+    },
+)
+
+
+def apply_external_ids(
+    *,
+    media: Media,
+    external_ids: dict[str, str | int],
+) -> None:
+    """Persist provider-emitted external IDs onto a media item.
+
+    Keys with dedicated columns (imdb_id, tmdb_id, google_books_id,
+    open_library_id, wikipedia_id, doi, pubmed_id, semantic_scholar_id)
+    are written to those columns only when the column is currently falsy.
+    Every remaining key (e.g. apple_podcasts_id, isbn_13, pmc_id, arxiv_id)
+    is preserved in ``media.metadata_json["external_ids"]`` as a str->str
+    map, merged without overwriting existing entries.
+
+    Args:
+        media: The media item to update in place.
+        external_ids: Provider-emitted external identifiers.
+    """
+    extra_ids: dict[str, str] = {}
+    for key, value in external_ids.items():
+        if key == "tmdb_id":
+            if not media.tmdb_id:
+                media.tmdb_id = int(value) if isinstance(value, (int, str)) else None
+        elif key in _EXTERNAL_ID_COLUMNS:
+            if not getattr(media, key):
+                setattr(media, key, str(value))
+        else:
+            extra_ids[key] = str(value)
+
+    if extra_ids:
+        metadata = dict(media.metadata_json or {})
+        existing_ids = dict(metadata.get("external_ids") or {})
+        metadata["external_ids"] = {**extra_ids, **existing_ids}
+        media.metadata_json = metadata
+
+
 # Types that should use Wikipedia as a fallback
 WIKIPEDIA_FALLBACK_TYPES = {
     "book",
@@ -242,24 +293,8 @@ class MediaEnricher:
         if result.description and not media.description:
             media.description = result.description
 
-        # Update external IDs
-        for key, value in result.external_ids.items():
-            if key == "imdb_id" and not media.imdb_id:
-                media.imdb_id = str(value)
-            elif key == "tmdb_id" and not media.tmdb_id:
-                media.tmdb_id = int(value) if isinstance(value, (int, str)) else None
-            elif key == "google_books_id" and not media.google_books_id:
-                media.google_books_id = str(value)
-            elif key == "open_library_id" and not media.open_library_id:
-                media.open_library_id = str(value)
-            elif key == "wikipedia_id" and not media.wikipedia_id:
-                media.wikipedia_id = str(value)
-            elif key == "doi" and not media.doi:
-                media.doi = str(value)
-            elif key == "pubmed_id" and not media.pubmed_id:
-                media.pubmed_id = str(value)
-            elif key == "semantic_scholar_id" and not media.semantic_scholar_id:
-                media.semantic_scholar_id = str(value)
+        # Update external IDs (columns plus metadata_json fallback)
+        apply_external_ids(media=media, external_ids=result.external_ids)
 
         # Merge metadata
         if result.metadata:
@@ -275,10 +310,13 @@ class MediaEnricher:
         media.enrichment_source = result.source.value
         media.enrichment_confidence = result.confidence
 
-        # Handle VerifiedEnrichmentResult fields
+        # Handle VerifiedEnrichmentResult fields; ordinary results still
+        # record their source so the pending-enrichment filter is satisfied.
         if isinstance(result, VerifiedEnrichmentResult):
             media.verification_sources = [s.value for s in result.verified_by]
             media.doi_verified = result.doi_verified
+        elif media.verification_sources is None:
+            media.verification_sources = [result.source.value]
 
     def enrich_and_apply(
         self,

--- a/backend/src/podex/services/media_enrichment_pipeline.py
+++ b/backend/src/podex/services/media_enrichment_pipeline.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from podex.models import Media, MediaAliasSourceType
 from podex.services.enrichment.base import EnrichmentResult, VerifiedEnrichmentResult
 from podex.services.media_alias_repository import ensure_media_alias
-from podex.services.media_enrichment import MediaEnricher
+from podex.services.media_enrichment import MediaEnricher, apply_external_ids
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,81 +60,91 @@ def enrich_pending_media(
     Returns:
         Batch enrichment summary.
     """
-    if enricher is None and loader is None:
+    owns_enricher = enricher is None and loader is None
+    if owns_enricher:
         enricher = MediaEnricher()
 
     effective_now = now or datetime.now(UTC)
-    media_items = (
-        db.query(Media)
-        .filter(
-            or_(
-                Media.enriched_at.is_(None),
-                Media.verification_sources.is_(None),
-            ),
-        )
-        .order_by(Media.created_at.asc(), Media.id.asc())
-        .limit(limit)
-        .all()
-    )
-    run_items: list[MediaEnrichmentRunItemData] = []
-
-    for media in media_items:
-        if loader is not None:
-            result = loader(media)
-        else:
-            if enricher is None:
-                raise RuntimeError("Media enricher was not configured")
-            result = enricher.enrich(media)
-        if result is None or result.confidence < min_confidence:
-            run_items.append(
-                MediaEnrichmentRunItemData(
-                    media_id=media.id,
-                    enriched=False,
-                    source=None,
-                    confidence=None,
-                    external_ids={},
-                    verification_sources=[],
-                )
+    try:
+        media_items = (
+            db.query(Media)
+            .filter(
+                or_(
+                    Media.enriched_at.is_(None),
+                    Media.verification_sources.is_(None),
+                ),
             )
-            continue
-
-        if enricher is not None:
-            enricher.apply_enrichment(media=media, result=result)
-        else:
-            _apply_enrichment_result(media=media, result=result, now=effective_now)
-
-        ensure_media_alias(
-            db=db,
-            media=media,
-            alias=media.title,
-            source=MediaAliasSourceType.ENRICHMENT,
-            is_primary=True,
+            .order_by(Media.created_at.asc(), Media.id.asc())
+            .limit(limit)
+            .all()
         )
-        for alias in _extract_enrichment_aliases(metadata=result.metadata):
+        run_items: list[MediaEnrichmentRunItemData] = []
+
+        for media in media_items:
+            if loader is not None:
+                result = loader(media)
+            else:
+                if enricher is None:
+                    raise RuntimeError("Media enricher was not configured")
+                result = enricher.enrich(media, min_confidence=min_confidence)
+            if result is None or result.confidence < min_confidence:
+                run_items.append(
+                    MediaEnrichmentRunItemData(
+                        media_id=media.id,
+                        enriched=False,
+                        source=None,
+                        confidence=None,
+                        external_ids={},
+                        verification_sources=[],
+                    )
+                )
+                continue
+
+            if enricher is not None:
+                enricher.apply_enrichment(media=media, result=result)
+                media.enriched_at = effective_now
+            else:
+                _apply_enrichment_result(
+                    media=media,
+                    result=result,
+                    now=effective_now,
+                )
+
             ensure_media_alias(
                 db=db,
                 media=media,
-                alias=alias,
+                alias=media.title,
                 source=MediaAliasSourceType.ENRICHMENT,
+                is_primary=True,
+            )
+            for alias in _extract_enrichment_aliases(metadata=result.metadata):
+                ensure_media_alias(
+                    db=db,
+                    media=media,
+                    alias=alias,
+                    source=MediaAliasSourceType.ENRICHMENT,
+                )
+
+            run_items.append(
+                MediaEnrichmentRunItemData(
+                    media_id=media.id,
+                    enriched=True,
+                    source=result.source.value,
+                    confidence=result.confidence,
+                    external_ids=result.external_ids,
+                    verification_sources=media.verification_sources or [],
+                )
             )
 
-        run_items.append(
-            MediaEnrichmentRunItemData(
-                media_id=media.id,
-                enriched=True,
-                source=result.source.value,
-                confidence=result.confidence,
-                external_ids=result.external_ids,
-                verification_sources=media.verification_sources or [],
-            )
+        db.flush()
+        return MediaEnrichmentRunData(
+            processed_count=len(run_items),
+            enriched_count=sum(1 for item in run_items if item.enriched),
+            items=run_items,
         )
-
-    db.flush()
-    return MediaEnrichmentRunData(
-        processed_count=len(run_items),
-        enriched_count=sum(1 for item in run_items if item.enriched),
-        items=run_items,
-    )
+    finally:
+        if owns_enricher and enricher is not None:
+            enricher.close()
 
 
 def _apply_enrichment_result(
@@ -149,23 +159,7 @@ def _apply_enrichment_result(
     if result.description and not media.description:
         media.description = result.description
 
-    for key, value in result.external_ids.items():
-        if key == "imdb_id" and not media.imdb_id:
-            media.imdb_id = str(value)
-        elif key == "tmdb_id" and not media.tmdb_id:
-            media.tmdb_id = int(value) if isinstance(value, (int, str)) else None
-        elif key == "google_books_id" and not media.google_books_id:
-            media.google_books_id = str(value)
-        elif key == "open_library_id" and not media.open_library_id:
-            media.open_library_id = str(value)
-        elif key == "wikipedia_id" and not media.wikipedia_id:
-            media.wikipedia_id = str(value)
-        elif key == "doi" and not media.doi:
-            media.doi = str(value)
-        elif key == "pubmed_id" and not media.pubmed_id:
-            media.pubmed_id = str(value)
-        elif key == "semantic_scholar_id" and not media.semantic_scholar_id:
-            media.semantic_scholar_id = str(value)
+    apply_external_ids(media=media, external_ids=result.external_ids)
 
     media.metadata_json = _merge_metadata(
         existing=media.metadata_json,

--- a/backend/tests/test_enrichment_provider_matrix.py
+++ b/backend/tests/test_enrichment_provider_matrix.py
@@ -358,6 +358,9 @@ def test_crossref_happy_path() -> None:
 
     if result is not None:
         assert_that(str(result.external_ids)).contains("10.1000")
+        assert_that(result.metadata["title"]).is_equal_to(
+            "Sleep and memory consolidation",
+        )
 
 
 def test_semantic_scholar_happy_path() -> None:
@@ -386,3 +389,6 @@ def test_semantic_scholar_happy_path() -> None:
 
     if result is not None:
         assert_that(result.has_useful_data()).is_true()
+        assert_that(result.metadata["title"]).is_equal_to(
+            "Sleep and memory consolidation",
+        )

--- a/backend/tests/test_media_enricher.py
+++ b/backend/tests/test_media_enricher.py
@@ -241,6 +241,9 @@ def test_pubmed_happy_path_via_esearch_and_efetch() -> None:
 
     if result is not None:
         assert_that(result.has_useful_data()).is_true()
+        assert_that(result.metadata["title"]).is_equal_to(
+            "Sleep and memory consolidation",
+        )
 
 
 def test_enricher_academic_path_and_apply() -> None:
@@ -313,6 +316,9 @@ def test_crossref_direct_doi_lookup() -> None:
 
     if result is not None:
         assert_that(result.confidence).is_greater_than(0.8)
+        assert_that(result.metadata["title"]).is_equal_to(
+            "Sleep and memory consolidation",
+        )
 
 
 def _swap_client_matrix(provider: Any, handler: Any) -> None:
@@ -436,6 +442,9 @@ def test_semantic_scholar_direct_paper_id() -> None:
     assert_that(result).is_not_none()
     if result is not None:
         assert_that(result.confidence).is_equal_to(1.0)
+        assert_that(result.metadata["title"]).is_equal_to(
+            "Sleep and memory consolidation",
+        )
 
 
 def test_pubmed_direct_pmid_fetch() -> None:
@@ -474,6 +483,7 @@ def test_pubmed_direct_pmid_fetch() -> None:
 
     if result is not None:
         assert_that(result.confidence).is_equal_to(1.0)
+        assert_that(result.metadata["title"]).is_equal_to("Direct fetch study")
 
 
 def test_apply_enrichment_fills_media_fields() -> None:
@@ -1840,3 +1850,269 @@ def test_provider_context_managers_close_clients() -> None:
         provider = factory()
         with provider:
             assert_that(provider).is_not_none()
+
+
+class _RaisingProvider:
+    """Provider double that always raises."""
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Raise unconditionally."""
+        del media
+        raise RuntimeError("provider exploded")
+
+    def close(self) -> None:
+        """No-op close."""
+
+
+class _SlowProvider:
+    """Provider double that sleeps past the aggregate deadline."""
+
+    def __init__(self, result: EnrichmentResult, delay: float) -> None:
+        self.result = result
+        self.delay = delay
+
+    def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
+        """Sleep, then return the canned result."""
+        import time
+
+        del media
+        time.sleep(self.delay)
+        return self.result
+
+    def close(self) -> None:
+        """No-op close."""
+
+
+def _academic_with(providers: dict[EnrichmentSource, Any], **kwargs: Any) -> Any:
+    """Build an AcademicEnricher whose providers are replaced by doubles."""
+    enricher = AcademicEnricher(**kwargs)
+    for provider in enricher.providers.values():
+        provider.close()
+    enricher.providers = providers
+    return enricher
+
+
+def test_academic_fanout_isolates_provider_failures() -> None:
+    """A raising provider does not prevent other results from aggregating."""
+    good = EnrichmentResult(
+        source=EnrichmentSource.CROSSREF,
+        description="A sleep study.",
+        external_ids={"doi": "10.1000/example.doi"},
+        metadata={"title": "Sleep study"},
+        confidence=0.9,
+    )
+    enricher = _academic_with(
+        {
+            EnrichmentSource.CROSSREF: _StubProvider(good),
+            EnrichmentSource.PUBMED: _RaisingProvider(),
+        },
+    )
+
+    result = enricher.enrich_with_verification(
+        _media("Sleep study", MediaType.STUDY),
+    )
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.verified_by).is_equal_to([EnrichmentSource.CROSSREF])
+
+
+def test_academic_fanout_drops_slow_provider() -> None:
+    """A provider sleeping past the aggregate deadline is dropped."""
+    fast = EnrichmentResult(
+        source=EnrichmentSource.CROSSREF,
+        description="A sleep study.",
+        external_ids={"doi": "10.1000/example.doi"},
+        metadata={"title": "Sleep study"},
+        confidence=0.9,
+    )
+    slow = EnrichmentResult(
+        source=EnrichmentSource.SEMANTIC_SCHOLAR,
+        description="A sleep study.",
+        external_ids={"doi": "10.1000/example.doi"},
+        metadata={"title": "Sleep study"},
+        confidence=0.95,
+    )
+    enricher = _academic_with(
+        {
+            EnrichmentSource.CROSSREF: _StubProvider(fast),
+            EnrichmentSource.SEMANTIC_SCHOLAR: _SlowProvider(slow, delay=1.0),
+        },
+        aggregate_timeout_seconds=0.1,
+    )
+
+    result = enricher.enrich_with_verification(
+        _media("Sleep study", MediaType.STUDY),
+    )
+
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.verified_by).is_equal_to([EnrichmentSource.CROSSREF])
+
+
+def test_academic_title_verification_requires_explicit_titles() -> None:
+    """Results lacking provider titles never verify by assumption."""
+    a = EnrichmentResult(
+        source=EnrichmentSource.CROSSREF,
+        description="A sleep study. With details.",
+        confidence=0.8,
+    )
+    b = EnrichmentResult(
+        source=EnrichmentSource.SEMANTIC_SCHOLAR,
+        description="A sleep study. With more details.",
+        confidence=0.75,
+    )
+    enricher = _academic_with(
+        {
+            EnrichmentSource.CROSSREF: _StubProvider(a),
+            EnrichmentSource.SEMANTIC_SCHOLAR: _StubProvider(b),
+        },
+    )
+
+    verified = enricher._verify_by_title(
+        {
+            EnrichmentSource.CROSSREF: a,
+            EnrichmentSource.SEMANTIC_SCHOLAR: b,
+        },
+    )
+    assert_that(verified).is_empty()
+
+    result = enricher.enrich_with_verification(
+        _media("Sleep study", MediaType.STUDY),
+    )
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(len(result.verified_by)).is_equal_to(1)
+
+
+def test_academic_title_verification_needs_two_title_bearers() -> None:
+    """A single title-bearing result cannot title-verify a pair."""
+    titled = EnrichmentResult(
+        source=EnrichmentSource.CROSSREF,
+        metadata={"title": "Sleep study"},
+        confidence=0.8,
+    )
+    untitled = EnrichmentResult(
+        source=EnrichmentSource.SEMANTIC_SCHOLAR,
+        description="A sleep study.",
+        confidence=0.75,
+    )
+    enricher = _academic_with({})
+
+    verified = enricher._verify_by_title(
+        {
+            EnrichmentSource.CROSSREF: titled,
+            EnrichmentSource.SEMANTIC_SCHOLAR: untitled,
+        },
+    )
+
+    assert_that(verified).is_empty()
+
+
+def test_apply_external_ids_maps_columns_and_metadata() -> None:
+    """Column-backed keys hit columns; other keys land in metadata_json."""
+    from podex.services.media_enrichment import apply_external_ids
+
+    media = _media("Dune", MediaType.BOOK)
+    apply_external_ids(
+        media=media,
+        external_ids={
+            "imdb_id": "tt1",
+            "tmdb_id": "7",
+            "apple_podcasts_id": "ap1",
+            "isbn_13": "9780000000000",
+        },
+    )
+
+    assert_that(media.imdb_id).is_equal_to("tt1")
+    assert_that(media.tmdb_id).is_equal_to(7)
+    assert_that(media.metadata_json).is_equal_to(
+        {
+            "external_ids": {
+                "apple_podcasts_id": "ap1",
+                "isbn_13": "9780000000000",
+            },
+        },
+    )
+
+
+def test_apply_external_ids_preserves_existing_values() -> None:
+    """Existing column and metadata values are never overwritten."""
+    from podex.services.media_enrichment import apply_external_ids
+
+    media = _media("Dune", MediaType.BOOK)
+    media.imdb_id = "tt-existing"
+    media.metadata_json = {
+        "keep": "me",
+        "external_ids": {"apple_podcasts_id": "ap-existing"},
+    }
+    apply_external_ids(
+        media=media,
+        external_ids={
+            "imdb_id": "tt-new",
+            "apple_podcasts_id": "ap-new",
+            "isbn_10": "1111111111",
+        },
+    )
+
+    assert_that(media.imdb_id).is_equal_to("tt-existing")
+    assert_that(media.metadata_json).is_equal_to(
+        {
+            "keep": "me",
+            "external_ids": {
+                "apple_podcasts_id": "ap-existing",
+                "isbn_10": "1111111111",
+            },
+        },
+    )
+
+
+def test_apply_enrichment_persists_extra_external_ids() -> None:
+    """apply_enrichment keeps unmapped identifiers in metadata_json."""
+    result = EnrichmentResult(
+        source=EnrichmentSource.ITUNES,
+        external_ids={"apple_podcasts_id": "ap1", "isbn_13": "978"},
+        metadata={"genre": "Technology"},
+        confidence=0.9,
+    )
+    enricher = _enricher_with({})
+    media = _media("Podcast", MediaType.PODCAST)
+    enricher.apply_enrichment(media, result)
+    enricher.close()
+
+    assert_that(media.metadata_json or {}).contains_key("external_ids")
+    assert_that((media.metadata_json or {})["external_ids"]).is_equal_to(
+        {"apple_podcasts_id": "ap1", "isbn_13": "978"},
+    )
+    assert_that((media.metadata_json or {})["genre"]).is_equal_to("Technology")
+
+
+def test_apply_enrichment_records_single_source_verification() -> None:
+    """Ordinary results record their source as verification provenance."""
+    result = EnrichmentResult(
+        source=EnrichmentSource.OPEN_LIBRARY,
+        external_ids={"open_library_id": "OL1W"},
+        confidence=0.9,
+    )
+    enricher = _enricher_with({})
+    media = _media("Dune", MediaType.BOOK)
+    enricher.apply_enrichment(media, result)
+    enricher.close()
+
+    assert_that(media.verification_sources).is_equal_to(["open_library"])
+
+
+def test_apply_enrichment_preserves_existing_verification_sources() -> None:
+    """An existing verification_sources value is never overwritten."""
+    result = EnrichmentResult(
+        source=EnrichmentSource.OPEN_LIBRARY,
+        external_ids={"open_library_id": "OL1W"},
+        confidence=0.9,
+    )
+    enricher = _enricher_with({})
+    media = _media("Dune", MediaType.BOOK)
+    media.verification_sources = ["manual"]
+    enricher.apply_enrichment(media, result)
+    enricher.close()
+
+    assert_that(media.verification_sources).is_equal_to(["manual"])

--- a/backend/tests/test_media_enrichment_pipeline.py
+++ b/backend/tests/test_media_enrichment_pipeline.py
@@ -1,15 +1,19 @@
 """Tests for media enrichment pipeline helpers."""
 
 from datetime import UTC, datetime
+from typing import cast
 
+import pytest
 from assertpy import assert_that
 from sqlalchemy.orm import Session
 
 from podex.models import Media, MediaAlias
 from podex.services.enrichment.base import (
+    EnrichmentResult,
     EnrichmentSource,
     VerifiedEnrichmentResult,
 )
+from podex.services.media_enrichment import MediaEnricher
 from podex.services.media_enrichment_pipeline import enrich_pending_media
 
 
@@ -81,3 +85,197 @@ def test_enrich_pending_media_skips_low_confidence_results(
     assert_that(result.processed_count).is_equal_to(1)
     assert_that(result.enriched_count).is_zero()
     assert_that(media.google_books_id).is_none()
+
+
+class _FakeEnricher:
+    """Enricher double recording calls and delegating apply logic."""
+
+    def __init__(self, result: EnrichmentResult | None) -> None:
+        self.result = result
+        self.close_calls = 0
+        self.seen_min_confidence: float | None = None
+
+    def enrich(
+        self,
+        media: Media,
+        min_confidence: float = 0.7,
+    ) -> EnrichmentResult | None:
+        """Record the threshold and return the canned result."""
+        del media
+        self.seen_min_confidence = min_confidence
+        return self.result
+
+    def apply_enrichment(self, media: Media, result: EnrichmentResult) -> None:
+        """Delegate to the real MediaEnricher application logic."""
+        MediaEnricher.apply_enrichment(
+            cast("MediaEnricher", self),
+            media,
+            result,
+        )
+
+    def close(self) -> None:
+        """Record closure."""
+        self.close_calls += 1
+
+
+def _ordinary_result(confidence: float = 0.9) -> EnrichmentResult:
+    """Build an ordinary (unverified) enrichment result."""
+    return EnrichmentResult(
+        source=EnrichmentSource.ITUNES,
+        description="A podcast.",
+        external_ids={"apple_podcasts_id": "ap1", "isbn_13": "978"},
+        metadata={"title": "Canonical Podcast"},
+        confidence=confidence,
+    )
+
+
+def test_enrich_pending_media_does_not_close_injected_enricher(
+    db_session: Session,
+) -> None:
+    """A caller-provided enricher is never closed by the pipeline."""
+    media = Media(type="podcast", title="Injected Podcast")
+    db_session.add(media)
+    db_session.flush()
+    fake = _FakeEnricher(_ordinary_result())
+
+    result = enrich_pending_media(
+        db=db_session,
+        enricher=cast("MediaEnricher", fake),
+    )
+
+    assert_that(result.enriched_count).is_equal_to(1)
+    assert_that(fake.close_calls).is_zero()
+
+
+def test_enrich_pending_media_closes_owned_enricher(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session: Session,
+) -> None:
+    """An internally created enricher is closed exactly once."""
+    media = Media(type="podcast", title="Owned Podcast")
+    db_session.add(media)
+    db_session.flush()
+    created: list[_FakeEnricher] = []
+
+    def _factory() -> _FakeEnricher:
+        fake = _FakeEnricher(None)
+        created.append(fake)
+        return fake
+
+    monkeypatch.setattr(
+        "podex.services.media_enrichment_pipeline.MediaEnricher",
+        _factory,
+    )
+
+    result = enrich_pending_media(db=db_session)
+
+    assert_that(result.enriched_count).is_zero()
+    assert_that(created).is_length(1)
+    assert_that(created[0].close_calls).is_equal_to(1)
+
+
+def test_enrich_pending_media_closes_owned_enricher_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session: Session,
+) -> None:
+    """The owned enricher is closed even when enrichment raises."""
+    media = Media(type="podcast", title="Raising Podcast")
+    db_session.add(media)
+    db_session.flush()
+
+    class _RaisingEnricher(_FakeEnricher):
+        def enrich(
+            self,
+            media: Media,
+            min_confidence: float = 0.7,
+        ) -> EnrichmentResult | None:
+            del media, min_confidence
+            raise RuntimeError("enrichment failed")
+
+    created: list[_FakeEnricher] = []
+
+    def _factory() -> _FakeEnricher:
+        fake = _RaisingEnricher(None)
+        created.append(fake)
+        return fake
+
+    monkeypatch.setattr(
+        "podex.services.media_enrichment_pipeline.MediaEnricher",
+        _factory,
+    )
+
+    with pytest.raises(RuntimeError, match="enrichment failed"):
+        enrich_pending_media(db=db_session)
+
+    assert_that(created).is_length(1)
+    assert_that(created[0].close_calls).is_equal_to(1)
+
+
+def test_enrich_pending_media_passes_min_confidence_and_now(
+    db_session: Session,
+) -> None:
+    """The enricher path honors min_confidence and the deterministic now."""
+    now = datetime(2026, 6, 1, 9, 30, tzinfo=UTC)
+    media = Media(type="podcast", title="Threshold Podcast")
+    db_session.add(media)
+    db_session.flush()
+    fake = _FakeEnricher(_ordinary_result(confidence=0.5))
+
+    result = enrich_pending_media(
+        db=db_session,
+        enricher=cast("MediaEnricher", fake),
+        min_confidence=0.4,
+        now=now,
+    )
+    db_session.commit()
+
+    assert_that(fake.seen_min_confidence).is_equal_to(0.4)
+    assert_that(result.enriched_count).is_equal_to(1)
+    assert_that(media.enriched_at).is_equal_to(now.replace(tzinfo=None))
+
+
+def test_enrich_pending_media_persists_extra_external_ids(
+    db_session: Session,
+) -> None:
+    """Unmapped provider identifiers survive both persistence paths."""
+    media = Media(type="podcast", title="Extra Ids Podcast")
+    db_session.add(media)
+    db_session.flush()
+
+    enrich_pending_media(
+        db=db_session,
+        loader=lambda item: _ordinary_result(),
+    )
+    db_session.commit()
+
+    assert_that(media.metadata_json or {}).contains_key("external_ids")
+    assert_that((media.metadata_json or {})["external_ids"]).is_equal_to(
+        {"apple_podcasts_id": "ap1", "isbn_13": "978"},
+    )
+
+
+def test_enrich_pending_media_second_run_processes_zero(
+    db_session: Session,
+) -> None:
+    """A successful enricher-path run leaves nothing pending."""
+    media = Media(type="podcast", title="Once Only Podcast")
+    db_session.add(media)
+    db_session.flush()
+    fake = _FakeEnricher(_ordinary_result())
+
+    first = enrich_pending_media(
+        db=db_session,
+        enricher=cast("MediaEnricher", fake),
+    )
+    db_session.commit()
+
+    assert_that(first.enriched_count).is_equal_to(1)
+    assert_that(media.enriched_at).is_not_none()
+    assert_that(media.verification_sources).is_equal_to(["itunes"])
+
+    def _unexpected(item: Media) -> EnrichmentResult | None:
+        raise AssertionError("no media should still be pending")
+
+    second = enrich_pending_media(db=db_session, loader=_unexpected)
+
+    assert_that(second.processed_count).is_zero()


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(enrichment): resolve post-merge review findings in the enrichment service layer`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Bundled post-merge review fixes across the enrichment service layer (`academic_enrichment.py`, `media_enrichment.py`, `media_enrichment_pipeline.py`), in one PR because the files overlap.

### #310 — concurrent academic provider fan-out

- `AcademicEnricher` now queries PubMed, Semantic Scholar, and CrossRef concurrently via a `ThreadPoolExecutor` in `_collect_provider_results`, with a bounded aggregate deadline (`aggregate_timeout_seconds` constructor kwarg, default `DEFAULT_AGGREGATE_TIMEOUT_SECONDS = 30.0`).
- Per-provider failures stay isolated: a raising provider is logged and skipped; a provider still running past the deadline is dropped with a warning. The `confidence >= 0.5` filter, `results[source]` shape, and downstream DOI/title verification are unchanged.
- `_normalize_doi` now reuses `canonicalize_doi` from `enrichment/base.py` (lowercased for comparison).

### #311 — explicit title-metadata contract

- CrossRef, PubMed, and Semantic Scholar `_build_result` now set `metadata["title"]` from the provider payload when present.
- `_verify_by_title` compares only `result.metadata["title"]`; the description-first-sentence fallback and the "no titles -> assume they match" branch are gone. Fewer than two title-bearing results returns `{}` so callers fall back to single-source behavior.

### #317 — close the internally created MediaEnricher

- `enrich_pending_media` records `owns_enricher` before the `MediaEnricher()` fallback, wraps the body in `try/finally`, and closes the enricher in `finally` only when it owns it. Caller-injected enrichers are never closed.

### #318 — honor `min_confidence` and `now` on the enricher path

- The enricher path now calls `enricher.enrich(media, min_confidence=min_confidence)` (the pipeline's own gate remains), and stamps `media.enriched_at = effective_now` after `apply_enrichment` so the enricher path matches the loader path's deterministic timestamp.

### #319 — persist every provider-emitted external ID

- New shared `apply_external_ids(*, media, external_ids)` helper in `media_enrichment.py`: known keys map to their columns (set only when falsy, `tmdb_id` int-coerced); every remaining key (`apple_podcasts_id`, `isbn_13`, `pmc_id`, `arxiv_id`, ...) is preserved in `media.metadata_json["external_ids"]`, merged without overwriting existing entries.
- Used from both `MediaEnricher.apply_enrichment` and the pipeline's `_apply_enrichment_result`, replacing both inline if/elif chains. (Per triage, only `MediaEnricher.apply_enrichment` lacked the fallback; the loader path gained it by unification.)

### #320 — record verification_sources for ordinary results

- `MediaEnricher.apply_enrichment` now sets `media.verification_sources = [result.source.value]` for ordinary `EnrichmentResult`s when it is `None`, matching the pipeline's `_apply_enrichment_result`, so enriched rows stop matching the pending filter and are not reprocessed forever. Existing non-null values are never overwritten.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Closes

- Closes #310
- Closes #311
- Closes #317
- Closes #318
- Closes #319
- Closes #320

## Details

- 15 new tests plus assertions added to existing provider happy-path tests (`test_media_enricher.py`, `test_media_enrichment_pipeline.py`, `test_enrichment_provider_matrix.py`): fan-out failure isolation and slow-provider drop, explicit-title verification, owned-enricher close (including on error), `min_confidence`/`now` plumbing, external-id persistence on both paths, and second-run-processes-zero reprocessing guard.
- Full backend suite: 451 passed, 1 skipped; coverage 87.21% (>= 85 gate).
- `uv run lintro fmt` / `chk`: clean on the diff; remaining failures are the known environmental noise (markdownlint on lintro's own run artifacts, local pip-audit ensurepip SIGABRT), present on the clean baseline too.
- All three commits are signed.