### PR TITLE
docs(adr): establish ADR practice — directory, template, and convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,57 @@
 # AGENTS.md
 
+## Architecture Decision Records
+
+Decisions with lasting architectural consequence require an ADR under
+`docs/adr/` in the same PR that implements them. Use
+`docs/adr/template.md`, update the index in `docs/adr/README.md`, and
+treat accepted ADRs as immutable (supersede instead of editing). Grilling
+sessions that settle design must leave an ADR, not only issue comments.
+See `CONTRIBUTING.md` for the full convention.
+
 ## Cursor Cloud specific instructions
 
 Podex is a monorepo with two apps that together form the product:
 
-- `backend/` — FastAPI + SQLAlchemy REST API (`/api/v2` + `/health`), managed with `uv`, SQLite by default.
-- `frontend/` — Astro/React/Tailwind SSR discovery site (port 4321), managed with `bun`, which fetches podcasts from the backend.
+- `backend/` — FastAPI + SQLAlchemy REST API (`/api/v2` + `/health`),
+  managed with `uv`, SQLite by default.
+- `frontend/` — Astro/React/Tailwind SSR discovery site (port 4321),
+  managed with `bun`, which fetches podcasts from the backend.
 
-Standard commands live in `CONTRIBUTING.md` and the manifests (`backend/pyproject.toml`, `frontend/package.json`); prefer those. Key ones: backend tests `uv run pytest`, backend lint `uv run lintro chk` / `uv run lintro fmt`, frontend tests `bun run test:run`, frontend type/build check `bun run check`.
+Standard commands live in `CONTRIBUTING.md` and the manifests
+(`backend/pyproject.toml`, `frontend/package.json`); prefer those. Key
+ones: backend tests `uv run pytest`, backend lint `uv run lintro chk` /
+`uv run lintro fmt`, frontend tests `bun run test:run`, frontend
+type/build check `bun run check`.
 
 Non-obvious caveats:
 
-- **Backend deps: run `uv sync` (not `uv sync --extra dev`).** `CONTRIBUTING.md` says `--extra dev`, but `dev` is a `[dependency-groups]` entry, not an optional extra, so `--extra dev` fails. `uv sync` installs the dev group by default.
-- **Run migrations before starting/using the API:** `cd backend && uv run alembic upgrade head`. `alembic.ini` has an empty `sqlalchemy.url`; `alembic/env.py` falls back to `PODEX_DATABASE_URL` (default `sqlite:///./podex.db`), so migrations and the app share the same DB file created in the `backend/` working dir. This is a one-shot setup step and is intentionally NOT in the automatic update script.
+- **Backend deps: run `uv sync` (not `uv sync --extra dev`).**
+  `CONTRIBUTING.md` says `--extra dev`, but `dev` is a
+  `[dependency-groups]` entry, not an optional extra, so `--extra dev`
+  fails. `uv sync` installs the dev group by default.
+- **Run migrations before starting/using the API:**
+  `cd backend && uv run alembic upgrade head`. `alembic.ini` has an
+  empty `sqlalchemy.url`; `alembic/env.py` falls back to
+  `PODEX_DATABASE_URL` (default `sqlite:///./podex.db`), so migrations
+  and the app share the same DB file created in the `backend/` working
+  dir. This is a one-shot setup step and is intentionally NOT in the
+  automatic update script.
 - **Run the servers from their app dirs:**
-  - Backend: `cd backend && uv run uvicorn podex.main:app --reload --port 8000`
-  - Frontend: `cd frontend && bun run dev` (serves on `http://localhost:4321`)
-- **Frontend → backend wiring:** the frontend calls `http://localhost:8000/api/v2` by default (override with `PUBLIC_API_URL`); backend CORS already allows `http://localhost:4321`. Start the backend before the frontend for data to load.
-- **The `/api/v2` surface is read-only (GET only).** There are no write endpoints yet; the LLM ingestion pipeline described in the README is not implemented. To get data into the catalog for local testing, seed rows directly via the ORM (e.g. `uv run python -c "..."` using `podex.database.SessionLocal` and `podex.models.Podcast`). An empty catalog renders "No podcasts yet." in the UI.
-- `uv` is installed at `~/.local/bin/uv` and `bun` at `~/.bun/bin/bun` (added to `~/.bashrc` at setup time).
+  - Backend:
+    `cd backend && uv run uvicorn podex.main:app --reload --port 8000`
+  - Frontend: `cd frontend && bun run dev`
+    (serves on `http://localhost:4321`)
+- **Frontend → backend wiring:** the frontend calls
+  `http://localhost:8000/api/v2` by default (override with
+  `PUBLIC_API_URL`); backend CORS already allows
+  `http://localhost:4321`. Start the backend before the frontend for
+  data to load.
+- **The `/api/v2` surface is read-only (GET only).** There are no write
+  endpoints yet; the LLM ingestion pipeline described in the README is
+  not implemented. To get data into the catalog for local testing, seed
+  rows directly via the ORM (e.g. `uv run python -c "..."` using
+  `podex.database.SessionLocal` and `podex.models.Podcast`). An empty
+  catalog renders "No podcasts yet." in the UI.
+- `uv` is installed at `~/.local/bin/uv` and `bun` at
+  `~/.bun/bin/bun` (added to `~/.bashrc` at setup time).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,12 @@
 ## Architecture Decision Records
 
 Decisions with lasting architectural consequence require an ADR under
-`docs/adr/` in the same PR that implements them. Use
-`docs/adr/template.md`, update the index in `docs/adr/README.md`, and
-treat accepted ADRs as immutable (supersede instead of editing). Grilling
-sessions that settle design must leave an ADR, not only issue comments.
-See `CONTRIBUTING.md` for the full convention.
+`docs/adr/`. Prefer the same PR that implements them; when the decision
+precedes code, a docs-only PR is fine. Use `docs/adr/template.md`, update
+the index in `docs/adr/README.md`, and treat accepted ADRs as immutable
+(supersede instead of editing). Grilling sessions that settle design must
+leave an ADR, not only issue comments. See `CONTRIBUTING.md` for the full
+convention.
 
 ## Cursor Cloud specific instructions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,9 @@ Do not invoke the underlying tools (ruff, black, mypy, eslint, etc.) directly.
 ## Architecture Decision Records
 
 Decisions with lasting architectural consequence get an
-[ADR](docs/adr/README.md) **in the same PR that implements them**.
-Grilling sessions that produce decisions also produce ADRs.
+[ADR](docs/adr/README.md). Prefer the **same PR that implements them**;
+when the decision precedes code, a docs-only PR is fine. Grilling
+sessions that produce decisions also produce ADRs.
 
 - Use `docs/adr/template.md` and add a row to `docs/adr/README.md`.
 - Accepted ADRs are immutable; supersede with a new ADR rather than

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,20 @@ Do not invoke the underlying tools (ruff, black, mypy, eslint, etc.) directly.
 - All required checks must pass before merge.
 - Address review feedback (human and automated) before requesting merge.
 
+## Architecture Decision Records
+
+Decisions with lasting architectural consequence get an
+[ADR](docs/adr/README.md) **in the same PR that implements them**.
+Grilling sessions that produce decisions also produce ADRs.
+
+- Use `docs/adr/template.md` and add a row to `docs/adr/README.md`.
+- Accepted ADRs are immutable; supersede with a new ADR rather than
+  editing the Decision.
+- Backfilled historical decisions use status `accepted (backfilled)`.
+
+Skip an ADR for routine refactors, bug fixes, or choices already fully
+covered by an accepted ADR.
+
 ## Reporting issues
 
 Open a [GitHub issue](https://github.com/lgtm-hq/podex/issues) using a

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,54 @@
+# Architecture Decision Records
+
+This directory records decisions with lasting architectural consequence
+for Podex. ADRs answer *why* the system is shaped the way it is; issues,
+PRs, and the changelog record *what* changed.
+
+## Index
+
+| Number | Title | Status | Date |
+| --- | --- | --- | --- |
+| 0001 | Nested settings cutover | proposed | — |
+| 0002 | Enrichment provider registry | proposed | — |
+
+Numbers **0001** and **0002** are reserved for the settings-migration
+and enrichment-registry epics. Their body files
+(`0001-nested-settings.md`, `0002-enrichment-provider-registry.md`)
+land with the owning implementation PRs; do not create placeholder
+bodies ahead of those PRs. Link the rows when the files land.
+
+## Format
+
+Use [template.md](./template.md). Fields:
+
+- **Title** — short, imperative or noun phrase (`NNNN-short-slug.md`).
+- **Status** — `proposed`, `accepted`, `superseded by NNNN`, or
+  `accepted (backfilled)` for historical decisions written after the
+  fact.
+- **Context** — the forces that made the decision necessary.
+- **Decision** — what we chose (and deliberately did not choose).
+- **Consequences** — trade-offs and follow-on constraints.
+
+## Lifecycle
+
+1. Draft an ADR as `proposed` in the same PR that implements the
+   decision (or in a docs-only PR when the decision precedes code).
+2. Mark it `accepted` when the implementing PR merges (or when the
+   owning change is already on `main` for a backfill).
+3. Never edit an accepted ADR's Decision. To change course, write a new
+   ADR that supersedes the old one and update the old Status line.
+
+## When to write an ADR
+
+Write an ADR when a choice:
+
+- Has lasting architectural consequence (shape of settings, provider
+  wiring, auth/billing vendors, storage contracts, schema conventions).
+- Is not obvious from the code alone, or is likely to be re-litigated.
+- Comes out of a grilling session that settles design.
+
+Do **not** ADR routine refactors, bug fixes, or choices already fully
+specified by an existing accepted ADR.
+
+See also the ADR-first convention in [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+and [`AGENTS.md`](../../AGENTS.md).

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,25 @@
+<!-- markdownlint-disable MD041 -->
+# NNNN. Title
+
+- Status: proposed | accepted | superseded by NNNN |
+  accepted (backfilled)
+- Date: YYYY-MM-DD
+- Deciders: (optional)
+- Tags: (optional)
+
+## Context
+
+What is the issue or force that requires a decision? Include enough
+background that a future reader can understand why the choice mattered
+without reconstructing issue threads.
+
+## Decision
+
+What did we decide, in one or two paragraphs? Be concrete about the
+chosen option and any deliberate non-choices.
+
+## Consequences
+
+What becomes easier, harder, or fixed by this decision? Call out
+follow-on work, constraints on future changes, and anything that would
+be expensive to reverse.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  docs(adr): establish ADR practice — directory, template, and convention
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Foundation for the ADR epic: add a lightweight MADR-style template and index under `docs/adr/`, reserve numbers 0001 (nested settings) and 0002 (enrichment provider registry) as proposed, and codify an ADR-first convention in `CONTRIBUTING.md` and `AGENTS.md`.

Docs-only; no code or test changes. Placeholder ADR body files for 0001/0002 are intentionally not created — they land with their owning implementation PRs.

Also includes the #351 curated backfill inventory as a PR comment (issue comments are not writable from this agent token).

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #350
- Relates to #351

## Details

- `docs/adr/template.md` — Title, Status (including `accepted (backfilled)`), Context, Decision, Consequences
- `docs/adr/README.md` — index table, lifecycle, when-to-write guidance; 0001/0002 reserved without body files
- Convention text: prefer same-PR ADRs; docs-only PR allowed when the decision precedes code; grilling sessions produce ADRs
- Wrapped long pre-existing `AGENTS.md` lines for markdownlint MD013

Verification: lintro clean; CI green; MERGEABLE / CLEAN.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for recording significant architectural decisions through Architecture Decision Records (ADRs).
  * Added an ADR directory guide, including lifecycle rules, numbering conventions, and required formatting.
  * Added a reusable ADR template covering context, decisions, and consequences.
  * Updated contributor guidance on when and how to create, update, or supersede ADRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->