### PR TITLE
refactor(config): nested settings foundation — DatabaseSettings + ADR 0001

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -6,12 +6,12 @@
 # Loaded into containers via env_file in docker-compose.staging.yml.
 
 # ── Database ─────────────────────────────────────────────────────────────────
-# POSTGRES_PASSWORD is read by the db service. PODEX_DATABASE_URL must use the
-# same password in the connection string (URL-encode reserved characters in the
-# password segment only):
+# POSTGRES_PASSWORD is read by the db service. PODEX_DATABASE__URL must use
+# the same password in the connection string (URL-encode reserved characters
+# in the password segment only):
 #   python -c "from urllib.parse import quote; print(quote('your-password', safe=''))"
 POSTGRES_PASSWORD=change-me-postgres-password
-PODEX_DATABASE_URL=postgresql://podex:change-me-postgres-password@db:5432/podex
+PODEX_DATABASE__URL=postgresql://podex:change-me-postgres-password@db:5432/podex
 
 # ── API (backend — PODEX_ prefix) ────────────────────────────────────────────
 PODEX_ENVIRONMENT=staging

--- a/.github/scripts/postgres-migration-replay.sh
+++ b/.github/scripts/postgres-migration-replay.sh
@@ -3,21 +3,21 @@
 # Postgres migration replay (#299)
 # -----------------------------------------------------------------------------
 # Replays the full Alembic migration chain against the CI Postgres service and
-# runs the migration test module as a smoke check. PODEX_DATABASE_URL must
+# runs the migration test module as a smoke check. PODEX_DATABASE__URL must
 # point at the Postgres service (alembic/env.py falls back to it when
 # alembic.ini leaves sqlalchemy.url empty).
 # =============================================================================
 set -euo pipefail
 
-if [[ -z "${PODEX_DATABASE_URL:-}" ]]; then
-  echo "PODEX_DATABASE_URL must be set to the Postgres service URL" >&2
+if [[ -z "${PODEX_DATABASE__URL:-}" ]]; then
+  echo "PODEX_DATABASE__URL must be set to the Postgres service URL" >&2
   exit 1
 fi
 
-case "${PODEX_DATABASE_URL}" in
+case "${PODEX_DATABASE__URL}" in
   postgresql*) ;;
   *)
-    echo "PODEX_DATABASE_URL must be a postgresql URL, got: ${PODEX_DATABASE_URL}" >&2
+    echo "PODEX_DATABASE__URL must be a postgresql URL, got: ${PODEX_DATABASE__URL}" >&2
     exit 1
     ;;
 esac

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -105,7 +105,7 @@ jobs:
           enable-cache: false
       - name: Replay migrations on Postgres
         env:
-          PODEX_DATABASE_URL: postgresql+psycopg://podex@localhost:5432/podex
+          PODEX_DATABASE__URL: postgresql+psycopg://podex@localhost:5432/podex
         run: bash .github/scripts/postgres-migration-replay.sh
 
   # Coverage publishing (#200 / epic #114): no separate coverage.yml calling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Non-obvious caveats:
 - **Run migrations before starting/using the API:**
   `cd backend && uv run alembic upgrade head`. `alembic.ini` has an
   empty `sqlalchemy.url`; `alembic/env.py` falls back to
-  `PODEX_DATABASE_URL` (default `sqlite:///./podex.db`), so migrations
+  `PODEX_DATABASE__URL` (default `sqlite:///./podex.db`), so migrations
   and the app share the same DB file created in the `backend/` working
   dir. This is a one-shot setup step and is intentionally NOT in the
   automatic update script.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -58,7 +58,7 @@ FROM python:3.14-slim-bookworm@sha256:86f975aca15cf04a40b399eebede9aea7c82eae084
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PATH="/app/.venv/bin:${PATH}" \
-    PODEX_DATABASE_URL="sqlite:///./podex.db"
+    PODEX_DATABASE__URL="sqlite:///./podex.db"
 
 # Non-root system user for the app. `--no-log-init` avoids a 32 GiB sparse
 # lastlog file on some base images (well-documented useradd quirk).

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -14,7 +14,7 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 if not config.get_main_option("sqlalchemy.url"):
-    config.set_main_option("sqlalchemy.url", get_settings().database_url)
+    config.set_main_option("sqlalchemy.url", get_settings().database.url)
 
 target_metadata = Base.metadata
 

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -3,8 +3,30 @@
 from functools import lru_cache
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class DatabaseSettings(BaseModel):
+    """Database URL and connection-pool tuning.
+
+    Nested under ``settings.database``. Environment grammar:
+    ``PODEX_DATABASE__URL``, ``PODEX_DATABASE__POOL_SIZE``, etc.
+    Flat names such as ``PODEX_DATABASE_URL`` are not recognized.
+    """
+
+    url: str = "sqlite:///./podex.db"
+
+    # Connection pooling for server-backed databases (Railway + Neon).
+    # Applied only when ``url`` is not SQLite; the local SQLite default
+    # keeps SQLAlchemy's stock pooling untouched. Defaults are sized for
+    # a small Railway service talking to Neon's pooled endpoint: a modest
+    # steady pool with equal burst headroom, recycled well inside typical
+    # idle-connection cutoffs, and pre-ping so suspended/rotated backends
+    # are detected instead of surfacing stale-connection errors.
+    pool_size: int = Field(default=5, ge=1)
+    max_overflow: int = Field(default=5, ge=0)
+    pool_recycle_seconds: int = Field(default=300, ge=1)
 
 
 class Settings(BaseSettings):
@@ -12,6 +34,7 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="PODEX_",
+        env_nested_delimiter="__",
         env_file=".env",
         extra="ignore",
     )
@@ -22,18 +45,7 @@ class Settings(BaseSettings):
     api_v2_prefix: str = "/api/v2"
     cors_origins: list[str] = ["http://localhost:4321"]
     public_web_url: str = "http://localhost:4321"
-    database_url: str = "sqlite:///./podex.db"
-
-    # Connection pooling for server-backed databases (Railway + Neon).
-    # Applied only when ``database_url`` is not SQLite; the local SQLite
-    # default keeps SQLAlchemy's stock pooling untouched. Defaults are sized
-    # for a small Railway service talking to Neon's pooled endpoint: a modest
-    # steady pool with equal burst headroom, recycled well inside typical
-    # idle-connection cutoffs, and pre-ping so suspended/rotated backends are
-    # detected instead of surfacing stale-connection errors.
-    database_pool_size: int = Field(default=5, ge=1)
-    database_max_overflow: int = Field(default=5, ge=0)
-    database_pool_recycle_seconds: int = Field(default=300, ge=1)
+    database: DatabaseSettings = Field(default_factory=DatabaseSettings)
 
     # Rate limiting. Defaults are deliberately generous so ordinary traffic
     # (and the test suite) never trips the limiter; tests inject tight values.

--- a/backend/src/podex/database.py
+++ b/backend/src/podex/database.py
@@ -19,19 +19,19 @@ def build_engine_kwargs(settings: Settings) -> dict[str, Any]:
     and idle connections are recycled.
 
     Args:
-        settings: Application settings providing the database URL and pool
-            tuning values.
+        settings: Application settings providing ``settings.database`` URL
+            and pool tuning values.
 
     Returns:
         Keyword arguments to splat into :func:`sqlalchemy.create_engine`.
     """
-    if settings.database_url.startswith("sqlite"):
+    if settings.database.url.startswith("sqlite"):
         return {"connect_args": {"check_same_thread": False}}
     return {
         "pool_pre_ping": True,
-        "pool_size": settings.database_pool_size,
-        "max_overflow": settings.database_max_overflow,
-        "pool_recycle": settings.database_pool_recycle_seconds,
+        "pool_size": settings.database.pool_size,
+        "max_overflow": settings.database.max_overflow,
+        "pool_recycle": settings.database.pool_recycle_seconds,
     }
 
 
@@ -56,7 +56,7 @@ def enable_sqlite_foreign_keys(target_engine: Engine) -> None:
 
 _settings = get_settings()
 
-engine = create_engine(_settings.database_url, **build_engine_kwargs(_settings))
+engine = create_engine(_settings.database.url, **build_engine_kwargs(_settings))
 enable_sqlite_foreign_keys(engine)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -5,8 +5,9 @@ import math
 import pytest
 from assertpy import assert_that
 from pydantic import ValidationError
+from pytest import MonkeyPatch
 
-from podex.config import Settings, get_settings
+from podex.config import DatabaseSettings, Settings, get_settings
 
 
 def test_default_settings() -> None:
@@ -16,6 +17,38 @@ def test_default_settings() -> None:
     assert_that(settings.app_name).is_equal_to("podex")
     assert_that(settings.api_v2_prefix).is_equal_to("/api/v2")
     assert_that(settings.debug).is_false()
+    assert_that(settings.database.url).is_equal_to("sqlite:///./podex.db")
+
+
+def test_database_settings_load_from_nested_env(monkeypatch: MonkeyPatch) -> None:
+    """Nested ``PODEX_DATABASE__*`` env vars populate ``settings.database``."""
+    monkeypatch.setenv(
+        "PODEX_DATABASE__URL",
+        "postgresql+psycopg://podex:podex@db.example.internal/podex",
+    )
+    monkeypatch.setenv("PODEX_DATABASE__POOL_SIZE", "11")
+    monkeypatch.setenv("PODEX_DATABASE__MAX_OVERFLOW", "4")
+    monkeypatch.setenv("PODEX_DATABASE__POOL_RECYCLE_SECONDS", "180")
+
+    settings = Settings()
+
+    assert_that(settings.database.url).is_equal_to(
+        "postgresql+psycopg://podex:podex@db.example.internal/podex",
+    )
+    assert_that(settings.database.pool_size).is_equal_to(11)
+    assert_that(settings.database.max_overflow).is_equal_to(4)
+    assert_that(settings.database.pool_recycle_seconds).is_equal_to(180)
+
+
+def test_flat_database_env_name_is_ignored(monkeypatch: MonkeyPatch) -> None:
+    """Old flat ``PODEX_DATABASE_URL`` is ignored after the nested cutover."""
+    monkeypatch.setenv("PODEX_DATABASE_URL", "sqlite:///./flat-ignored.db")
+    monkeypatch.delenv("PODEX_DATABASE__URL", raising=False)
+
+    settings = Settings()
+
+    assert_that(settings.database.url).is_equal_to("sqlite:///./podex.db")
+    assert_that(settings.database).is_instance_of(DatabaseSettings)
 
 
 def test_rate_limit_defaults_are_generous() -> None:

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -2,13 +2,13 @@
 
 from assertpy import assert_that
 
-from podex.config import Settings
+from podex.config import DatabaseSettings, Settings
 from podex.database import build_engine_kwargs
 
 
 def test_sqlite_engine_kwargs_keep_thread_connect_args() -> None:
     """SQLite URLs keep ``check_same_thread=False`` and no pool tuning."""
-    settings = Settings(database_url="sqlite:///./podex.db")
+    settings = Settings(database=DatabaseSettings(url="sqlite:///./podex.db"))
 
     kwargs = build_engine_kwargs(settings)
 
@@ -20,10 +20,12 @@ def test_sqlite_engine_kwargs_keep_thread_connect_args() -> None:
 def test_postgres_engine_kwargs_enable_pooling() -> None:
     """Server-backed URLs get pre-ping plus settings-driven pool sizing."""
     settings = Settings(
-        database_url="postgresql+psycopg://podex:podex@db.example.internal/podex",
-        database_pool_size=7,
-        database_max_overflow=3,
-        database_pool_recycle_seconds=120,
+        database=DatabaseSettings(
+            url="postgresql+psycopg://podex:podex@db.example.internal/podex",
+            pool_size=7,
+            max_overflow=3,
+            pool_recycle_seconds=120,
+        ),
     )
 
     kwargs = build_engine_kwargs(settings)
@@ -42,6 +44,6 @@ def test_pool_defaults_are_sized_for_managed_postgres() -> None:
     """Default pool tuning matches the Railway + Neon deployment contract."""
     settings = Settings()
 
-    assert_that(settings.database_pool_size).is_equal_to(5)
-    assert_that(settings.database_max_overflow).is_equal_to(5)
-    assert_that(settings.database_pool_recycle_seconds).is_equal_to(300)
+    assert_that(settings.database.pool_size).is_equal_to(5)
+    assert_that(settings.database.max_overflow).is_equal_to(5)
+    assert_that(settings.database.pool_recycle_seconds).is_equal_to(300)

--- a/docs/adr/0001-nested-settings-models.md
+++ b/docs/adr/0001-nested-settings-models.md
@@ -1,0 +1,53 @@
+<!-- markdownlint-disable MD041 -->
+# 0001. Nested settings models with hard cutover
+
+- Status: accepted
+- Date: 2026-07-20
+- Tags: config, pydantic-settings, deployment
+
+## Context
+
+`Settings` in `backend/src/podex/config.py` was a single flat
+pydantic-settings class (~40 fields under the `PODEX_` prefix). Domain
+groups (database, auth, billing, transcripts, rate limiting, …) shared one
+namespace, so related knobs were hard to pass as a typed unit and easy to
+mis-name in deployment templates.
+
+A grilling session on the enrichment provider registry (#349) settled that
+nested sub-models are the better long-term shape. Podex still has no
+production users, so this is the cheapest moment for a **hard cutover**:
+change the env grammar once, update every consumer in the same release,
+and refuse aliases that would freeze the flat names forever.
+
+## Decision
+
+1. Enable `env_nested_delimiter="__"` on `Settings` while keeping
+   `env_prefix="PODEX_"`. Nested fields use
+   `PODEX_<DOMAIN>__<FIELD>` (for example `PODEX_DATABASE__URL`).
+2. One pydantic `BaseModel` sub-model per domain, attached as a field on
+   `Settings` (for example `settings.database: DatabaseSettings`).
+   App-level basics (`app_name`, `environment`, `debug`, `cors_origins`,
+   `public_web_url`, `api_v2_prefix`, …) stay top-level.
+3. **No aliases.** Flat names for a migrated domain stop working in the
+   same PR that nests that domain. `extra="ignore"` continues to drop
+   unknown env keys rather than mapping them.
+4. Migrate domains one PR at a time after this foundation; the database
+   domain is the exemplar that proves the grammar end-to-end.
+
+Deliberate non-choices: keeping `Field(validation_alias=…)` bridges for
+old flat names; dual-read periods; optional-extra aliases in
+podex-ops templates.
+
+## Consequences
+
+- Call sites can pass `settings.database` (and later peer sub-models) as
+  one typed object; sub-models are reusable in tests via
+  `DatabaseSettings(...)`.
+- Every deployment template that sets a migrated domain must switch to
+  the nested grammar **before** provisioning gates run. Sync
+  lgtm-hq/podex-ops#15 (and any Railway/Neon env sheets) ahead of the
+  next cloud cutover — this repo does not provision cloud resources.
+- Sibling domain migrations (rate limit, stats cache, transcripts/R2,
+  auth, billing, observability) follow the same hard-cutover rule.
+- Operators who still export `PODEX_DATABASE_URL` will silently fall back
+  to the SQLite default until they rename to `PODEX_DATABASE__URL`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,14 +8,13 @@ PRs, and the changelog record *what* changed.
 
 | Number | Title | Status | Date |
 | --- | --- | --- | --- |
-| 0001 | Nested settings cutover | proposed | — |
+| [0001](./0001-nested-settings-models.md) | Nested settings models with hard cutover | accepted | 2026-07-20 |
 | 0002 | Enrichment provider registry | proposed | — |
 
-Numbers **0001** and **0002** are reserved for the settings-migration
-and enrichment-registry epics. Their body files
-(`0001-nested-settings.md`, `0002-enrichment-provider-registry.md`)
-land with the owning implementation PRs; do not create placeholder
-bodies ahead of those PRs. Link the rows when the files land.
+Number **0002** is reserved for the enrichment-registry epic
+(`0002-enrichment-provider-registry.md`). Its body file lands with the
+owning implementation PR; do not create a placeholder body ahead of that
+PR. Link the row when the file lands.
 
 ## Format
 

--- a/docs/staging-deployment.md
+++ b/docs/staging-deployment.md
@@ -26,7 +26,7 @@ the stack will not start without `.env.staging`).
 | Variable | Read by | Purpose |
 | --- | --- | --- |
 | `POSTGRES_PASSWORD` | `db` | Postgres password |
-| `PODEX_DATABASE_URL` | `api` (Alembic + runtime) | SQLAlchemy connection string |
+| `PODEX_DATABASE__URL` | `api` (Alembic + runtime) | SQLAlchemy connection string |
 | `PODEX_ENVIRONMENT` | `api` | Runtime environment label |
 | `PODEX_CORS_ORIGINS` | `api` | Allowed browser origins (JSON list) |
 | `API_PORT` / `FRONTEND_PORT` | compose | Host ports published for `api` / `frontend` |
@@ -37,10 +37,10 @@ the stack will not start without `.env.staging`).
 
 ### Database credentials
 
-Set both `POSTGRES_PASSWORD` and `PODEX_DATABASE_URL` in `.env.staging`. The
+Set both `POSTGRES_PASSWORD` and `PODEX_DATABASE__URL` in `.env.staging`. The
 password in the URL must match `POSTGRES_PASSWORD`. If the password contains
 URI-reserved characters (`@`, `:`, `/`, `?`, `#`, etc.), URL-encode only the
-password segment of `PODEX_DATABASE_URL`:
+password segment of `PODEX_DATABASE__URL`:
 
 ```bash
 python -c "from urllib.parse import quote; print(quote('your-password', safe=''))"
@@ -50,7 +50,7 @@ Example:
 
 ```bash
 POSTGRES_PASSWORD='p@ss:word'
-PODEX_DATABASE_URL=postgresql://podex:p%40ss%3Aword@db:5432/podex
+PODEX_DATABASE__URL=postgresql://podex:p%40ss%3Aword@db:5432/podex
 ```
 
 ### Host ports and CORS
@@ -91,7 +91,7 @@ docker compose -f docker-compose.staging.yml --env-file .env.staging \
   run --rm api alembic upgrade head
 ```
 
-Alembic reads `PODEX_DATABASE_URL` via `backend/src/podex/config.py`.
+Alembic reads `PODEX_DATABASE__URL` via `backend/src/podex/config.py`.
 
 ## 4. Verify
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(config): nested settings foundation — DatabaseSettings + ADR 0001
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [x] `!` in title or `BREAKING CHANGE:` footer included

BREAKING CHANGE: Database env knobs move to nested grammar
`PODEX_DATABASE__URL` / `PODEX_DATABASE__POOL_SIZE` /
`PODEX_DATABASE__MAX_OVERFLOW` / `PODEX_DATABASE__POOL_RECYCLE_SECONDS`.
Flat `PODEX_DATABASE_URL` and `PODEX_DATABASE_POOL_*` names are ignored.

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Foundation of the nested-settings epic (#362):

- `Settings.model_config` gains `env_nested_delimiter="__"` (prefix stays `PODEX_`).
- Exemplar domain: `DatabaseSettings` as `settings.database` with fields `url`,
  `pool_size`, `max_overflow`, `pool_recycle_seconds` (pooling rationale + Field
  validators preserved). Hard cutover — no aliases.
- Engine construction, Alembic, Postgres-replay CI, Dockerfile, staging env
  example, and docs updated to `PODEX_DATABASE__*`.
- ADR 0001 records the hard-cutover decision and the podex-ops sync consequence
  (lgtm-hq/podex-ops#15 before provisioning).

`AUTO_MIGRATE` remains a non-`PODEX_` shell entrypoint flag (from #330); it was
never a Settings field and is out of scope for this nesting.

#360 is absorbed — database was chosen as the exemplar, so that sibling issue
should close with this PR.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #353
- Closes #360

## Details

Tests added:

- Nested env mapping populates `settings.database`
- Flat `PODEX_DATABASE_URL` is ignored (proves the break)

Local verification: `uv run lintro chk` on touched paths clean; full
`uv run pytest` → 481 passed, 1 skipped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

