### PR TITLE
refactor(config)!: nest rate_limit through observability settings domains

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -31,8 +31,8 @@ PUBLIC_API_URL=http://api:8000/api/v2
 # ── Transcript storage (encrypted S3) — not used on main yet ─────────────────
 # Generate the Fernet key with:
 #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-TRANSCRIPT_ARTIFACT_ENCRYPTION_KEY=change-me-fernet-key
-TRANSCRIPT_ARTIFACT_S3_BUCKET=change-me-private-transcript-bucket
+PODEX_TRANSCRIPTS__ENCRYPTION_KEY=change-me-fernet-key
+PODEX_TRANSCRIPTS__S3_BUCKET=change-me-private-transcript-bucket
 
 # ── Search — not used on main yet ─────────────────────────────────────────────
 MEILI_MASTER_KEY=change-me-meilisearch-master-key
@@ -41,6 +41,7 @@ MEILI_MASTER_KEY=change-me-meilisearch-master-key
 API_KEY=change-me-podex-api-key
 
 # ── Email (magic-link auth) — not used on main yet ───────────────────────────
-SMTP_HOST=change-me-smtp-host
-SMTP_USERNAME=change-me-smtp-user
-SMTP_PASSWORD=change-me-smtp-password
+PODEX_AUTH__SMTP_HOST=change-me-smtp-host
+PODEX_AUTH__SMTP_USERNAME=change-me-smtp-user
+PODEX_AUTH__SMTP_PASSWORD=change-me-smtp-password
+# PODEX_AUTH__SMTP_FROM_EMAIL=signin@example.com

--- a/backend/src/podex/api/v2/auth.py
+++ b/backend/src/podex/api/v2/auth.py
@@ -158,7 +158,7 @@ def _require_authenticated_account(
     """Resolve the authenticated account or reject the request."""
     user = get_authenticated_user(
         db=db,
-        session_token=request.cookies.get(settings.auth_session_cookie_name),
+        session_token=request.cookies.get(settings.auth.session_cookie_name),
     )
     if user is None:
         raise HTTPException(
@@ -176,11 +176,11 @@ def _set_session_cookie(
 ) -> None:
     """Set the secure, http-only account session cookie."""
     response.set_cookie(
-        key=settings.auth_session_cookie_name,
+        key=settings.auth.session_cookie_name,
         value=token,
-        max_age=settings.auth_session_ttl_days * 24 * 60 * 60,
+        max_age=settings.auth.session_ttl_days * 24 * 60 * 60,
         path="/",
-        secure=settings.auth_session_cookie_secure,
+        secure=settings.auth.session_cookie_secure,
         httponly=True,
         samesite="lax",
     )
@@ -233,7 +233,7 @@ def request_auth_magic_link(
         db=db,
         email=payload.email,
         redirect_path=payload.redirect_path,
-        ttl_minutes=settings.auth_magic_link_ttl_minutes,
+        ttl_minutes=settings.auth.magic_link_ttl_minutes,
     )
     # The token travels in the URL fragment, which browsers never send in
     # Referer headers or request lines, so it stays out of proxy and access
@@ -270,7 +270,7 @@ def verify_auth_magic_link(
     authenticated = authenticate_magic_link(
         db=db,
         token=payload.token,
-        session_ttl_days=settings.auth_session_ttl_days,
+        session_ttl_days=settings.auth.session_ttl_days,
     )
     if authenticated is None:
         raise HTTPException(
@@ -309,7 +309,7 @@ def begin_workos_login(
         value=state,
         max_age=_WORKOS_STATE_TTL_SECONDS,
         path="/",
-        secure=settings.auth_session_cookie_secure,
+        secure=settings.auth.session_cookie_secure,
         httponly=True,
         samesite="lax",
     )
@@ -348,7 +348,7 @@ def complete_workos_callback(
     authenticated = issue_user_session(
         db=db,
         user=user,
-        session_ttl_days=settings.auth_session_ttl_days,
+        session_ttl_days=settings.auth.session_ttl_days,
     )
     redirect = RedirectResponse(
         url=f"{settings.public_web_url.rstrip('/')}/account",
@@ -373,9 +373,9 @@ def logout_account_session(
     """Revoke the current account session and expire its browser cookie."""
     signed_out = revoke_user_session(
         db=db,
-        session_token=request.cookies.get(settings.auth_session_cookie_name),
+        session_token=request.cookies.get(settings.auth.session_cookie_name),
     )
-    response.delete_cookie(key=settings.auth_session_cookie_name, path="/")
+    response.delete_cookie(key=settings.auth.session_cookie_name, path="/")
     db.commit()
     return AuthLogoutResponse(signed_out=signed_out)
 
@@ -700,7 +700,7 @@ def delete_current_account(
             "digests": result.digests,
         },
     )
-    response.delete_cookie(key=settings.auth_session_cookie_name, path="/")
+    response.delete_cookie(key=settings.auth.session_cookie_name, path="/")
     db.commit()
     return AuthLogoutResponse(signed_out=True)
 
@@ -721,7 +721,7 @@ def get_current_account_subscription(
     return SubscriptionRead(
         tier=subscription.tier,
         status=subscription.status,
-        paid_features_enforced=settings.paid_tier_enforced,
+        paid_features_enforced=settings.billing.paid_tier_enforced,
         current_period_ends_at=subscription.current_period_ends_at,
         quotas=[
             QuotaRead(
@@ -744,7 +744,7 @@ def begin_current_account_checkout(
 ) -> SubscriptionCheckoutRead:
     """Start provider-hosted paid-tier checkout once launch gates are enabled."""
     user = _require_authenticated_account(request=request, db=db, settings=settings)
-    if not settings.paid_tier_enabled:
+    if not settings.billing.paid_tier_enabled:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Paid upgrades are not available until launch review is complete",

--- a/backend/src/podex/api/v2/billing.py
+++ b/backend/src/podex/api/v2/billing.py
@@ -66,7 +66,7 @@ async def receive_paddle_webhook(
     settings: AppSettings,
 ) -> BillingWebhookAck:
     """Verify, dedupe, and apply one signed Paddle webhook delivery."""
-    if not settings.paddle_webhook_secret:
+    if not settings.billing.paddle_webhook_secret:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Paddle webhooks are not configured",
@@ -82,7 +82,7 @@ async def receive_paddle_webhook(
         verify_paddle_signature(
             signature_header=signature_header,
             raw_body=raw_body,
-            secret=settings.paddle_webhook_secret,
+            secret=settings.billing.paddle_webhook_secret,
         )
     except PaddleSignatureFormatError as exc:
         raise HTTPException(

--- a/backend/src/podex/api/v2/router.py
+++ b/backend/src/podex/api/v2/router.py
@@ -20,7 +20,7 @@ api_v2_router = APIRouter(tags=["v2"])
 
 def read_status(settings: AppSettings) -> ApiStatusRead:
     """Report that the v2 API surface is reachable and how sign-in works."""
-    return ApiStatusRead(workos_enabled=settings.workos_enabled)
+    return ApiStatusRead(workos_enabled=settings.auth.workos_enabled)
 
 
 api_v2_router.add_api_route(

--- a/backend/src/podex/api/v2/stats.py
+++ b/backend/src/podex/api/v2/stats.py
@@ -23,14 +23,14 @@ def get_catalog_stats(
     """Return catalog-wide counts and a small top-media-types breakdown.
 
     Responses are cached in-process for
-    ``PODEX_STATS_CACHE_TTL_SECONDS`` seconds (configurable via
+    ``PODEX_STATS_CACHE__TTL_SECONDS`` seconds (configurable via
     :class:`~podex.config.Settings`); set the TTL to ``0`` to bypass the
     cache entirely.
     """
     return stats_queries.get_catalog_stats(
         db,
         cache=cache,
-        ttl_seconds=settings.stats_cache_ttl_seconds,
+        ttl_seconds=settings.stats_cache.ttl_seconds,
     )
 
 

--- a/backend/src/podex/config.py
+++ b/backend/src/podex/config.py
@@ -29,65 +29,79 @@ class DatabaseSettings(BaseModel):
     pool_recycle_seconds: int = Field(default=300, ge=1)
 
 
-class Settings(BaseSettings):
-    """Runtime settings, overridable via ``PODEX_`` environment variables."""
+class RateLimitSettings(BaseModel):
+    """HTTP rate limiting and Redis store selection.
 
-    model_config = SettingsConfigDict(
-        env_prefix="PODEX_",
-        env_nested_delimiter="__",
-        env_file=".env",
-        extra="ignore",
-    )
+    Nested under ``settings.rate_limit``. Environment grammar:
+    ``PODEX_RATE_LIMIT__ENABLED``, ``PODEX_RATE_LIMIT__REDIS_URL``, etc.
+    """
 
-    app_name: str = "podex"
-    environment: str = "development"
-    debug: bool = False
-    api_v2_prefix: str = "/api/v2"
-    cors_origins: list[str] = ["http://localhost:4321"]
-    public_web_url: str = "http://localhost:4321"
-    database: DatabaseSettings = Field(default_factory=DatabaseSettings)
+    # Defaults are deliberately generous so ordinary traffic (and the test
+    # suite) never trips the limiter; tests inject tight values. When
+    # ``redis_url`` is unset the limiter runs process-locally; setting it
+    # (e.g. ``redis://redis:6379/0``) switches to a shared Redis store so
+    # limits hold across workers/instances.
+    enabled: bool = True
+    max_requests: int = 120
+    window_seconds: float = 60.0
+    exempt_paths: list[str] = ["/health"]
+    redis_url: str = ""
+    redis_prefix: str = "podex:ratelimit"
 
-    # Rate limiting. Defaults are deliberately generous so ordinary traffic
-    # (and the test suite) never trips the limiter; tests inject tight values.
-    # When ``rate_limit_redis_url`` is unset the limiter runs process-locally;
-    # setting it (e.g. ``redis://redis:6379/0``) switches to a shared Redis
-    # store so limits hold across workers/instances.
-    rate_limit_enabled: bool = True
-    rate_limit_max_requests: int = 120
-    rate_limit_window_seconds: float = 60.0
-    rate_limit_exempt_paths: list[str] = ["/health"]
-    rate_limit_redis_url: str = ""
-    rate_limit_redis_prefix: str = "podex:ratelimit"
 
-    # Aggregate/stats caching. Short TTL because we currently have no
-    # write-time invalidation hooks (see ``services/stats_queries.py``);
-    # setting the TTL to ``0`` disables caching entirely. ``allow_inf_nan``
-    # rejects ``NaN`` (which would silently bypass caching after mypy-safe
-    # comparisons) and ``inf`` (which would keep entries alive forever); the
-    # ``ge=0`` bound catches negative overrides at startup instead of allowing
-    # a misconfigured value to disable caching in a surprising way.
-    stats_cache_ttl_seconds: float = Field(default=30.0, ge=0, allow_inf_nan=False)
+class StatsCacheSettings(BaseModel):
+    """Aggregate/stats response caching.
 
-    # Encrypted raw transcript artifact storage. Raw transcripts are stored
-    # only as encrypted objects; without an encryption key no artifact store
-    # is built and raw storage is unavailable. Placeholder-free by default —
-    # keys and buckets come from the deployment environment.
-    transcript_artifact_storage_backend: str = "encrypted_filesystem"
-    transcript_artifact_storage_path: Path = Path("./data/transcript-artifacts")
-    transcript_artifact_encryption_key: str = ""
-    transcript_artifact_s3_bucket: str = ""
-    transcript_artifact_s3_endpoint_url: str = ""
-    transcript_artifact_s3_region_name: str = ""
-    transcript_artifact_s3_access_key_id: str = ""
-    transcript_artifact_s3_secret_access_key: str = ""
+    Nested under ``settings.stats_cache``. Environment grammar:
+    ``PODEX_STATS_CACHE__TTL_SECONDS``.
+    """
 
-    # Passwordless account authentication. Magic-link email delivery stays
-    # disabled until SMTP settings are provided by the deployment
-    # environment; defaults are placeholder-free.
-    auth_magic_link_ttl_minutes: int = 15
-    auth_session_ttl_days: int = 30
-    auth_session_cookie_name: str = "podex_session"
-    auth_session_cookie_secure: bool = True
+    # Short TTL because we currently have no write-time invalidation hooks
+    # (see ``services/stats_queries.py``); setting the TTL to ``0`` disables
+    # caching entirely. ``allow_inf_nan`` rejects ``NaN`` (which would
+    # silently bypass caching after mypy-safe comparisons) and ``inf``
+    # (which would keep entries alive forever); the ``ge=0`` bound catches
+    # negative overrides at startup instead of allowing a misconfigured
+    # value to disable caching in a surprising way.
+    ttl_seconds: float = Field(default=30.0, ge=0, allow_inf_nan=False)
+
+
+class TranscriptStorageSettings(BaseModel):
+    """Encrypted raw transcript artifact storage (filesystem or S3/R2).
+
+    Nested under ``settings.transcripts``. Environment grammar:
+    ``PODEX_TRANSCRIPTS__STORAGE_BACKEND``,
+    ``PODEX_TRANSCRIPTS__ENCRYPTION_KEY``, etc.
+    """
+
+    # Raw transcripts are stored only as encrypted objects; without an
+    # encryption key no artifact store is built and raw storage is
+    # unavailable. Placeholder-free by default — keys and buckets come
+    # from the deployment environment.
+    storage_backend: str = "encrypted_filesystem"
+    storage_path: Path = Path("./data/transcript-artifacts")
+    encryption_key: str = ""
+    s3_bucket: str = ""
+    s3_endpoint_url: str = ""
+    s3_region_name: str = ""
+    s3_access_key_id: str = ""
+    s3_secret_access_key: str = ""
+
+
+class AuthSettings(BaseModel):
+    """Passwordless auth (magic link + hosted WorkOS AuthKit).
+
+    Nested under ``settings.auth``. Environment grammar:
+    ``PODEX_AUTH__MAGIC_LINK_TTL_MINUTES``, ``PODEX_AUTH__WORKOS_CLIENT_ID``,
+    ``PODEX_AUTH__SMTP_HOST``, etc.
+    """
+
+    # Magic-link email delivery stays disabled until SMTP settings are
+    # provided by the deployment environment; defaults are placeholder-free.
+    magic_link_ttl_minutes: int = 15
+    session_ttl_days: int = 30
+    session_cookie_name: str = "podex_session"
+    session_cookie_secure: bool = True
     smtp_host: str = ""
     smtp_port: int = 587
     smtp_username: str = ""
@@ -109,16 +123,25 @@ class Settings(BaseSettings):
             self.workos_client_id and self.workos_api_key and self.workos_redirect_uri,
         )
 
-    # Paid tier and billing. Both gates default off: ``paid_tier_enabled``
-    # controls whether checkout can begin, ``paid_tier_enforced`` controls
-    # whether personalization writes require entitlement. The checkout URL
-    # and provider name come from the deployment environment.
+
+class BillingSettings(BaseModel):
+    """Paid-tier gates and Paddle Merchant of Record checkout/webhooks.
+
+    Nested under ``settings.billing``. Environment grammar:
+    ``PODEX_BILLING__PAID_TIER_ENABLED``, ``PODEX_BILLING__PADDLE_PRICE_ID``,
+    etc.
+    """
+
+    # Both gates default off: ``paid_tier_enabled`` controls whether
+    # checkout can begin, ``paid_tier_enforced`` controls whether
+    # personalization writes require entitlement. The checkout URL and
+    # provider name come from the deployment environment.
     paid_tier_enabled: bool = False
     paid_tier_enforced: bool = False
     paid_api_requests_per_month: int = 500
     paid_llm_requests_per_month: int = 25
-    billing_provider_name: str = ""
-    billing_checkout_url: str = ""
+    provider_name: str = ""
+    checkout_url: str = ""
 
     # Paddle Merchant of Record. Every identifier defaults to an empty
     # string so the Paddle provider stays disabled until the deployment
@@ -134,6 +157,53 @@ class Settings(BaseSettings):
         """Whether Paddle-hosted checkout is fully configured."""
         return bool(self.paddle_checkout_url and self.paddle_price_id)
 
+
+class ObservabilitySettings(BaseModel):
+    """Error tracking (Sentry).
+
+    Nested under ``settings.observability``. Environment grammar:
+    ``PODEX_OBSERVABILITY__SENTRY_DSN``,
+    ``PODEX_OBSERVABILITY__SENTRY_ENVIRONMENT``.
+
+    Prometheus ``/metrics`` gating remains on ``settings.ops_api_key``
+    (ops console domain); it is not part of this sub-model.
+    """
+
+    # Disabled until a DSN is provided by the deployment environment;
+    # defaults are placeholder-free. Error tracking only — no
+    # tracing/profiling sample rates are configured.
+    sentry_dsn: str = ""
+    sentry_environment: str = "production"
+
+
+class Settings(BaseSettings):
+    """Runtime settings, overridable via ``PODEX_`` environment variables."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="PODEX_",
+        env_nested_delimiter="__",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    app_name: str = "podex"
+    environment: str = "development"
+    debug: bool = False
+    api_v2_prefix: str = "/api/v2"
+    cors_origins: list[str] = ["http://localhost:4321"]
+    public_web_url: str = "http://localhost:4321"
+    database: DatabaseSettings = Field(default_factory=DatabaseSettings)
+    rate_limit: RateLimitSettings = Field(default_factory=RateLimitSettings)
+    stats_cache: StatsCacheSettings = Field(default_factory=StatsCacheSettings)
+    transcripts: TranscriptStorageSettings = Field(
+        default_factory=TranscriptStorageSettings,
+    )
+    auth: AuthSettings = Field(default_factory=AuthSettings)
+    billing: BillingSettings = Field(default_factory=BillingSettings)
+    observability: ObservabilitySettings = Field(
+        default_factory=ObservabilitySettings,
+    )
+
     # Ops console API. The ops surface stays disabled until a key is
     # configured by the deployment environment; requests must present it in
     # the X-Ops-Key header.
@@ -146,12 +216,6 @@ class Settings(BaseSettings):
     scheduler_tick_seconds: int = 60
     scheduler_digest_interval_minutes: int = 1440
     scheduler_retention_interval_minutes: int = 1440
-
-    # Sentry error tracking. Disabled until a DSN is provided by the
-    # deployment environment; defaults are placeholder-free. Error tracking
-    # only — no tracing/profiling sample rates are configured.
-    sentry_dsn: str = ""
-    sentry_environment: str = "production"
 
 
 @lru_cache

--- a/backend/src/podex/main.py
+++ b/backend/src/podex/main.py
@@ -23,7 +23,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Stash the resolved settings on ``app.state`` so route dependencies see
     # the same instance ``create_app`` used to configure middleware — tests
     # (and callers passing an explicit ``settings=``) rely on this to override
-    # e.g. ``stats_cache_ttl_seconds`` without touching global state.
+    # e.g. ``settings.stats_cache.ttl_seconds`` without touching global state.
     app.state.settings = resolved
     # Process-wide read-through cache for aggregate/stats endpoints. Shared
     # across requests (and workers within this process) so the aggregation
@@ -39,13 +39,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Middleware is applied in reverse registration order (last added runs
     # outermost). Register the rate limiter and request-context logger first so
     # CORS ends up outermost and still annotates 429 responses.
-    if resolved.rate_limit_enabled:
+    if resolved.rate_limit.enabled:
         limiter = build_rate_limiter(resolved)
         app.state.rate_limiter = limiter
         app.add_middleware(
             RateLimitMiddleware,
             limiter=limiter,
-            exempt_paths=tuple(resolved.rate_limit_exempt_paths),
+            exempt_paths=tuple(resolved.rate_limit.exempt_paths),
         )
     app.add_middleware(RequestContextMiddleware)
     # Registered after the limiter/context middleware so it observes every

--- a/backend/src/podex/observability.py
+++ b/backend/src/podex/observability.py
@@ -76,8 +76,9 @@ def scrub_event(event: Event, hint: Hint) -> Event:
 def init_sentry(settings: Settings) -> bool:
     """Initialize the Sentry SDK when a DSN is configured.
 
-    No-ops (leaving the SDK fully disabled) when ``settings.sentry_dsn`` is
-    empty. Tracing and profiling stay disabled — error tracking only.
+    No-ops (leaving the SDK fully disabled) when
+    ``settings.observability.sentry_dsn`` is empty. Tracing and profiling stay
+    disabled — error tracking only.
 
     Args:
         settings: Runtime settings providing the DSN and environment.
@@ -85,11 +86,11 @@ def init_sentry(settings: Settings) -> bool:
     Returns:
         True when the SDK was initialized, False when disabled.
     """
-    if not settings.sentry_dsn:
+    if not settings.observability.sentry_dsn:
         return False
     sentry_sdk.init(
-        dsn=settings.sentry_dsn,
-        environment=settings.sentry_environment,
+        dsn=settings.observability.sentry_dsn,
+        environment=settings.observability.sentry_environment,
         release=f"podex@{__version__}",
         before_send=scrub_event,
         send_default_pii=False,

--- a/backend/src/podex/services/account_subscriptions.py
+++ b/backend/src/podex/services/account_subscriptions.py
@@ -80,9 +80,9 @@ def get_quota_snapshot(
         period=period,
         feature=feature,
         limit=(
-            settings.paid_api_requests_per_month
+            settings.billing.paid_api_requests_per_month
             if feature == API_REQUESTS
-            else settings.paid_llm_requests_per_month
+            else settings.billing.paid_llm_requests_per_month
         ),
         used=usage.units if usage is not None else 0,
     )
@@ -96,7 +96,7 @@ def consume_paid_api_request(
     now: datetime | None = None,
 ) -> QuotaSnapshot | None:
     """Enforce paid access and record one personalized API mutation."""
-    if not settings.paid_tier_enforced:
+    if not settings.billing.paid_tier_enforced:
         return None
     subscription = get_account_subscription(db=db, user_id=user_id)
     if not has_paid_access(subscription=subscription):

--- a/backend/src/podex/services/billing_checkout.py
+++ b/backend/src/podex/services/billing_checkout.py
@@ -95,14 +95,14 @@ def build_billing_checkout_provider(
     settings: Settings,
 ) -> BillingCheckoutProvider | None:
     """Build the configured provider bridge only when checkout is configured."""
-    if settings.paddle_checkout_enabled:
+    if settings.billing.paddle_checkout_enabled:
         return PaddleBillingCheckoutProvider(
-            checkout_url=settings.paddle_checkout_url,
-            price_id=settings.paddle_price_id,
+            checkout_url=settings.billing.paddle_checkout_url,
+            price_id=settings.billing.paddle_price_id,
         )
-    if not settings.billing_provider_name or not settings.billing_checkout_url:
+    if not settings.billing.provider_name or not settings.billing.checkout_url:
         return None
     return HostedBillingCheckoutProvider(
-        provider=settings.billing_provider_name,
-        checkout_url=settings.billing_checkout_url,
+        provider=settings.billing.provider_name,
+        checkout_url=settings.billing.checkout_url,
     )

--- a/backend/src/podex/services/limiter.py
+++ b/backend/src/podex/services/limiter.py
@@ -3,8 +3,8 @@
 This limiter keeps a sliding window of request timestamps per client key in
 process memory. It is intentionally simple and process-local: each worker
 enforces its own counts. It remains the default backend and the fallback used
-in development/tests; when ``rate_limit_redis_url`` is configured the factory
-in :mod:`podex.services.limiter_factory` swaps in a Redis-backed limiter that
+in development/tests; when ``settings.rate_limit.redis_url`` is configured the
+factory in :mod:`podex.services.limiter_factory` swaps in a Redis-backed limiter that
 shares state across workers.
 """
 

--- a/backend/src/podex/services/limiter_factory.py
+++ b/backend/src/podex/services/limiter_factory.py
@@ -2,10 +2,10 @@
 
 The application talks to a single :class:`~podex.services.limiter.RateLimiter`
 interface; this module hides which concrete backend gets wired in. When
-``rate_limit_redis_url`` is configured, requests share state through Redis so
-horizontal scaling and restarts don't leak budget. Otherwise we fall back to
-the in-process sliding-window implementation, which is what development, CI,
-and single-worker deployments actually need.
+``settings.rate_limit.redis_url`` is configured, requests share state through
+Redis so horizontal scaling and restarts don't leak budget. Otherwise we fall
+back to the in-process sliding-window implementation, which is what
+development, CI, and single-worker deployments actually need.
 """
 
 from __future__ import annotations
@@ -31,12 +31,12 @@ def build_rate_limiter(settings: Settings) -> RateLimiter:
 
     Selection rules:
 
-    * ``settings.rate_limit_redis_url`` is empty → return an in-memory
+    * ``settings.rate_limit.redis_url`` is empty → return an in-memory
       :class:`SlidingWindowRateLimiter`.
-    * ``settings.rate_limit_redis_url`` is set → return a
+    * ``settings.rate_limit.redis_url`` is set → return a
       :class:`~podex.services.redis_limiter.RedisSlidingWindowRateLimiter`
       pointed at that URL, with its shared key prefix taken from
-      ``settings.rate_limit_redis_prefix``.
+      ``settings.rate_limit.redis_prefix``.
 
     ``redis`` is imported lazily so environments that never opt into the
     shared store don't pay the import cost and don't require the extra to be
@@ -53,10 +53,10 @@ def build_rate_limiter(settings: Settings) -> RateLimiter:
     Returns:
         RateLimiter: A ready-to-use limiter matching the configured backend.
     """
-    if not settings.rate_limit_redis_url:
+    if not settings.rate_limit.redis_url:
         return SlidingWindowRateLimiter(
-            max_requests=settings.rate_limit_max_requests,
-            window_seconds=settings.rate_limit_window_seconds,
+            max_requests=settings.rate_limit.max_requests,
+            window_seconds=settings.rate_limit.window_seconds,
         )
 
     import redis
@@ -64,13 +64,13 @@ def build_rate_limiter(settings: Settings) -> RateLimiter:
     from podex.services.redis_limiter import RedisSlidingWindowRateLimiter
 
     client = redis.Redis.from_url(
-        settings.rate_limit_redis_url,
+        settings.rate_limit.redis_url,
         socket_connect_timeout=_REDIS_CONNECT_TIMEOUT_SECONDS,
         socket_timeout=_REDIS_SOCKET_TIMEOUT_SECONDS,
     )
     return RedisSlidingWindowRateLimiter(
         client,
-        max_requests=settings.rate_limit_max_requests,
-        window_seconds=settings.rate_limit_window_seconds,
-        key_prefix=settings.rate_limit_redis_prefix,
+        max_requests=settings.rate_limit.max_requests,
+        window_seconds=settings.rate_limit.window_seconds,
+        key_prefix=settings.rate_limit.redis_prefix,
     )

--- a/backend/src/podex/services/magic_link_delivery.py
+++ b/backend/src/podex/services/magic_link_delivery.py
@@ -47,13 +47,13 @@ class SmtpMagicLinkSender:
 
 def build_magic_link_sender(*, settings: Settings) -> MagicLinkSender | None:
     """Build SMTP delivery when sign-in email configuration is present."""
-    if not settings.smtp_host or not settings.smtp_from_email:
+    if not settings.auth.smtp_host or not settings.auth.smtp_from_email:
         return None
     return SmtpMagicLinkSender(
-        host=settings.smtp_host,
-        port=settings.smtp_port,
-        from_email=settings.smtp_from_email,
-        username=settings.smtp_username,
-        password=settings.smtp_password,
-        starttls=settings.smtp_starttls,
+        host=settings.auth.smtp_host,
+        port=settings.auth.smtp_port,
+        from_email=settings.auth.smtp_from_email,
+        username=settings.auth.smtp_username,
+        password=settings.auth.smtp_password,
+        starttls=settings.auth.smtp_starttls,
     )

--- a/backend/src/podex/services/notification_delivery.py
+++ b/backend/src/podex/services/notification_delivery.py
@@ -43,13 +43,13 @@ class SmtpDigestSender:
 
 def build_digest_sender(*, settings: Settings) -> DigestSender | None:
     """Build configured digest email delivery when SMTP is available."""
-    if not settings.smtp_host or not settings.smtp_from_email:
+    if not settings.auth.smtp_host or not settings.auth.smtp_from_email:
         return None
     return SmtpDigestSender(
-        host=settings.smtp_host,
-        port=settings.smtp_port,
-        from_email=settings.smtp_from_email,
-        username=settings.smtp_username,
-        password=settings.smtp_password,
-        starttls=settings.smtp_starttls,
+        host=settings.auth.smtp_host,
+        port=settings.auth.smtp_port,
+        from_email=settings.auth.smtp_from_email,
+        username=settings.auth.smtp_username,
+        password=settings.auth.smtp_password,
+        starttls=settings.auth.smtp_starttls,
     )

--- a/backend/src/podex/services/transcript_artifacts.py
+++ b/backend/src/podex/services/transcript_artifacts.py
@@ -120,7 +120,7 @@ class EncryptedFilesystemTranscriptArtifactStore:
         encryption_key: str,
     ) -> None:
         if not encryption_key:
-            raise ValueError("TRANSCRIPT_ARTIFACT_ENCRYPTION_KEY must be configured")
+            raise ValueError("PODEX_TRANSCRIPTS__ENCRYPTION_KEY must be configured")
         self.root_path = root_path
         self.fernet = Fernet(encryption_key.encode("ascii"))
         self.key_id = sha256(encryption_key.encode("ascii")).hexdigest()[:16]
@@ -187,9 +187,9 @@ class EncryptedS3TranscriptArtifactStore:
         client: S3ObjectClient | None = None,
     ) -> None:
         if not bucket:
-            raise ValueError("TRANSCRIPT_ARTIFACT_S3_BUCKET must be configured")
+            raise ValueError("PODEX_TRANSCRIPTS__S3_BUCKET must be configured")
         if not encryption_key:
-            raise ValueError("TRANSCRIPT_ARTIFACT_ENCRYPTION_KEY must be configured")
+            raise ValueError("PODEX_TRANSCRIPTS__ENCRYPTION_KEY must be configured")
         self.bucket = bucket
         self.fernet = Fernet(encryption_key.encode("ascii"))
         self.key_id = sha256(encryption_key.encode("ascii")).hexdigest()[:16]
@@ -242,23 +242,23 @@ def build_transcript_artifact_store(
     settings: Settings,
 ) -> TranscriptArtifactStore | None:
     """Build the configured private artifact adapter when a key is supplied."""
-    if not settings.transcript_artifact_encryption_key:
+    if not settings.transcripts.encryption_key:
         return None
     backend = TranscriptArtifactStorageBackend(
-        settings.transcript_artifact_storage_backend,
+        settings.transcripts.storage_backend,
     )
     if backend is TranscriptArtifactStorageBackend.ENCRYPTED_S3:
         return EncryptedS3TranscriptArtifactStore(
-            bucket=settings.transcript_artifact_s3_bucket,
-            encryption_key=settings.transcript_artifact_encryption_key,
-            endpoint_url=settings.transcript_artifact_s3_endpoint_url,
-            region_name=settings.transcript_artifact_s3_region_name,
-            access_key_id=settings.transcript_artifact_s3_access_key_id,
-            secret_access_key=settings.transcript_artifact_s3_secret_access_key,
+            bucket=settings.transcripts.s3_bucket,
+            encryption_key=settings.transcripts.encryption_key,
+            endpoint_url=settings.transcripts.s3_endpoint_url,
+            region_name=settings.transcripts.s3_region_name,
+            access_key_id=settings.transcripts.s3_access_key_id,
+            secret_access_key=settings.transcripts.s3_secret_access_key,
         )
     return EncryptedFilesystemTranscriptArtifactStore(
-        root_path=settings.transcript_artifact_storage_path,
-        encryption_key=settings.transcript_artifact_encryption_key,
+        root_path=settings.transcripts.storage_path,
+        encryption_key=settings.transcripts.encryption_key,
     )
 
 

--- a/backend/src/podex/services/workos_auth.py
+++ b/backend/src/podex/services/workos_auth.py
@@ -143,12 +143,12 @@ def build_workos_auth_client(*, settings: Settings) -> WorkOSAuthClient | None:
     Returns:
         A configured client, or ``None`` when any credential is missing.
     """
-    if not settings.workos_enabled:
+    if not settings.auth.workos_enabled:
         return None
     return WorkOSAuthClient(
-        client_id=settings.workos_client_id,
-        api_key=settings.workos_api_key,
-        redirect_uri=settings.workos_redirect_uri,
+        client_id=settings.auth.workos_client_id,
+        api_key=settings.auth.workos_api_key,
+        redirect_uri=settings.auth.workos_redirect_uri,
     )
 
 

--- a/backend/tests/test_account_alerts_digests.py
+++ b/backend/tests/test_account_alerts_digests.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from assertpy import assert_that
 from sqlalchemy.orm import Session
 
-from podex.config import Settings
+from podex.config import AuthSettings, Settings
 from podex.models import (
     AccountAlertEvent,
     AccountUser,
@@ -268,8 +268,10 @@ def test_build_digest_sender_requires_smtp_configuration() -> None:
     assert_that(build_digest_sender(settings=Settings())).is_none()
     sender = build_digest_sender(
         settings=Settings(
-            smtp_host="smtp.example.com",
-            smtp_from_email="digests@example.com",
+            auth=AuthSettings(
+                smtp_host="smtp.example.com",
+                smtp_from_email="digests@example.com",
+            ),
         ),
     )
     assert_that(sender).is_instance_of(SmtpDigestSender)

--- a/backend/tests/test_account_personalization.py
+++ b/backend/tests/test_account_personalization.py
@@ -6,7 +6,7 @@ import pytest
 from assertpy import assert_that
 from sqlalchemy.orm import Session
 
-from podex.config import Settings
+from podex.config import AuthSettings, Settings
 from podex.models import AccountUser
 from podex.services.account_follows import (
     follow_podcast,
@@ -125,8 +125,10 @@ def test_build_magic_link_sender_requires_smtp_configuration() -> None:
     assert_that(build_magic_link_sender(settings=Settings())).is_none()
     sender = build_magic_link_sender(
         settings=Settings(
-            smtp_host="smtp.example.com",
-            smtp_from_email="signin@example.com",
+            auth=AuthSettings(
+                smtp_host="smtp.example.com",
+                smtp_from_email="signin@example.com",
+            ),
         ),
     )
     assert_that(sender).is_instance_of(SmtpMagicLinkSender)

--- a/backend/tests/test_billing_paddle.py
+++ b/backend/tests/test_billing_paddle.py
@@ -13,7 +13,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from podex.api.deps import get_app_settings
-from podex.config import Settings
+from podex.config import BillingSettings, Settings
 from podex.models import AccountSubscription, AccountUser, BillingWebhookEvent
 from podex.services.billing_checkout import (
     HostedBillingCheckoutProvider,
@@ -47,7 +47,7 @@ def _configure_paddle(client: TestClient) -> None:
     if not isinstance(app, FastAPI):  # pragma: no cover - narrowed
         raise AssertionError
     app.dependency_overrides[get_app_settings] = lambda: Settings(
-        paddle_webhook_secret=_SECRET,
+        billing=BillingSettings(paddle_webhook_secret=_SECRET),
     )
 
 
@@ -97,8 +97,10 @@ def test_paddle_provider_builds_prefilled_checkout() -> None:
     """The Paddle bridge carries email and an opaque account reference."""
     provider = build_billing_checkout_provider(
         settings=Settings(
-            paddle_checkout_url="https://buy.paddle.example/checkout",
-            paddle_price_id="pri_123",
+            billing=BillingSettings(
+                paddle_checkout_url="https://buy.paddle.example/checkout",
+                paddle_price_id="pri_123",
+            ),
         ),
     )
     assert_that(provider).is_instance_of(PaddleBillingCheckoutProvider)
@@ -126,17 +128,21 @@ def test_provider_builder_prefers_paddle_then_hosted() -> None:
     assert_that(build_billing_checkout_provider(settings=Settings())).is_none()
     hosted = build_billing_checkout_provider(
         settings=Settings(
-            billing_provider_name="hosted-test",
-            billing_checkout_url="https://billing.example/upgrade",
+            billing=BillingSettings(
+                provider_name="hosted-test",
+                checkout_url="https://billing.example/upgrade",
+            ),
         ),
     )
     assert_that(hosted).is_instance_of(HostedBillingCheckoutProvider)
     paddle = build_billing_checkout_provider(
         settings=Settings(
-            billing_provider_name="hosted-test",
-            billing_checkout_url="https://billing.example/upgrade",
-            paddle_checkout_url="https://buy.paddle.example/checkout",
-            paddle_price_id="pri_123",
+            billing=BillingSettings(
+                provider_name="hosted-test",
+                checkout_url="https://billing.example/upgrade",
+                paddle_checkout_url="https://buy.paddle.example/checkout",
+                paddle_price_id="pri_123",
+            ),
         ),
     )
     assert_that(paddle).is_instance_of(PaddleBillingCheckoutProvider)

--- a/backend/tests/test_billing_subscriptions.py
+++ b/backend/tests/test_billing_subscriptions.py
@@ -7,7 +7,7 @@ from assertpy import assert_that
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from podex.config import Settings
+from podex.config import BillingSettings, Settings
 from podex.models import AccountSubscription, AccountUser
 from podex.services.account_subscriptions import (
     API_REQUESTS,
@@ -52,12 +52,17 @@ def test_subscription_defaults_to_free(db_session: Session) -> None:
 def test_consume_paid_api_request_enforcement(db_session: Session) -> None:
     """Enforcement requires paid entitlement and honors monthly limits."""
     user = _create_user(db_session)
-    relaxed = Settings(paid_tier_enforced=False)
+    relaxed = Settings(billing=BillingSettings(paid_tier_enforced=False))
     assert_that(
         consume_paid_api_request(db=db_session, user_id=user.id, settings=relaxed),
     ).is_none()
 
-    enforced = Settings(paid_tier_enforced=True, paid_api_requests_per_month=2)
+    enforced = Settings(
+        billing=BillingSettings(
+            paid_tier_enforced=True,
+            paid_api_requests_per_month=2,
+        ),
+    )
     with pytest.raises(PaidSubscriptionRequiredError):
         consume_paid_api_request(db=db_session, user_id=user.id, settings=enforced)
 
@@ -107,8 +112,10 @@ def test_checkout_provider_builds_prefilled_url() -> None:
     assert_that(build_billing_checkout_provider(settings=Settings())).is_none()
     provider = build_billing_checkout_provider(
         settings=Settings(
-            billing_provider_name="hosted-test",
-            billing_checkout_url="https://billing.example/upgrade",
+            billing=BillingSettings(
+                provider_name="hosted-test",
+                checkout_url="https://billing.example/upgrade",
+            ),
         ),
     )
     assert_that(provider).is_instance_of(HostedBillingCheckoutProvider)
@@ -168,7 +175,7 @@ def test_paid_enforcement_blocks_personalization_writes(
     from podex.api.deps import get_app_settings
 
     app.dependency_overrides[get_app_settings] = lambda: Settings(
-        paid_tier_enforced=True,
+        billing=BillingSettings(paid_tier_enforced=True),
     )
 
     blocked = client.put(f"/api/v2/me/saves/{graph.media_id}", headers=cookie)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,13 +1,24 @@
 """Tests for application settings."""
 
 import math
+from pathlib import Path
 
 import pytest
 from assertpy import assert_that
 from pydantic import ValidationError
 from pytest import MonkeyPatch
 
-from podex.config import DatabaseSettings, Settings, get_settings
+from podex.config import (
+    AuthSettings,
+    BillingSettings,
+    DatabaseSettings,
+    ObservabilitySettings,
+    RateLimitSettings,
+    Settings,
+    StatsCacheSettings,
+    TranscriptStorageSettings,
+    get_settings,
+)
 
 
 def test_default_settings() -> None:
@@ -55,10 +66,45 @@ def test_rate_limit_defaults_are_generous() -> None:
     """Rate-limit defaults are enabled but roomy so normal traffic is fine."""
     settings = Settings()
 
-    assert_that(settings.rate_limit_enabled).is_true()
-    assert_that(settings.rate_limit_max_requests).is_greater_than(0)
-    assert_that(settings.rate_limit_window_seconds).is_greater_than(0)
-    assert_that(settings.rate_limit_exempt_paths).contains("/health")
+    assert_that(settings.rate_limit.enabled).is_true()
+    assert_that(settings.rate_limit.max_requests).is_greater_than(0)
+    assert_that(settings.rate_limit.window_seconds).is_greater_than(0)
+    assert_that(settings.rate_limit.exempt_paths).contains("/health")
+
+
+def test_rate_limit_settings_load_from_nested_env(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Nested ``PODEX_RATE_LIMIT__*`` env vars populate rate limiting."""
+    monkeypatch.setenv("PODEX_RATE_LIMIT__ENABLED", "false")
+    monkeypatch.setenv("PODEX_RATE_LIMIT__MAX_REQUESTS", "7")
+    monkeypatch.setenv("PODEX_RATE_LIMIT__WINDOW_SECONDS", "2.5")
+    monkeypatch.setenv("PODEX_RATE_LIMIT__EXEMPT_PATHS", '["/health","/ready"]')
+    monkeypatch.setenv("PODEX_RATE_LIMIT__REDIS_URL", "redis://redis:6379/1")
+    monkeypatch.setenv("PODEX_RATE_LIMIT__REDIS_PREFIX", "podex-test")
+
+    settings = Settings()
+
+    assert_that(settings.rate_limit.enabled).is_false()
+    assert_that(settings.rate_limit.max_requests).is_equal_to(7)
+    assert_that(settings.rate_limit.window_seconds).is_equal_to(2.5)
+    assert_that(settings.rate_limit.exempt_paths).is_equal_to(["/health", "/ready"])
+    assert_that(settings.rate_limit.redis_url).is_equal_to("redis://redis:6379/1")
+    assert_that(settings.rate_limit.redis_prefix).is_equal_to("podex-test")
+
+
+def test_flat_rate_limit_env_name_is_ignored(monkeypatch: MonkeyPatch) -> None:
+    """Old flat ``PODEX_RATE_LIMIT_*`` names are ignored."""
+    monkeypatch.setenv("PODEX_RATE_LIMIT_ENABLED", "false")
+    monkeypatch.setenv("PODEX_RATE_LIMIT_REDIS_URL", "redis://flat-ignored")
+    monkeypatch.delenv("PODEX_RATE_LIMIT__ENABLED", raising=False)
+    monkeypatch.delenv("PODEX_RATE_LIMIT__REDIS_URL", raising=False)
+
+    settings = Settings()
+
+    assert_that(settings.rate_limit.enabled).is_true()
+    assert_that(settings.rate_limit.redis_url).is_equal_to("")
+    assert_that(settings.rate_limit).is_instance_of(RateLimitSettings)
 
 
 def test_get_settings_is_cached() -> None:
@@ -70,27 +116,211 @@ def test_stats_cache_ttl_rejects_non_finite_values() -> None:
     """``NaN`` and ``inf`` are refused so misconfig fails at startup."""
     for bad in (math.nan, math.inf, -math.inf):
         with pytest.raises(ValidationError):
-            Settings(stats_cache_ttl_seconds=bad)
+            Settings(stats_cache=StatsCacheSettings(ttl_seconds=bad))
 
 
 def test_stats_cache_ttl_rejects_negative_values() -> None:
     """A negative TTL is refused (``ge=0`` guard)."""
     with pytest.raises(ValidationError):
-        Settings(stats_cache_ttl_seconds=-1.0)
+        Settings(stats_cache=StatsCacheSettings(ttl_seconds=-1.0))
 
 
 def test_stats_cache_ttl_accepts_zero_and_positive() -> None:
     """``0`` (disabled) and positive floats are accepted."""
-    zero = Settings(stats_cache_ttl_seconds=0).stats_cache_ttl_seconds
-    positive = Settings(stats_cache_ttl_seconds=45.5).stats_cache_ttl_seconds
+    zero = Settings(stats_cache=StatsCacheSettings(ttl_seconds=0))
+    positive = Settings(stats_cache=StatsCacheSettings(ttl_seconds=45.5))
 
-    assert_that(zero).is_equal_to(0)
-    assert_that(positive).is_equal_to(45.5)
+    assert_that(zero.stats_cache.ttl_seconds).is_equal_to(0)
+    assert_that(positive.stats_cache.ttl_seconds).is_equal_to(45.5)
+
+
+def test_stats_cache_settings_load_from_nested_env(monkeypatch: MonkeyPatch) -> None:
+    """Nested ``PODEX_STATS_CACHE__*`` env vars populate stats caching."""
+    monkeypatch.setenv("PODEX_STATS_CACHE__TTL_SECONDS", "12.5")
+
+    settings = Settings()
+
+    assert_that(settings.stats_cache.ttl_seconds).is_equal_to(12.5)
+    assert_that(settings.stats_cache).is_instance_of(StatsCacheSettings)
+
+
+def test_flat_stats_cache_env_name_is_ignored(monkeypatch: MonkeyPatch) -> None:
+    """Old flat ``PODEX_STATS_CACHE_TTL_SECONDS`` is ignored."""
+    monkeypatch.setenv("PODEX_STATS_CACHE_TTL_SECONDS", "0")
+    monkeypatch.delenv("PODEX_STATS_CACHE__TTL_SECONDS", raising=False)
+
+    settings = Settings()
+
+    assert_that(settings.stats_cache.ttl_seconds).is_equal_to(30.0)
 
 
 def test_rate_limit_redis_url_defaults_to_disabled() -> None:
     """Default deployment stays on the in-memory backend (empty Redis URL)."""
     settings = Settings()
 
-    assert_that(settings.rate_limit_redis_url).is_equal_to("")
-    assert_that(settings.rate_limit_redis_prefix).is_not_empty()
+    assert_that(settings.rate_limit.redis_url).is_equal_to("")
+    assert_that(settings.rate_limit.redis_prefix).is_not_empty()
+
+
+def test_transcripts_settings_load_from_nested_env(monkeypatch: MonkeyPatch) -> None:
+    """Nested ``PODEX_TRANSCRIPTS__*`` env vars populate artifact storage."""
+    monkeypatch.setenv("PODEX_TRANSCRIPTS__STORAGE_BACKEND", "encrypted_s3")
+    monkeypatch.setenv("PODEX_TRANSCRIPTS__STORAGE_PATH", "/tmp/podex-transcripts")
+    monkeypatch.setenv("PODEX_TRANSCRIPTS__ENCRYPTION_KEY", "fernet-key")
+    monkeypatch.setenv("PODEX_TRANSCRIPTS__S3_BUCKET", "private-transcripts")
+    monkeypatch.setenv("PODEX_TRANSCRIPTS__S3_ENDPOINT_URL", "https://r2.example")
+    monkeypatch.setenv("PODEX_TRANSCRIPTS__S3_REGION_NAME", "auto")
+    monkeypatch.setenv("PODEX_TRANSCRIPTS__S3_ACCESS_KEY_ID", "key-id")
+    monkeypatch.setenv("PODEX_TRANSCRIPTS__S3_SECRET_ACCESS_KEY", "secret")
+
+    settings = Settings()
+
+    assert_that(settings.transcripts.storage_backend).is_equal_to("encrypted_s3")
+    assert_that(settings.transcripts.storage_path).is_equal_to(
+        Path("/tmp/podex-transcripts"),
+    )
+    assert_that(settings.transcripts.encryption_key).is_equal_to("fernet-key")
+    assert_that(settings.transcripts.s3_bucket).is_equal_to("private-transcripts")
+    assert_that(settings.transcripts.s3_endpoint_url).is_equal_to(
+        "https://r2.example",
+    )
+    assert_that(settings.transcripts.s3_region_name).is_equal_to("auto")
+    assert_that(settings.transcripts.s3_access_key_id).is_equal_to("key-id")
+    assert_that(settings.transcripts.s3_secret_access_key).is_equal_to("secret")
+    assert_that(settings.transcripts).is_instance_of(TranscriptStorageSettings)
+
+
+def test_flat_transcripts_env_name_is_ignored(monkeypatch: MonkeyPatch) -> None:
+    """Old flat ``PODEX_TRANSCRIPT_ARTIFACT_*`` names are ignored."""
+    monkeypatch.setenv("PODEX_TRANSCRIPT_ARTIFACT_ENCRYPTION_KEY", "flat-key")
+    monkeypatch.setenv("PODEX_TRANSCRIPT_ARTIFACT_S3_BUCKET", "flat-bucket")
+    monkeypatch.delenv("PODEX_TRANSCRIPTS__ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("PODEX_TRANSCRIPTS__S3_BUCKET", raising=False)
+
+    settings = Settings()
+
+    assert_that(settings.transcripts.encryption_key).is_equal_to("")
+    assert_that(settings.transcripts.s3_bucket).is_equal_to("")
+
+
+def test_auth_settings_load_from_nested_env(monkeypatch: MonkeyPatch) -> None:
+    """Nested ``PODEX_AUTH__*`` env vars populate auth settings."""
+    monkeypatch.setenv("PODEX_AUTH__MAGIC_LINK_TTL_MINUTES", "30")
+    monkeypatch.setenv("PODEX_AUTH__SESSION_TTL_DAYS", "45")
+    monkeypatch.setenv("PODEX_AUTH__SESSION_COOKIE_NAME", "podex_test_session")
+    monkeypatch.setenv("PODEX_AUTH__SESSION_COOKIE_SECURE", "false")
+    monkeypatch.setenv("PODEX_AUTH__SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("PODEX_AUTH__SMTP_PORT", "2525")
+    monkeypatch.setenv("PODEX_AUTH__SMTP_USERNAME", "smtp-user")
+    monkeypatch.setenv("PODEX_AUTH__SMTP_PASSWORD", "smtp-password")
+    monkeypatch.setenv("PODEX_AUTH__SMTP_FROM_EMAIL", "signin@example.com")
+    monkeypatch.setenv("PODEX_AUTH__SMTP_STARTTLS", "false")
+    monkeypatch.setenv("PODEX_AUTH__WORKOS_CLIENT_ID", "client_123")
+    monkeypatch.setenv("PODEX_AUTH__WORKOS_API_KEY", "sk_test")
+    monkeypatch.setenv("PODEX_AUTH__WORKOS_REDIRECT_URI", "https://app/callback")
+
+    settings = Settings()
+
+    assert_that(settings.auth.magic_link_ttl_minutes).is_equal_to(30)
+    assert_that(settings.auth.session_ttl_days).is_equal_to(45)
+    assert_that(settings.auth.session_cookie_name).is_equal_to("podex_test_session")
+    assert_that(settings.auth.session_cookie_secure).is_false()
+    assert_that(settings.auth.smtp_host).is_equal_to("smtp.example.com")
+    assert_that(settings.auth.smtp_port).is_equal_to(2525)
+    assert_that(settings.auth.smtp_username).is_equal_to("smtp-user")
+    assert_that(settings.auth.smtp_password).is_equal_to("smtp-password")
+    assert_that(settings.auth.smtp_from_email).is_equal_to("signin@example.com")
+    assert_that(settings.auth.smtp_starttls).is_false()
+    assert_that(settings.auth.workos_client_id).is_equal_to("client_123")
+    assert_that(settings.auth.workos_api_key).is_equal_to("sk_test")
+    assert_that(settings.auth.workos_redirect_uri).is_equal_to("https://app/callback")
+    assert_that(settings.auth.workos_enabled).is_true()
+    assert_that(settings.auth).is_instance_of(AuthSettings)
+
+
+def test_flat_auth_env_name_is_ignored(monkeypatch: MonkeyPatch) -> None:
+    """Old flat auth, SMTP, and WorkOS env names are ignored."""
+    monkeypatch.setenv("PODEX_AUTH_MAGIC_LINK_TTL_MINUTES", "30")
+    monkeypatch.setenv("PODEX_SMTP_HOST", "smtp-flat.example.com")
+    monkeypatch.setenv("PODEX_WORKOS_CLIENT_ID", "client_flat")
+    monkeypatch.delenv("PODEX_AUTH__MAGIC_LINK_TTL_MINUTES", raising=False)
+    monkeypatch.delenv("PODEX_AUTH__SMTP_HOST", raising=False)
+    monkeypatch.delenv("PODEX_AUTH__WORKOS_CLIENT_ID", raising=False)
+
+    settings = Settings()
+
+    assert_that(settings.auth.magic_link_ttl_minutes).is_equal_to(15)
+    assert_that(settings.auth.smtp_host).is_equal_to("")
+    assert_that(settings.auth.workos_client_id).is_equal_to("")
+
+
+def test_billing_settings_load_from_nested_env(monkeypatch: MonkeyPatch) -> None:
+    """Nested ``PODEX_BILLING__*`` env vars populate paid-tier settings."""
+    monkeypatch.setenv("PODEX_BILLING__PAID_TIER_ENABLED", "true")
+    monkeypatch.setenv("PODEX_BILLING__PAID_TIER_ENFORCED", "true")
+    monkeypatch.setenv("PODEX_BILLING__PAID_API_REQUESTS_PER_MONTH", "1000")
+    monkeypatch.setenv("PODEX_BILLING__PAID_LLM_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("PODEX_BILLING__PROVIDER_NAME", "hosted-test")
+    monkeypatch.setenv("PODEX_BILLING__CHECKOUT_URL", "https://billing.example")
+    monkeypatch.setenv("PODEX_BILLING__PADDLE_API_KEY", "pdl_api")
+    monkeypatch.setenv("PODEX_BILLING__PADDLE_WEBHOOK_SECRET", "whsec")
+    monkeypatch.setenv("PODEX_BILLING__PADDLE_PRICE_ID", "pri_123")
+    monkeypatch.setenv("PODEX_BILLING__PADDLE_CHECKOUT_URL", "https://buy.example")
+
+    settings = Settings()
+
+    assert_that(settings.billing.paid_tier_enabled).is_true()
+    assert_that(settings.billing.paid_tier_enforced).is_true()
+    assert_that(settings.billing.paid_api_requests_per_month).is_equal_to(1000)
+    assert_that(settings.billing.paid_llm_requests_per_month).is_equal_to(50)
+    assert_that(settings.billing.provider_name).is_equal_to("hosted-test")
+    assert_that(settings.billing.checkout_url).is_equal_to("https://billing.example")
+    assert_that(settings.billing.paddle_api_key).is_equal_to("pdl_api")
+    assert_that(settings.billing.paddle_webhook_secret).is_equal_to("whsec")
+    assert_that(settings.billing.paddle_price_id).is_equal_to("pri_123")
+    assert_that(settings.billing.paddle_checkout_url).is_equal_to("https://buy.example")
+    assert_that(settings.billing.paddle_checkout_enabled).is_true()
+    assert_that(settings.billing).is_instance_of(BillingSettings)
+
+
+def test_flat_billing_env_name_is_ignored(monkeypatch: MonkeyPatch) -> None:
+    """Old flat paid-tier, billing, and Paddle env names are ignored."""
+    monkeypatch.setenv("PODEX_PAID_TIER_ENABLED", "true")
+    monkeypatch.setenv("PODEX_BILLING_PROVIDER_NAME", "flat-provider")
+    monkeypatch.setenv("PODEX_PADDLE_CHECKOUT_URL", "https://flat-buy.example")
+    monkeypatch.delenv("PODEX_BILLING__PAID_TIER_ENABLED", raising=False)
+    monkeypatch.delenv("PODEX_BILLING__PROVIDER_NAME", raising=False)
+    monkeypatch.delenv("PODEX_BILLING__PADDLE_CHECKOUT_URL", raising=False)
+
+    settings = Settings()
+
+    assert_that(settings.billing.paid_tier_enabled).is_false()
+    assert_that(settings.billing.provider_name).is_equal_to("")
+    assert_that(settings.billing.paddle_checkout_url).is_equal_to("")
+
+
+def test_observability_settings_load_from_nested_env(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Nested ``PODEX_OBSERVABILITY__*`` env vars populate Sentry settings."""
+    monkeypatch.setenv("PODEX_OBSERVABILITY__SENTRY_DSN", "https://key@sentry/1")
+    monkeypatch.setenv("PODEX_OBSERVABILITY__SENTRY_ENVIRONMENT", "staging")
+
+    settings = Settings()
+
+    assert_that(settings.observability.sentry_dsn).is_equal_to("https://key@sentry/1")
+    assert_that(settings.observability.sentry_environment).is_equal_to("staging")
+    assert_that(settings.observability).is_instance_of(ObservabilitySettings)
+
+
+def test_flat_observability_env_name_is_ignored(monkeypatch: MonkeyPatch) -> None:
+    """Old flat ``PODEX_SENTRY_*`` env names are ignored."""
+    monkeypatch.setenv("PODEX_SENTRY_DSN", "https://flat@sentry/1")
+    monkeypatch.setenv("PODEX_SENTRY_ENVIRONMENT", "staging")
+    monkeypatch.delenv("PODEX_OBSERVABILITY__SENTRY_DSN", raising=False)
+    monkeypatch.delenv("PODEX_OBSERVABILITY__SENTRY_ENVIRONMENT", raising=False)
+
+    settings = Settings()
+
+    assert_that(settings.observability.sentry_dsn).is_equal_to("")
+    assert_that(settings.observability.sentry_environment).is_equal_to("production")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -165,7 +165,10 @@ def test_rate_limit_redis_url_defaults_to_disabled() -> None:
 def test_transcripts_settings_load_from_nested_env(monkeypatch: MonkeyPatch) -> None:
     """Nested ``PODEX_TRANSCRIPTS__*`` env vars populate artifact storage."""
     monkeypatch.setenv("PODEX_TRANSCRIPTS__STORAGE_BACKEND", "encrypted_s3")
-    monkeypatch.setenv("PODEX_TRANSCRIPTS__STORAGE_PATH", "/tmp/podex-transcripts")
+    monkeypatch.setenv(
+        "PODEX_TRANSCRIPTS__STORAGE_PATH",
+        "./data/podex-transcripts-test",
+    )
     monkeypatch.setenv("PODEX_TRANSCRIPTS__ENCRYPTION_KEY", "fernet-key")
     monkeypatch.setenv("PODEX_TRANSCRIPTS__S3_BUCKET", "private-transcripts")
     monkeypatch.setenv("PODEX_TRANSCRIPTS__S3_ENDPOINT_URL", "https://r2.example")
@@ -177,7 +180,7 @@ def test_transcripts_settings_load_from_nested_env(monkeypatch: MonkeyPatch) -> 
 
     assert_that(settings.transcripts.storage_backend).is_equal_to("encrypted_s3")
     assert_that(settings.transcripts.storage_path).is_equal_to(
-        Path("/tmp/podex-transcripts"),
+        Path("./data/podex-transcripts-test"),
     )
     assert_that(settings.transcripts.encryption_key).is_equal_to("fernet-key")
     assert_that(settings.transcripts.s3_bucket).is_equal_to("private-transcripts")

--- a/backend/tests/test_error_envelope.py
+++ b/backend/tests/test_error_envelope.py
@@ -12,7 +12,7 @@ from podex.api.v2.errors import (
     STATUS_CODE_TO_ERROR_CODE,
     error_code_for_status,
 )
-from podex.config import Settings
+from podex.config import RateLimitSettings, Settings
 from podex.main import create_app
 from podex.middleware import REQUEST_ID_HEADER
 
@@ -54,7 +54,7 @@ def test_unhandled_exception_returns_500_envelope(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Unhandled route errors are wrapped in an opaque 500 envelope."""
-    app = create_app(Settings(rate_limit_enabled=False))
+    app = create_app(Settings(rate_limit=RateLimitSettings(enabled=False)))
 
     async def _boom() -> None:
         """Route handler that always fails."""
@@ -93,7 +93,7 @@ def test_http_exception_with_structured_detail_preserves_code(
     from podex.main import app as _base_app
 
     del _base_app
-    app = create_app(Settings(rate_limit_enabled=False))
+    app = create_app(Settings(rate_limit=RateLimitSettings(enabled=False)))
 
     async def _custom() -> None:
         """Raise a structured HTTPException to exercise the handler."""

--- a/backend/tests/test_limiter.py
+++ b/backend/tests/test_limiter.py
@@ -8,7 +8,7 @@ import pytest
 import redis
 from assertpy import assert_that
 
-from podex.config import Settings
+from podex.config import RateLimitSettings, Settings
 from podex.services.limiter import RateLimiter, SlidingWindowRateLimiter
 from podex.services.limiter_factory import build_rate_limiter
 from podex.services.redis_limiter import RedisSlidingWindowRateLimiter
@@ -278,11 +278,13 @@ def test_redis_limiter_matches_in_memory_decisions_over_a_sequence() -> None:
 
 
 def test_build_rate_limiter_returns_in_memory_when_redis_url_unset() -> None:
-    """An empty ``rate_limit_redis_url`` selects the in-memory backend."""
+    """An empty ``settings.rate_limit.redis_url`` selects the in-memory backend."""
     settings = Settings(
-        rate_limit_max_requests=4,
-        rate_limit_window_seconds=15.0,
-        rate_limit_redis_url="",
+        rate_limit=RateLimitSettings(
+            max_requests=4,
+            window_seconds=15.0,
+            redis_url="",
+        ),
     )
 
     limiter = build_rate_limiter(settings)
@@ -295,7 +297,7 @@ def test_build_rate_limiter_returns_in_memory_when_redis_url_unset() -> None:
 def test_build_rate_limiter_returns_redis_backend_when_url_set(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A non-empty ``rate_limit_redis_url`` selects the shared backend.
+    """A non-empty ``settings.rate_limit.redis_url`` selects the shared backend.
 
     The factory imports ``redis`` lazily; we swap in a fakeredis-backed
     ``from_url`` so no real network connection is attempted.
@@ -312,10 +314,12 @@ def test_build_rate_limiter_returns_redis_backend_when_url_set(
     monkeypatch.setattr(redis.Redis, "from_url", staticmethod(fake_from_url))
 
     settings = Settings(
-        rate_limit_max_requests=2,
-        rate_limit_window_seconds=60.0,
-        rate_limit_redis_url="redis://localhost:6379/0",
-        rate_limit_redis_prefix="podex-test:ratelimit",
+        rate_limit=RateLimitSettings(
+            max_requests=2,
+            window_seconds=60.0,
+            redis_url="redis://localhost:6379/0",
+            redis_prefix="podex-test:ratelimit",
+        ),
     )
 
     limiter = build_rate_limiter(settings)
@@ -437,7 +441,9 @@ def test_build_rate_limiter_configures_finite_redis_timeouts(
 
     monkeypatch.setattr(redis.Redis, "from_url", staticmethod(fake_from_url))
 
-    settings = Settings(rate_limit_redis_url="redis://localhost:6379/0")
+    settings = Settings(
+        rate_limit=RateLimitSettings(redis_url="redis://localhost:6379/0"),
+    )
 
     build_rate_limiter(settings)
 

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -9,7 +9,7 @@ from assertpy import assert_that
 from fastapi.testclient import TestClient
 from starlette.requests import Request
 
-from podex.config import Settings
+from podex.config import RateLimitSettings, Settings
 from podex.main import create_app
 from podex.middleware import REQUEST_ID_HEADER, RateLimitMiddleware
 from podex.services.limiter import SlidingWindowRateLimiter
@@ -36,10 +36,12 @@ def tight_client() -> Iterator[TestClient]:
         TestClient: A client backed by an app with a tight rate limit.
     """
     settings = Settings(
-        rate_limit_enabled=True,
-        rate_limit_max_requests=2,
-        rate_limit_window_seconds=60.0,
-        rate_limit_exempt_paths=["/health"],
+        rate_limit=RateLimitSettings(
+            enabled=True,
+            max_requests=2,
+            window_seconds=60.0,
+            exempt_paths=["/health"],
+        ),
     )
     with _make_client(settings) as client:
         yield client
@@ -108,7 +110,7 @@ def test_health_is_exempt_from_rate_limiting(tight_client: TestClient) -> None:
 
 def test_rate_limiting_can_be_disabled() -> None:
     """Disabling the limiter removes both the 429 path and its headers."""
-    settings = Settings(rate_limit_enabled=False)
+    settings = Settings(rate_limit=RateLimitSettings(enabled=False))
     with _make_client(settings) as client:
         for _ in range(10):
             response = client.get("/api/v2/status")
@@ -135,7 +137,7 @@ def test_access_log_emitted_when_handler_raises(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Unhandled handler exceptions still produce a 500 access-log line."""
-    app = create_app(Settings(rate_limit_enabled=False))
+    app = create_app(Settings(rate_limit=RateLimitSettings(enabled=False)))
 
     async def _boom() -> None:
         """Route handler that always fails."""
@@ -157,7 +159,7 @@ def test_access_log_emitted_when_handler_raises(
 
 def test_cors_exposes_rate_limit_headers_to_browsers() -> None:
     """Cross-origin responses expose the request-id and rate-limit headers."""
-    settings = Settings(rate_limit_enabled=True)
+    settings = Settings(rate_limit=RateLimitSettings(enabled=True))
     with _make_client(settings) as client:
         response = client.get(
             "/api/v2/status", headers={"Origin": "http://localhost:4321"}
@@ -190,9 +192,11 @@ def test_middleware_works_with_redis_backed_limiter(
     )
 
     settings = Settings(
-        rate_limit_enabled=True,
-        rate_limit_max_requests=2,
-        rate_limit_window_seconds=60.0,
+        rate_limit=RateLimitSettings(
+            enabled=True,
+            max_requests=2,
+            window_seconds=60.0,
+        ),
     )
     with TestClient(create_app(settings)) as client:
         first = client.get("/api/v2/status")

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -6,7 +6,7 @@ from assertpy import assert_that
 from sentry_sdk.types import Event
 
 from podex import __version__
-from podex.config import Settings
+from podex.config import ObservabilitySettings, RateLimitSettings, Settings
 from podex.main import create_app
 from podex.observability import init_sentry, scrub_event
 from podex.scheduler_runner import main as scheduler_main
@@ -14,7 +14,7 @@ from podex.scheduler_runner import main as scheduler_main
 
 def test_init_sentry_noops_without_dsn() -> None:
     """The SDK stays fully disabled when no DSN is configured."""
-    settings = Settings(sentry_dsn="")
+    settings = Settings(observability=ObservabilitySettings(sentry_dsn=""))
     with patch("podex.observability.sentry_sdk.init") as mock_init:
         result = init_sentry(settings)
     assert_that(result).is_false()
@@ -24,8 +24,10 @@ def test_init_sentry_noops_without_dsn() -> None:
 def test_init_sentry_initializes_with_dsn() -> None:
     """A configured DSN initializes the SDK with environment and release."""
     settings = Settings(
-        sentry_dsn="https://key@sentry.example/1",
-        sentry_environment="staging",
+        observability=ObservabilitySettings(
+            sentry_dsn="https://key@sentry.example/1",
+            sentry_environment="staging",
+        ),
     )
     with patch("podex.observability.sentry_sdk.init") as mock_init:
         result = init_sentry(settings)
@@ -42,8 +44,8 @@ def test_init_sentry_initializes_with_dsn() -> None:
 def test_init_sentry_defaults_keep_sdk_disabled() -> None:
     """Default settings carry an empty DSN so Sentry never activates."""
     settings = Settings()
-    assert_that(settings.sentry_dsn).is_empty()
-    assert_that(settings.sentry_environment).is_equal_to("production")
+    assert_that(settings.observability.sentry_dsn).is_empty()
+    assert_that(settings.observability.sentry_environment).is_equal_to("production")
 
 
 def test_scrub_event_redacts_emails_in_message() -> None:
@@ -100,7 +102,7 @@ def test_scrub_event_leaves_clean_events_untouched() -> None:
 
 def test_create_app_initializes_sentry() -> None:
     """The API app factory initializes Sentry with the resolved settings."""
-    settings = Settings(rate_limit_enabled=False)
+    settings = Settings(rate_limit=RateLimitSettings(enabled=False))
     with patch("podex.main.init_sentry") as mock_init:
         create_app(settings)
     mock_init.assert_called_once_with(settings)

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from podex.api.deps import get_app_cache
-from podex.config import Settings
+from podex.config import Settings, StatsCacheSettings
 from podex.database import get_db
 from podex.main import create_app
 from podex.models import Episode, Media, MediaType, Mention, Podcast
@@ -169,13 +169,13 @@ def test_stats_endpoint_honors_settings_from_create_app(
 ) -> None:
     """``create_app(settings=...)`` reaches the ``/api/v2/stats`` handler.
 
-    Explicitly building the app with ``stats_cache_ttl_seconds=0`` and no
+    Explicitly building the app with ``settings.stats_cache.ttl_seconds=0`` and no
     other override must produce a response that bypasses the cache — i.e.
     each call recomputes and no entry lands in ``app.state.cache``. If the
     dependency instead resolved to the cached global settings, the default
     30-second TTL would apply and this test would fail.
     """
-    settings = Settings(stats_cache_ttl_seconds=0)
+    settings = Settings(stats_cache=StatsCacheSettings(ttl_seconds=0))
     app = create_app(settings=settings)
 
     def override_get_db() -> Iterator[Session]:

--- a/backend/tests/test_transcript_artifacts.py
+++ b/backend/tests/test_transcript_artifacts.py
@@ -9,7 +9,7 @@ from assertpy import assert_that
 from cryptography.fernet import Fernet
 from sqlalchemy.orm import Session
 
-from podex.config import Settings
+from podex.config import Settings, TranscriptStorageSettings
 from podex.models import (
     Episode,
     Podcast,
@@ -185,8 +185,10 @@ def test_build_artifact_store_selects_encrypted_filesystem_by_default(
     """Verify local deployments retain the encrypted filesystem adapter."""
     store = build_transcript_artifact_store(
         settings=Settings(
-            transcript_artifact_storage_path=tmp_path,
-            transcript_artifact_encryption_key=Fernet.generate_key().decode("ascii"),
+            transcripts=TranscriptStorageSettings(
+                storage_path=tmp_path,
+                encryption_key=Fernet.generate_key().decode("ascii"),
+            ),
         ),
     )
 
@@ -205,11 +207,11 @@ def test_build_artifact_store_selects_s3_backend(
 
     store = build_transcript_artifact_store(
         settings=Settings(
-            transcript_artifact_storage_backend=(
-                TranscriptArtifactStorageBackend.ENCRYPTED_S3.value
+            transcripts=TranscriptStorageSettings(
+                storage_backend=TranscriptArtifactStorageBackend.ENCRYPTED_S3.value,
+                encryption_key=Fernet.generate_key().decode("ascii"),
+                s3_bucket="private-transcripts",
             ),
-            transcript_artifact_encryption_key=Fernet.generate_key().decode("ascii"),
-            transcript_artifact_s3_bucket="private-transcripts",
         ),
     )
 

--- a/backend/tests/test_transcript_artifacts_r2_smoke.py
+++ b/backend/tests/test_transcript_artifacts_r2_smoke.py
@@ -5,10 +5,10 @@ bucket; it is skipped entirely by default and therefore never runs in CI
 and never affects coverage. Arm it with:
 
     PODEX_R2_SMOKE=1 \
-    PODEX_TRANSCRIPT_ARTIFACT_S3_BUCKET=<staging-bucket> \
-    PODEX_TRANSCRIPT_ARTIFACT_S3_ENDPOINT_URL=<R2 S3 API endpoint> \
-    PODEX_TRANSCRIPT_ARTIFACT_S3_ACCESS_KEY_ID=<token-key-id> \
-    PODEX_TRANSCRIPT_ARTIFACT_S3_SECRET_ACCESS_KEY=<token-secret> \
+    PODEX_TRANSCRIPTS__S3_BUCKET=<staging-bucket> \
+    PODEX_TRANSCRIPTS__S3_ENDPOINT_URL=<R2 S3 API endpoint> \
+    PODEX_TRANSCRIPTS__S3_ACCESS_KEY_ID=<token-key-id> \
+    PODEX_TRANSCRIPTS__S3_SECRET_ACCESS_KEY=<token-secret> \
     uv run pytest tests/test_transcript_artifacts_r2_smoke.py
 
 See the r2 runbook in lgtm-hq/podex-ops (runbooks/r2.md) for the full
@@ -31,10 +31,10 @@ from podex.services.transcript_artifacts import (
 )
 
 _REQUIRED_ENV_VARS: tuple[str, ...] = (
-    "PODEX_TRANSCRIPT_ARTIFACT_S3_BUCKET",
-    "PODEX_TRANSCRIPT_ARTIFACT_S3_ENDPOINT_URL",
-    "PODEX_TRANSCRIPT_ARTIFACT_S3_ACCESS_KEY_ID",
-    "PODEX_TRANSCRIPT_ARTIFACT_S3_SECRET_ACCESS_KEY",
+    "PODEX_TRANSCRIPTS__S3_BUCKET",
+    "PODEX_TRANSCRIPTS__S3_ENDPOINT_URL",
+    "PODEX_TRANSCRIPTS__S3_ACCESS_KEY_ID",
+    "PODEX_TRANSCRIPTS__S3_SECRET_ACCESS_KEY",
 )
 
 
@@ -66,15 +66,15 @@ def r2_store_fixture() -> EncryptedS3TranscriptArtifactStore:
         Encrypted S3-compatible store configured for the staging bucket.
     """
     return EncryptedS3TranscriptArtifactStore(
-        bucket=os.environ["PODEX_TRANSCRIPT_ARTIFACT_S3_BUCKET"],
+        bucket=os.environ["PODEX_TRANSCRIPTS__S3_BUCKET"],
         encryption_key=os.environ.get(
-            "PODEX_TRANSCRIPT_ARTIFACT_ENCRYPTION_KEY",
+            "PODEX_TRANSCRIPTS__ENCRYPTION_KEY",
             Fernet.generate_key().decode("ascii"),
         ),
-        endpoint_url=os.environ["PODEX_TRANSCRIPT_ARTIFACT_S3_ENDPOINT_URL"],
-        region_name=os.environ.get("PODEX_TRANSCRIPT_ARTIFACT_S3_REGION_NAME", "auto"),
-        access_key_id=os.environ["PODEX_TRANSCRIPT_ARTIFACT_S3_ACCESS_KEY_ID"],
-        secret_access_key=os.environ["PODEX_TRANSCRIPT_ARTIFACT_S3_SECRET_ACCESS_KEY"],
+        endpoint_url=os.environ["PODEX_TRANSCRIPTS__S3_ENDPOINT_URL"],
+        region_name=os.environ.get("PODEX_TRANSCRIPTS__S3_REGION_NAME", "auto"),
+        access_key_id=os.environ["PODEX_TRANSCRIPTS__S3_ACCESS_KEY_ID"],
+        secret_access_key=os.environ["PODEX_TRANSCRIPTS__S3_SECRET_ACCESS_KEY"],
     )
 
 

--- a/backend/tests/test_workos_auth.py
+++ b/backend/tests/test_workos_auth.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from podex.api.deps import get_app_settings
 from podex.api.v2 import auth as v2_auth_api
-from podex.config import Settings
+from podex.config import AuthSettings, Settings
 from podex.models import AccountUser, UserSession
 from podex.services.workos_auth import (
     WORKOS_AUTHENTICATE_URL,
@@ -44,10 +44,12 @@ def _workos_settings(*, secure_cookies: bool = True) -> Settings:
         Settings enabling the WorkOS feature.
     """
     return Settings(
-        workos_client_id="client_123",
-        workos_api_key="sk_test_456",
-        workos_redirect_uri="https://app.example.com/api/v2/auth/callback",
-        auth_session_cookie_secure=secure_cookies,
+        auth=AuthSettings(
+            workos_client_id="client_123",
+            workos_api_key="sk_test_456",
+            workos_redirect_uri="https://app.example.com/api/v2/auth/callback",
+            session_cookie_secure=secure_cookies,
+        ),
     )
 
 
@@ -98,12 +100,16 @@ def _state_cookie(response: httpx.Response) -> str:
 
 def test_workos_enabled_requires_all_three_settings() -> None:
     """The feature stays off unless every WorkOS credential is present."""
-    assert_that(Settings().workos_enabled).is_false()
-    assert_that(Settings(workos_client_id="client_123").workos_enabled).is_false()
+    assert_that(Settings().auth.workos_enabled).is_false()
     assert_that(
-        Settings(workos_client_id="client_123", workos_api_key="sk").workos_enabled,
+        Settings(auth=AuthSettings(workos_client_id="client_123")).auth.workos_enabled,
     ).is_false()
-    assert_that(_workos_settings().workos_enabled).is_true()
+    assert_that(
+        Settings(
+            auth=AuthSettings(workos_client_id="client_123", workos_api_key="sk"),
+        ).auth.workos_enabled,
+    ).is_false()
+    assert_that(_workos_settings().auth.workos_enabled).is_true()
 
 
 def test_build_workos_auth_client_requires_configuration() -> None:

--- a/docs/staging-deployment.md
+++ b/docs/staging-deployment.md
@@ -31,7 +31,7 @@ the stack will not start without `.env.staging`).
 | `PODEX_CORS_ORIGINS` | `api` | Allowed browser origins (JSON list) |
 | `API_PORT` / `FRONTEND_PORT` | compose | Host ports published for `api` / `frontend` |
 | `PUBLIC_API_URL` | `frontend` (build arg) | Base URL for SSR API fetches |
-| `TRANSCRIPT_*`, `MEILI_*`, `API_KEY`, `SMTP_*` | *(future)* | Reserved for pipeline/auth; unused on main |
+| `PODEX_TRANSCRIPTS__*`, `MEILI_*`, `API_KEY`, `PODEX_AUTH__SMTP_*` | *(future)* | Reserved for pipeline/auth; unused on main |
 
 `.env.staging` is git-ignored; never commit real secrets.
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4713,7 +4713,7 @@
     },
     "/api/v2/stats": {
       "get": {
-        "description": "Return catalog-wide counts and a small top-media-types breakdown.\n\nResponses are cached in-process for\n``PODEX_STATS_CACHE_TTL_SECONDS`` seconds (configurable via\n:class:`~podex.config.Settings`); set the TTL to ``0`` to bypass the\ncache entirely.",
+        "description": "Return catalog-wide counts and a small top-media-types breakdown.\n\nResponses are cached in-process for\n``PODEX_STATS_CACHE__TTL_SECONDS`` seconds (configurable via\n:class:`~podex.config.Settings`); set the TTL to ``0`` to bypass the\ncache entirely.",
         "operationId": "get_catalog_stats_api_v2_stats_get",
         "responses": {
           "200": {

--- a/frontend/src/lib/types.gen.ts
+++ b/frontend/src/lib/types.gen.ts
@@ -868,7 +868,7 @@ export interface paths {
          * @description Return catalog-wide counts and a small top-media-types breakdown.
          *
          *     Responses are cached in-process for
-         *     ``PODEX_STATS_CACHE_TTL_SECONDS`` seconds (configurable via
+         *     ``PODEX_STATS_CACHE__TTL_SECONDS`` seconds (configurable via
          *     :class:`~podex.config.Settings`); set the TTL to ``0`` to bypass the
          *     cache entirely.
          */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(config)!: nest rate_limit through observability settings domains
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [x] `!` in title or `BREAKING CHANGE:` footer included

BREAKING CHANGE: Remaining Settings domains move to nested env grammar
(`PODEX_<DOMAIN>__<FIELD>`). Flat names such as `PODEX_RATE_LIMIT_ENABLED`,
`PODEX_STATS_CACHE_TTL_SECONDS`, `PODEX_TRANSCRIPT_ARTIFACT_*`,
`PODEX_SMTP_*` / `PODEX_WORKOS_*`, `PODEX_PAID_*` / `PODEX_PADDLE_*`, and
`PODEX_SENTRY_*` are ignored. Sync podex-ops templates before provisioning.

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Batched domain migrations for the nested-settings epic, following the #353 /
ADR 0001 exemplar:

| Domain | Sub-model | Env prefix |
| --- | --- | --- |
| rate limit | `settings.rate_limit` | `PODEX_RATE_LIMIT__*` |
| stats cache | `settings.stats_cache` | `PODEX_STATS_CACHE__*` |
| transcripts / R2 | `settings.transcripts` | `PODEX_TRANSCRIPTS__*` |
| auth (magic link + WorkOS + SMTP) | `settings.auth` | `PODEX_AUTH__*` |
| billing (paid tier + Paddle) | `settings.billing` | `PODEX_BILLING__*` |
| observability (Sentry) | `settings.observability` | `PODEX_OBSERVABILITY__*` |

Hard cutover per domain — no aliases. Call sites, tests, staging env example,
and the stats OpenAPI docstring updated. Defaults / Field validators / rationale
comments preserved field-for-field.

Left top-level (out of this batch): `ops_*`, `scheduler_*`, and app basics.
`/metrics` gating remains on `settings.ops_api_key` (not an observability field
today).

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #354
- Closes #355
- Closes #356
- Closes #357
- Closes #358
- Closes #359

## Details

Verification: `uv run pytest` → 493 passed, 1 skipped; lintro clean on touched
paths. Per-domain tests assert nested env load and that old flat env names are
ignored.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated application settings to use structured, namespaced configuration for authentication, billing, rate limiting, transcript storage, statistics caching, and observability.
  * Updated staging environment examples to use the new configuration variable names.

* **Documentation**
  * Refreshed staging deployment and statistics caching documentation with the latest environment variable names.

* **Bug Fixes**
  * Improved consistency when reading authentication, billing, webhook, WorkOS, Sentry, and caching settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->