### PR TITLE
chore(config): final nested-settings sweep for env examples and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ PODEX_BILLING__PADDLE_CHECKOUT_URL=
 
 # -- Observability ------------------------------------------------------------
 PODEX_OBSERVABILITY__SENTRY_DSN=
-PODEX_OBSERVABILITY__SENTRY_ENVIRONMENT=production
+PODEX_OBSERVABILITY__SENTRY_ENVIRONMENT=development
 
 # -- Ops top-level ------------------------------------------------------------
 PODEX_OPS_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,32 +1,17 @@
-# .env.staging.example - copy to .env.staging before deploying.
-# This file is tracked in git and contains placeholder/default values only.
-# Real secrets must never be committed.
-#
-# Used by: docker compose -f docker-compose.staging.yml --env-file .env.staging
-# Loaded into containers via env_file in docker-compose.staging.yml.
-
-# -- Compose and frontend -----------------------------------------------------
-# POSTGRES_PASSWORD is read by the db service. PODEX_DATABASE__URL below must
-# use the same password in the URL-encoded password segment.
-POSTGRES_PASSWORD=change-me-postgres-password
-API_PORT=8000
-FRONTEND_PORT=4321
-# Use the internal Docker service name so Astro SSR fetches stay on the network.
-PUBLIC_API_URL=http://api:8000/api/v2
+# .env.example - copy to .env for local backend overrides.
+# This file is the canonical inventory of every PODEX_ settings field.
+# Keep names nested as PODEX_<DOMAIN>__<FIELD> for domain settings.
 
 # -- App top-level ------------------------------------------------------------
 PODEX_APP_NAME=podex
-PODEX_ENVIRONMENT=staging
+PODEX_ENVIRONMENT=development
 PODEX_DEBUG=false
 PODEX_API_V2_PREFIX=/api/v2
-# JSON list; must include the browser origin (scheme + host + port).
 PODEX_CORS_ORIGINS=["http://localhost:4321"]
 PODEX_PUBLIC_WEB_URL=http://localhost:4321
 
 # -- Database -----------------------------------------------------------------
-# URL-encode reserved characters in the password segment only:
-#   python -c "from urllib.parse import quote; print(quote('your-password', safe=''))"
-PODEX_DATABASE__URL=postgresql://podex:change-me-postgres-password@db:5432/podex
+PODEX_DATABASE__URL=sqlite:///./podex.db
 PODEX_DATABASE__POOL_SIZE=5
 PODEX_DATABASE__MAX_OVERFLOW=5
 PODEX_DATABASE__POOL_RECYCLE_SECONDS=300
@@ -43,27 +28,25 @@ PODEX_RATE_LIMIT__REDIS_PREFIX=podex:ratelimit
 PODEX_STATS_CACHE__TTL_SECONDS=30.0
 
 # -- Transcripts --------------------------------------------------------------
-# Generate a Fernet key with:
-#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-PODEX_TRANSCRIPTS__STORAGE_BACKEND=encrypted_s3
+PODEX_TRANSCRIPTS__STORAGE_BACKEND=encrypted_filesystem
 PODEX_TRANSCRIPTS__STORAGE_PATH=./data/transcript-artifacts
-PODEX_TRANSCRIPTS__ENCRYPTION_KEY=change-me-fernet-key
-PODEX_TRANSCRIPTS__S3_BUCKET=change-me-private-transcript-bucket
-PODEX_TRANSCRIPTS__S3_ENDPOINT_URL=https://change-me-r2-account.r2.cloudflarestorage.com
-PODEX_TRANSCRIPTS__S3_REGION_NAME=auto
-PODEX_TRANSCRIPTS__S3_ACCESS_KEY_ID=change-me-r2-access-key-id
-PODEX_TRANSCRIPTS__S3_SECRET_ACCESS_KEY=change-me-r2-secret-access-key
+PODEX_TRANSCRIPTS__ENCRYPTION_KEY=
+PODEX_TRANSCRIPTS__S3_BUCKET=
+PODEX_TRANSCRIPTS__S3_ENDPOINT_URL=
+PODEX_TRANSCRIPTS__S3_REGION_NAME=
+PODEX_TRANSCRIPTS__S3_ACCESS_KEY_ID=
+PODEX_TRANSCRIPTS__S3_SECRET_ACCESS_KEY=
 
 # -- Auth ---------------------------------------------------------------------
 PODEX_AUTH__MAGIC_LINK_TTL_MINUTES=15
 PODEX_AUTH__SESSION_TTL_DAYS=30
 PODEX_AUTH__SESSION_COOKIE_NAME=podex_session
 PODEX_AUTH__SESSION_COOKIE_SECURE=true
-PODEX_AUTH__SMTP_HOST=change-me-smtp-host
+PODEX_AUTH__SMTP_HOST=
 PODEX_AUTH__SMTP_PORT=587
-PODEX_AUTH__SMTP_USERNAME=change-me-smtp-user
-PODEX_AUTH__SMTP_PASSWORD=change-me-smtp-password
-PODEX_AUTH__SMTP_FROM_EMAIL=signin@example.com
+PODEX_AUTH__SMTP_USERNAME=
+PODEX_AUTH__SMTP_PASSWORD=
+PODEX_AUTH__SMTP_FROM_EMAIL=
 PODEX_AUTH__SMTP_STARTTLS=true
 PODEX_AUTH__WORKOS_CLIENT_ID=
 PODEX_AUTH__WORKOS_API_KEY=
@@ -83,7 +66,7 @@ PODEX_BILLING__PADDLE_CHECKOUT_URL=
 
 # -- Observability ------------------------------------------------------------
 PODEX_OBSERVABILITY__SENTRY_DSN=
-PODEX_OBSERVABILITY__SENTRY_ENVIRONMENT=staging
+PODEX_OBSERVABILITY__SENTRY_ENVIRONMENT=production
 
 # -- Ops top-level ------------------------------------------------------------
 PODEX_OPS_API_KEY=

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -99,27 +99,91 @@ def test_complete_nested_settings_load_from_env_mapping(
     settings = Settings()
 
     assert_that(settings.app_name).is_equal_to("podex-full")
+    assert_that(settings.environment).is_equal_to("staging")
+    assert_that(settings.debug).is_true()
+    assert_that(settings.api_v2_prefix).is_equal_to("/api/test")
+    assert_that(settings.cors_origins).is_equal_to(["https://app.example.com"])
     assert_that(settings.public_web_url).is_equal_to("https://app.example.com")
+
     assert_that(settings.database.url).is_equal_to(
         "postgresql+psycopg://podex@db/podex",
     )
     assert_that(settings.database.pool_size).is_equal_to(9)
+    assert_that(settings.database.max_overflow).is_equal_to(3)
+    assert_that(settings.database.pool_recycle_seconds).is_equal_to(240)
+
     assert_that(settings.rate_limit.enabled).is_false()
+    assert_that(settings.rate_limit.max_requests).is_equal_to(42)
+    assert_that(settings.rate_limit.window_seconds).is_equal_to(12.5)
     assert_that(settings.rate_limit.exempt_paths).is_equal_to(
         ["/health", "/metrics"],
     )
+    assert_that(settings.rate_limit.redis_url).is_equal_to("redis://redis:6379/2")
+    assert_that(settings.rate_limit.redis_prefix).is_equal_to("podex:full")
+
     assert_that(settings.stats_cache.ttl_seconds).is_equal_to(7.5)
+
+    assert_that(settings.transcripts.storage_backend).is_equal_to("encrypted_s3")
     assert_that(settings.transcripts.storage_path).is_equal_to(
         Path("./data/full-model-transcripts"),
     )
+    assert_that(settings.transcripts.encryption_key).is_equal_to("fernet-key")
     assert_that(settings.transcripts.s3_bucket).is_equal_to("full-transcripts")
+    assert_that(settings.transcripts.s3_endpoint_url).is_equal_to(
+        "https://r2.example",
+    )
+    assert_that(settings.transcripts.s3_region_name).is_equal_to("auto")
+    assert_that(settings.transcripts.s3_access_key_id).is_equal_to("access-key-id")
+    assert_that(settings.transcripts.s3_secret_access_key).is_equal_to(
+        "secret-access-key",
+    )
+
+    assert_that(settings.auth.magic_link_ttl_minutes).is_equal_to(20)
+    assert_that(settings.auth.session_ttl_days).is_equal_to(60)
+    assert_that(settings.auth.session_cookie_name).is_equal_to(
+        "podex_full_session",
+    )
+    assert_that(settings.auth.session_cookie_secure).is_false()
+    assert_that(settings.auth.smtp_host).is_equal_to("smtp.example.com")
     assert_that(settings.auth.smtp_port).is_equal_to(2525)
+    assert_that(settings.auth.smtp_username).is_equal_to("smtp-user")
+    assert_that(settings.auth.smtp_password).is_equal_to("smtp-password")
+    assert_that(settings.auth.smtp_from_email).is_equal_to("signin@example.com")
+    assert_that(settings.auth.smtp_starttls).is_false()
+    assert_that(settings.auth.workos_client_id).is_equal_to("client_full")
+    assert_that(settings.auth.workos_api_key).is_equal_to("sk_full")
+    assert_that(settings.auth.workos_redirect_uri).is_equal_to(
+        "https://app.example.com/callback",
+    )
     assert_that(settings.auth.workos_enabled).is_true()
+
+    assert_that(settings.billing.paid_tier_enabled).is_true()
+    assert_that(settings.billing.paid_tier_enforced).is_true()
     assert_that(settings.billing.paid_api_requests_per_month).is_equal_to(1500)
+    assert_that(settings.billing.paid_llm_requests_per_month).is_equal_to(75)
+    assert_that(settings.billing.provider_name).is_equal_to("paddle")
+    assert_that(settings.billing.checkout_url).is_equal_to(
+        "https://checkout.example.com",
+    )
+    assert_that(settings.billing.paddle_api_key).is_equal_to("pdl_full")
+    assert_that(settings.billing.paddle_webhook_secret).is_equal_to("whsec_full")
+    assert_that(settings.billing.paddle_price_id).is_equal_to("pri_full")
+    assert_that(settings.billing.paddle_checkout_url).is_equal_to(
+        "https://buy.example.com",
+    )
     assert_that(settings.billing.paddle_checkout_enabled).is_true()
+
+    assert_that(settings.observability.sentry_dsn).is_equal_to(
+        "https://key@sentry.example/1",
+    )
     assert_that(settings.observability.sentry_environment).is_equal_to("staging")
+
+    assert_that(settings.ops_api_key).is_equal_to("ops-key")
     assert_that(settings.ops_review_pending_alert_threshold).is_equal_to(12)
+    assert_that(settings.ops_alert_delivery_pending_threshold).is_equal_to(6)
+    assert_that(settings.scheduler_tick_seconds).is_equal_to(15)
     assert_that(settings.scheduler_digest_interval_minutes).is_equal_to(120)
+    assert_that(settings.scheduler_retention_interval_minutes).is_equal_to(240)
 
 
 def test_database_settings_load_from_nested_env(monkeypatch: MonkeyPatch) -> None:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -31,6 +31,97 @@ def test_default_settings() -> None:
     assert_that(settings.database.url).is_equal_to("sqlite:///./podex.db")
 
 
+def test_complete_nested_settings_load_from_env_mapping(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A complete nested env mapping populates every settings domain."""
+    sample_env = {
+        "PODEX_APP_NAME": "podex-full",
+        "PODEX_ENVIRONMENT": "staging",
+        "PODEX_DEBUG": "true",
+        "PODEX_API_V2_PREFIX": "/api/test",
+        "PODEX_CORS_ORIGINS": '["https://app.example.com"]',
+        "PODEX_PUBLIC_WEB_URL": "https://app.example.com",
+        "PODEX_DATABASE__URL": "postgresql+psycopg://podex@db/podex",
+        "PODEX_DATABASE__POOL_SIZE": "9",
+        "PODEX_DATABASE__MAX_OVERFLOW": "3",
+        "PODEX_DATABASE__POOL_RECYCLE_SECONDS": "240",
+        "PODEX_RATE_LIMIT__ENABLED": "false",
+        "PODEX_RATE_LIMIT__MAX_REQUESTS": "42",
+        "PODEX_RATE_LIMIT__WINDOW_SECONDS": "12.5",
+        "PODEX_RATE_LIMIT__EXEMPT_PATHS": '["/health","/metrics"]',
+        "PODEX_RATE_LIMIT__REDIS_URL": "redis://redis:6379/2",
+        "PODEX_RATE_LIMIT__REDIS_PREFIX": "podex:full",
+        "PODEX_STATS_CACHE__TTL_SECONDS": "7.5",
+        "PODEX_TRANSCRIPTS__STORAGE_BACKEND": "encrypted_s3",
+        "PODEX_TRANSCRIPTS__STORAGE_PATH": "./data/full-model-transcripts",
+        "PODEX_TRANSCRIPTS__ENCRYPTION_KEY": "fernet-key",
+        "PODEX_TRANSCRIPTS__S3_BUCKET": "full-transcripts",
+        "PODEX_TRANSCRIPTS__S3_ENDPOINT_URL": "https://r2.example",
+        "PODEX_TRANSCRIPTS__S3_REGION_NAME": "auto",
+        "PODEX_TRANSCRIPTS__S3_ACCESS_KEY_ID": "access-key-id",
+        "PODEX_TRANSCRIPTS__S3_SECRET_ACCESS_KEY": "secret-access-key",
+        "PODEX_AUTH__MAGIC_LINK_TTL_MINUTES": "20",
+        "PODEX_AUTH__SESSION_TTL_DAYS": "60",
+        "PODEX_AUTH__SESSION_COOKIE_NAME": "podex_full_session",
+        "PODEX_AUTH__SESSION_COOKIE_SECURE": "false",
+        "PODEX_AUTH__SMTP_HOST": "smtp.example.com",
+        "PODEX_AUTH__SMTP_PORT": "2525",
+        "PODEX_AUTH__SMTP_USERNAME": "smtp-user",
+        "PODEX_AUTH__SMTP_PASSWORD": "smtp-password",
+        "PODEX_AUTH__SMTP_FROM_EMAIL": "signin@example.com",
+        "PODEX_AUTH__SMTP_STARTTLS": "false",
+        "PODEX_AUTH__WORKOS_CLIENT_ID": "client_full",
+        "PODEX_AUTH__WORKOS_API_KEY": "sk_full",
+        "PODEX_AUTH__WORKOS_REDIRECT_URI": "https://app.example.com/callback",
+        "PODEX_BILLING__PAID_TIER_ENABLED": "true",
+        "PODEX_BILLING__PAID_TIER_ENFORCED": "true",
+        "PODEX_BILLING__PAID_API_REQUESTS_PER_MONTH": "1500",
+        "PODEX_BILLING__PAID_LLM_REQUESTS_PER_MONTH": "75",
+        "PODEX_BILLING__PROVIDER_NAME": "paddle",
+        "PODEX_BILLING__CHECKOUT_URL": "https://checkout.example.com",
+        "PODEX_BILLING__PADDLE_API_KEY": "pdl_full",
+        "PODEX_BILLING__PADDLE_WEBHOOK_SECRET": "whsec_full",
+        "PODEX_BILLING__PADDLE_PRICE_ID": "pri_full",
+        "PODEX_BILLING__PADDLE_CHECKOUT_URL": "https://buy.example.com",
+        "PODEX_OBSERVABILITY__SENTRY_DSN": "https://key@sentry.example/1",
+        "PODEX_OBSERVABILITY__SENTRY_ENVIRONMENT": "staging",
+        "PODEX_OPS_API_KEY": "ops-key",
+        "PODEX_OPS_REVIEW_PENDING_ALERT_THRESHOLD": "12",
+        "PODEX_OPS_ALERT_DELIVERY_PENDING_THRESHOLD": "6",
+        "PODEX_SCHEDULER_TICK_SECONDS": "15",
+        "PODEX_SCHEDULER_DIGEST_INTERVAL_MINUTES": "120",
+        "PODEX_SCHEDULER_RETENTION_INTERVAL_MINUTES": "240",
+    }
+    for name, value in sample_env.items():
+        monkeypatch.setenv(name, value)
+
+    settings = Settings()
+
+    assert_that(settings.app_name).is_equal_to("podex-full")
+    assert_that(settings.public_web_url).is_equal_to("https://app.example.com")
+    assert_that(settings.database.url).is_equal_to(
+        "postgresql+psycopg://podex@db/podex",
+    )
+    assert_that(settings.database.pool_size).is_equal_to(9)
+    assert_that(settings.rate_limit.enabled).is_false()
+    assert_that(settings.rate_limit.exempt_paths).is_equal_to(
+        ["/health", "/metrics"],
+    )
+    assert_that(settings.stats_cache.ttl_seconds).is_equal_to(7.5)
+    assert_that(settings.transcripts.storage_path).is_equal_to(
+        Path("./data/full-model-transcripts"),
+    )
+    assert_that(settings.transcripts.s3_bucket).is_equal_to("full-transcripts")
+    assert_that(settings.auth.smtp_port).is_equal_to(2525)
+    assert_that(settings.auth.workos_enabled).is_true()
+    assert_that(settings.billing.paid_api_requests_per_month).is_equal_to(1500)
+    assert_that(settings.billing.paddle_checkout_enabled).is_true()
+    assert_that(settings.observability.sentry_environment).is_equal_to("staging")
+    assert_that(settings.ops_review_pending_alert_threshold).is_equal_to(12)
+    assert_that(settings.scheduler_digest_interval_minutes).is_equal_to(120)
+
+
 def test_database_settings_load_from_nested_env(monkeypatch: MonkeyPatch) -> None:
     """Nested ``PODEX_DATABASE__*`` env vars populate ``settings.database``."""
     monkeypatch.setenv(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -60,7 +60,7 @@ def test_complete_nested_settings_load_from_env_mapping(
         "PODEX_TRANSCRIPTS__S3_ENDPOINT_URL": "https://r2.example",
         "PODEX_TRANSCRIPTS__S3_REGION_NAME": "auto",
         "PODEX_TRANSCRIPTS__S3_ACCESS_KEY_ID": "access-key-id",
-        "PODEX_TRANSCRIPTS__S3_SECRET_ACCESS_KEY": "secret-access-key",
+        "PODEX_TRANSCRIPTS__S3_SECRET_ACCESS_KEY": "secret-access-key",  # nosec B105
         "PODEX_AUTH__MAGIC_LINK_TTL_MINUTES": "20",
         "PODEX_AUTH__SESSION_TTL_DAYS": "60",
         "PODEX_AUTH__SESSION_COOKIE_NAME": "podex_full_session",
@@ -68,7 +68,7 @@ def test_complete_nested_settings_load_from_env_mapping(
         "PODEX_AUTH__SMTP_HOST": "smtp.example.com",
         "PODEX_AUTH__SMTP_PORT": "2525",
         "PODEX_AUTH__SMTP_USERNAME": "smtp-user",
-        "PODEX_AUTH__SMTP_PASSWORD": "smtp-password",
+        "PODEX_AUTH__SMTP_PASSWORD": "smtp-password",  # nosec B105
         "PODEX_AUTH__SMTP_FROM_EMAIL": "signin@example.com",
         "PODEX_AUTH__SMTP_STARTTLS": "false",
         "PODEX_AUTH__WORKOS_CLIENT_ID": "client_full",
@@ -81,7 +81,7 @@ def test_complete_nested_settings_load_from_env_mapping(
         "PODEX_BILLING__PROVIDER_NAME": "paddle",
         "PODEX_BILLING__CHECKOUT_URL": "https://checkout.example.com",
         "PODEX_BILLING__PADDLE_API_KEY": "pdl_full",
-        "PODEX_BILLING__PADDLE_WEBHOOK_SECRET": "whsec_full",
+        "PODEX_BILLING__PADDLE_WEBHOOK_SECRET": "whsec_full",  # nosec B105
         "PODEX_BILLING__PADDLE_PRICE_ID": "pri_full",
         "PODEX_BILLING__PADDLE_CHECKOUT_URL": "https://buy.example.com",
         "PODEX_OBSERVABILITY__SENTRY_DSN": "https://key@sentry.example/1",

--- a/docs/staging-deployment.md
+++ b/docs/staging-deployment.md
@@ -20,18 +20,25 @@ cp .env.staging.example .env.staging
 
 Edit `.env.staging` and replace every `change-me-*` placeholder. The root
 `.env.staging.example` is the single source of truth for staging secrets and
-service wiring. Compose loads it into containers via `env_file` (required —
-the stack will not start without `.env.staging`).
+service wiring; the root `.env.example` is the complete inventory of backend
+`PODEX_` settings names. Compose loads `.env.staging` into containers via
+`env_file` (required — the stack will not start without `.env.staging`).
 
-| Variable | Read by | Purpose |
+| Variable/group | Read by | Purpose |
 | --- | --- | --- |
 | `POSTGRES_PASSWORD` | `db` | Postgres password |
-| `PODEX_DATABASE__URL` | `api` (Alembic + runtime) | SQLAlchemy connection string |
-| `PODEX_ENVIRONMENT` | `api` | Runtime environment label |
-| `PODEX_CORS_ORIGINS` | `api` | Allowed browser origins (JSON list) |
 | `API_PORT` / `FRONTEND_PORT` | compose | Host ports published for `api` / `frontend` |
 | `PUBLIC_API_URL` | `frontend` (build arg) | Base URL for SSR API fetches |
-| `PODEX_TRANSCRIPTS__*`, `MEILI_*`, `API_KEY`, `PODEX_AUTH__SMTP_*` | *(future)* | Reserved for pipeline/auth; unused on main |
+| `PODEX_APP_NAME`, `PODEX_ENVIRONMENT`, `PODEX_DEBUG`, `PODEX_API_V2_PREFIX`, `PODEX_CORS_ORIGINS`, `PODEX_PUBLIC_WEB_URL` | `api`, `scheduler` | Top-level app settings |
+| `PODEX_DATABASE__*` | `api`, `scheduler` (Alembic + runtime) | SQLAlchemy connection string and pool tuning |
+| `PODEX_RATE_LIMIT__*` | `api` | HTTP rate limiting and optional Redis store |
+| `PODEX_STATS_CACHE__*` | `api` | Aggregate/stats response cache |
+| `PODEX_TRANSCRIPTS__*` | `api`, `scheduler` | Encrypted transcript artifact storage |
+| `PODEX_AUTH__*` | `api` | Magic-link SMTP and WorkOS AuthKit settings |
+| `PODEX_BILLING__*` | `api` | Paid tier, Paddle checkout, and webhooks |
+| `PODEX_OBSERVABILITY__*` | `api`, `scheduler` | Sentry error tracking |
+| `PODEX_OPS_*` | `api` | Ops console API gate and alert thresholds |
+| `PODEX_SCHEDULER_*` | `scheduler` | Recurring scheduler intervals |
 
 `.env.staging` is git-ignored; never commit real secrets.
 

--- a/docs/staging-deployment.md
+++ b/docs/staging-deployment.md
@@ -29,16 +29,16 @@ service wiring; the root `.env.example` is the complete inventory of backend
 | `POSTGRES_PASSWORD` | `db` | Postgres password |
 | `API_PORT` / `FRONTEND_PORT` | compose | Host ports published for `api` / `frontend` |
 | `PUBLIC_API_URL` | `frontend` (build arg) | Base URL for SSR API fetches |
-| `PODEX_APP_NAME`, `PODEX_ENVIRONMENT`, `PODEX_DEBUG`, `PODEX_API_V2_PREFIX`, `PODEX_CORS_ORIGINS`, `PODEX_PUBLIC_WEB_URL` | `api`, `scheduler` | Top-level app settings |
-| `PODEX_DATABASE__*` | `api`, `scheduler` (Alembic + runtime) | SQLAlchemy connection string and pool tuning |
+| `PODEX_APP_NAME`, `PODEX_ENVIRONMENT`, `PODEX_DEBUG`, `PODEX_API_V2_PREFIX`, `PODEX_CORS_ORIGINS`, `PODEX_PUBLIC_WEB_URL` | `api` | Top-level app settings |
+| `PODEX_DATABASE__*` | `api` (Alembic + runtime) | SQLAlchemy connection string and pool tuning |
 | `PODEX_RATE_LIMIT__*` | `api` | HTTP rate limiting and optional Redis store |
 | `PODEX_STATS_CACHE__*` | `api` | Aggregate/stats response cache |
-| `PODEX_TRANSCRIPTS__*` | `api`, `scheduler` | Encrypted transcript artifact storage |
+| `PODEX_TRANSCRIPTS__*` | `api` | Encrypted transcript artifact storage |
 | `PODEX_AUTH__*` | `api` | Magic-link SMTP and WorkOS AuthKit settings |
 | `PODEX_BILLING__*` | `api` | Paid tier, Paddle checkout, and webhooks |
-| `PODEX_OBSERVABILITY__*` | `api`, `scheduler` | Sentry error tracking |
+| `PODEX_OBSERVABILITY__*` | `api` | Sentry error tracking |
 | `PODEX_OPS_*` | `api` | Ops console API gate and alert thresholds |
-| `PODEX_SCHEDULER_*` | `scheduler` | Recurring scheduler intervals |
+| `PODEX_SCHEDULER_*` | planned `scheduler` (not in this Compose stack) | Recurring scheduler intervals; unused until a scheduler service is deployed |
 
 `.env.staging` is git-ignored; never commit real secrets.
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -10,7 +10,7 @@
         "@astrojs/react": "^6.0.0",
         "@sentry/browser": "^10.66.0",
         "@tailwindcss/vite": "^4.0.0",
-        "astro": "^7.0.0",
+        "astro": "^7.1.3",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "tailwindcss": "^4.0.0",
@@ -27,6 +27,9 @@
         "vitest": "4.1.10",
       },
     },
+  },
+  "overrides": {
+    "js-yaml": "4.3.0",
   },
   "packages": {
     "@astrojs/check": ["@astrojs/check@0.9.9", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg=="],
@@ -59,7 +62,7 @@
 
     "@astrojs/language-server": ["@astrojs/language-server@2.16.11", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.4", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.71", "volar-service-emmet": "0.0.71", "volar-service-html": "0.0.71", "volar-service-prettier": "0.0.71", "volar-service-typescript": "0.0.71", "volar-service-typescript-twoslash-queries": "0.0.71", "volar-service-yaml": "0.0.71", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "./bin/nodeServer.js" } }, "sha512-sJ/EfnFp0+gurTrkvONtd9qRqmMZLT9bHelfI1SA35CaQVTrRrA74qteOcNT/al1b9Atg3IiH1Jk/qfckyC+fg=="],
 
-    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "satteri": "^0.9.1" } }, "sha512-Lje33Ittd8UQGgbIIWQvhPkj5X5c4b1sZnZWX3JQV/AWpfbuQGxVi2ONt6+ScydcwfR4egilslEWyczMclrJ1g=="],
+    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "satteri": "^0.9.1" } }, "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw=="],
 
     "@astrojs/node": ["@astrojs/node@11.0.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "send": "^1.2.1", "server-destroy": "^1.0.1" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-/ijULxT+A5Cm8wSwWZ2vgqfim1b05D6B8n/a9l6MMA4FCotIH73g7fL7y76XojKXpTe75FVvQH92OxsMqea9kQ=="],
 
@@ -485,7 +488,7 @@
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA=="],
 
-    "astro": ["astro@7.0.7", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.0", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.3", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-swqrKDSI/B83GFroYPZYMFcxqbSe9+tkynu1WDBk3GLgBfV9++qVM4Z+2uFT6uu9A53Q0TROnxLketfMEENuqQ=="],
+    "astro": ["astro@7.1.3", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.1", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.4", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -537,7 +540,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@2.0.1", "", {}, "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w=="],
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
@@ -653,9 +656,17 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "hast-util-from-html": ["hast-util-from-html@2.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.1.0", "hast-util-from-parse5": "^8.0.0", "parse5": "^7.0.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" } }, "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw=="],
+
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
@@ -765,7 +776,7 @@
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
-    "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
+    "neotraverse": ["neotraverse@1.0.1", "", {}, "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w=="],
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 
@@ -802,6 +813,8 @@
     "package-manager-detector": ["package-manager-detector@1.7.0", "", {}, "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ=="],
 
     "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
@@ -965,6 +978,8 @@
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
@@ -1007,6 +1022,8 @@
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
@@ -1045,8 +1062,6 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@redocly/openapi-core/js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
-
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
@@ -1076,6 +1091,8 @@
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@astrojs/react": "^6.0.0",
     "@sentry/browser": "^10.66.0",
     "@tailwindcss/vite": "^4.0.0",
-    "astro": "^7.0.0",
+    "astro": "^7.1.3",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "tailwindcss": "^4.0.0",
@@ -35,5 +35,8 @@
     "happy-dom": "20.10.6",
     "openapi-typescript": "7.13.0",
     "vitest": "4.1.10"
+  },
+  "overrides": {
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(config): final nested-settings sweep for env examples and docs
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Final nested-settings epic sweep after #353–#359:

- Repo-wide audit: no migrated-domain flat `PODEX_*` names remain as live config
  surfaces (only intentional ignore-tests, ADR history, and “not recognized”
  comments)
- Create canonical `.env.example` listing **every** Settings field (grouped by
  domain) — intended as the rename source for lgtm-hq/podex-ops#15
- Regenerate `.env.staging.example` with nested grammar + staging-only extras
- Full-model settings test instantiating every domain from a nested env mapping
  (assertions cover every populated field)
- Staging docs aligned; scheduler env consumers marked planned / not in Compose

CI follow-ups: `# nosec B105` on canned fixture secrets; bump `astro` to
`^7.1.3` and override `js-yaml` to `4.3.0` for GHSA-4g3v-8h47-v7g6 /
GHSA-52cp-r559-cp3m; CodeRabbit notes on Sentry env default and staging docs.

## Audit table (flat → nested / status)

| Old flat env name | Status / replacement |
| --- | --- |
| `PODEX_APP_NAME` … `PODEX_PUBLIC_WEB_URL` | Retained top-level canonical |
| `PODEX_DATABASE_URL` | `PODEX_DATABASE__URL` (test/ADR/comment only) |
| `PODEX_DATABASE_POOL_*` | `PODEX_DATABASE__*` (removed) |
| `PODEX_RATE_LIMIT_*` | `PODEX_RATE_LIMIT__*` (ignore-tests only where retained) |
| `PODEX_STATS_CACHE_TTL_SECONDS` | `PODEX_STATS_CACHE__TTL_SECONDS` |
| `PODEX_TRANSCRIPT_ARTIFACT_*` | `PODEX_TRANSCRIPTS__*` |
| `PODEX_AUTH_*` / `PODEX_SMTP_*` / `PODEX_WORKOS_*` | `PODEX_AUTH__*` |
| `PODEX_PAID_*` / `PODEX_BILLING_*` / `PODEX_PADDLE_*` | `PODEX_BILLING__*` |
| `PODEX_SENTRY_*` | `PODEX_OBSERVABILITY__SENTRY_*` |
| `PODEX_OPS_*` / `PODEX_SCHEDULER_*` | Retained top-level canonical |

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #361

## Details

Verification: `uv run pytest` → 494 passed, 1 skipped; required CI green.
Could not verify lgtm-hq/podex-ops#15 from this token; sync remains an ops gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive environment configuration templates covering application, database, authentication, billing, storage, monitoring, operations, and scheduling settings.
  * Updated the staging deployment guide with the expanded configuration reference and startup requirements.

* **Tests**
  * Added coverage validating that complete environment configuration is loaded correctly across application services.

* **Maintenance**
  * Updated the frontend build tooling and pinned a YAML parser version for consistent installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->