### PR TITLE
ci(release): cap version bumps at minor until 1.0

### DIFF
--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -21,8 +21,10 @@ jobs:
       # yamllint disable-line rule:line-length
       ecosystem-config: '{"python":{"pyproject":"backend/pyproject.toml","init":"backend/src/podex/__init__.py"}}'
       auto-merge: true
-      # Allow MAJOR bumps so the version file stays aligned with auto-tag.
-      max-bump: major
+      # Pre-1.0: clamp breaking changes to a minor bump. Auto-tag reads the
+      # version from the merged release commit, so no desync is possible.
+      # Raise to major deliberately when the project is ready to ship 1.0.
+      max-bump: minor
       # Patch releases auto-merge; minor/major need explicit review.
       auto-merge-patch-only: true
       tooling-ref: '6a96470c698addc35f81b5420e1e4114b35c5a03'  # v0.59.1


### PR DESCRIPTION
## Summary

- Clamp `max-bump` from `major` to `minor` in the version-PR workflow so breaking-change commits (`type!:` / `BREAKING CHANGE:`) bump the minor version while the project is pre-1.0.
- Context: #375 (`refactor(config)!:`) minted v1.0.0 via the previous `max-bump: major`; that release has been purged and will be re-issued as v0.40.0. The project is not ready to signal a stable 1.0.
- No auto-tag desync is possible: `release-auto-tag.yml` uses the default commit version-source, reading the version from the merged `chore(release): version X.Y.Z` commit rather than computing its own bump.
- Raise back to `major` deliberately when 1.0 is an intentional decision.

## Testing

- Workflow-input change only; validated against the reusable workflow's `max-bump` input (lgtm-ci v0.59.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted pre-1.0 release automation to cap breaking changes at minor version bumps.
  * Updated release guidance to reserve major version increases for the 1.0 milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->