### PR TITLE
chore(release): version 0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog][kac], and this project adheres to
 
 ### Security
 
-## [1.0.0] - 2026-07-20
+## [0.40.0] - 2026-07-21
 
 ### Changed
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "podex"
-version = "1.0.0"
+version = "0.40.0"
 description = "Podex backend — podcast media-index API and ingestion pipeline."
 requires-python = ">=3.11"
 license = "AGPL-3.0-only"

--- a/backend/src/podex/__init__.py
+++ b/backend/src/podex/__init__.py
@@ -1,3 +1,3 @@
 """Podex backend package."""
 
-__version__ = "1.0.0"
+__version__ = "0.40.0"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "podex"
-version = "1.0.0"
+version = "0.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Re-issues the purged v1.0.0 release as **v0.40.0**. The breaking `refactor(config)!:` in #375 was allowed to mint a major bump by `max-bump: major`; the project is pre-1.0, so the release and its tags (`v1.0.0`, floating `v1`) have been deleted and this PR restores the version files to the intended minor bump from v0.39.1.

- CHANGELOG: `[1.0.0]` section renamed to `[0.40.0]` (content unchanged)
- `backend/pyproject.toml`, `backend/src/podex/__init__.py`, `backend/uv.lock`: `1.0.0` → `0.40.0`

On merge, Release - Auto Tag reads this commit and mints `v0.40.0` + the GitHub Release, and Docker publish re-tags images (`0.40.0`/`0.40`/`0`/`latest`).

Companion: #381 caps `max-bump` at minor to prevent recurrence.

## Testing

- Version-file-only diff, mirrors the auto-generated #378 exactly (with 0.40.0 substituted).