### PR TITLE
fix(enrichment): implement documented OMDB/TMDB fallback behaviors

### DIFF
--- a/backend/src/podex/services/enrichment/omdb.py
+++ b/backend/src/podex/services/enrichment/omdb.py
@@ -19,6 +19,7 @@ from podex.services.enrichment.base import (
     EnrichmentSource,
     describe_http_error,
 )
+from podex.services.enrichment.search_utils import generate_search_variations
 
 if TYPE_CHECKING:
     from podex.models.media import Media
@@ -67,8 +68,9 @@ class OMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     def search_and_enrich(self, media: Media) -> EnrichmentResult | None:
         """Search OMDB and enrich media item.
 
-        If media already has an IMDB ID, use it directly.
-        Otherwise, search by title.
+        If media already has an IMDB ID, use it directly. Otherwise search by
+        title, retrying stripped-title variants (subtitle removal, article
+        stripping, etc.) when the exact title misses.
 
         Args:
             media: The media item to enrich.
@@ -85,19 +87,45 @@ class OMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
             if data and data.get("Response") == "True":
                 return self._build_result(data, confidence=1.0)
 
-        # Otherwise search by title
         omdb_type = self._get_omdb_type(media.type)
-        data = self._search_by_title(media.title, media.year, omdb_type)
+        for title_variant in generate_search_variations(media.title):
+            data = self._search_by_title(title_variant, media.year, omdb_type)
+            if not data or data.get("Response") != "True":
+                continue
 
-        if not data or data.get("Response") != "True":
-            logger.debug(f"No OMDB results for: {media.title}")
-            return None
+            result = self._result_from_title_hit(
+                media=media,
+                data=data,
+                title_variant=title_variant,
+            )
+            if result is not None:
+                if title_variant != media.title:
+                    logger.debug(
+                        "OMDB match for '%s' via title variant '%s'",
+                        media.title,
+                        title_variant,
+                    )
+                return result
 
-        # Calculate confidence based on title match
+        logger.debug(f"No OMDB results for: {media.title}")
+        return None
+
+    def _result_from_title_hit(
+        self,
+        *,
+        media: Media,
+        data: dict[str, Any],
+        title_variant: str,
+    ) -> EnrichmentResult | None:
+        """Score a title-search hit; return a result when confidence clears 0.7."""
         result_title = data.get("Title", "")
-        confidence = self._calculate_title_similarity(media.title, result_title)
+        # Score against both the original title and the query variant so a
+        # stripped-subtitle hit (e.g. "Dune" for "Dune: Part One") is accepted.
+        confidence = max(
+            self._calculate_title_similarity(media.title, result_title),
+            self._calculate_title_similarity(title_variant, result_title),
+        )
 
-        # Boost confidence if year matches
         result_year = data.get("Year", "")
         if media.year and result_year:
             try:

--- a/backend/src/podex/services/enrichment/tmdb.py
+++ b/backend/src/podex/services/enrichment/tmdb.py
@@ -26,9 +26,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# When a detail fetch fails, emit a search-document result at this fraction of
+# the match confidence so the fallback is clearly below the detail-path score.
+_DETAIL_FALLBACK_CONFIDENCE_FACTOR = 0.75
+
 
 class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich movies and TV shows from The Movie Database.
+
+    When a detail fetch fails after a confident search hit, a reduced-confidence
+    result is built from the search document
+    (``match_confidence * 0.75``) instead of returning ``None``.
 
     Args:
         api_key: TMDB API key.
@@ -129,7 +137,37 @@ class TMDBProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
                                 f"TMDB match for '{media.title}' using "
                                 f"query='{query}' type={search_type}"
                             )
-                            return self._build_result(details, search_type, confidence)
+                            return self._build_result(
+                                details,
+                                search_type,
+                                confidence,
+                            )
+
+                        search_doc = next(
+                            (
+                                result
+                                for result in search_results
+                                if result.get("id") == tmdb_id
+                            ),
+                            None,
+                        )
+                        if search_doc is not None:
+                            fallback_confidence = (
+                                confidence * _DETAIL_FALLBACK_CONFIDENCE_FACTOR
+                            )
+                            logger.debug(
+                                "TMDB detail fetch failed for '%s' (id=%s); "
+                                "falling back to search document "
+                                "(confidence=%.2f)",
+                                media.title,
+                                tmdb_id,
+                                fallback_confidence,
+                            )
+                            return self._build_result(
+                                search_doc,
+                                search_type,
+                                fallback_confidence,
+                            )
 
         logger.debug(f"No TMDB results for: {media.title}")
         return None

--- a/backend/src/podex/services/enrichment/tmdb_person.py
+++ b/backend/src/podex/services/enrichment/tmdb_person.py
@@ -20,12 +20,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# When a detail fetch fails, emit a search-document result at this fraction of
+# the match confidence so the fallback is clearly below the detail-path score.
+_DETAIL_FALLBACK_CONFIDENCE_FACTOR = 0.75
+
 
 class TMDBPersonProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignore]
     """Enrich people from TMDB Person API.
 
     Also used as fallback for standup_special when the title
     appears to be a person's name rather than a show title.
+
+    When ``media.tmdb_id`` is set, fetches ``/person/{id}`` directly at
+    confidence 1.0 (mirroring :class:`TMDBProvider`), falling back to name
+    search when unset or on failure. When a detail fetch fails after a
+    confident search hit, a reduced-confidence result is built from the
+    search document (``match_confidence * 0.75``) instead of returning
+    ``None``.
 
     Args:
         api_key: TMDB API key.
@@ -71,7 +82,12 @@ class TMDBPersonProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignor
         if not self.supports_media_type(media.type):
             return None
 
-        self.rate_limiter.wait_sync()
+        # Direct lookup by stored TMDB ID before any name search
+        if media.tmdb_id:
+            self.rate_limiter.wait_sync()
+            details = self._get_person_details(media.tmdb_id)
+            if details:
+                return self._build_result(details, confidence=1.0)
 
         # For standup_special, check if title looks like a person name
         # (no colons, parentheses, or typical show title patterns)
@@ -80,27 +96,40 @@ class TMDBPersonProvider(EnrichmentProvider):  # type: ignore[misc, unused-ignor
         ):
             return None
 
-        # Search for person
+        self.rate_limiter.wait_sync()
         results = self._search_person(media.title)
 
         if not results:
             logger.debug(f"No TMDB person results for: {media.title}")
             return None
 
-        # Find best match
         best_match = self._find_best_match(results, media)
         if not best_match:
             return None
 
         person_id, confidence = best_match
+        search_doc = next(
+            (person for person in results if person.get("id") == person_id),
+            None,
+        )
 
-        # Fetch full details
         self.rate_limiter.wait_sync()
         details = self._get_person_details(person_id)
-        if not details:
-            return None
+        if details:
+            return self._build_result(details, confidence)
 
-        return self._build_result(details, confidence)
+        if search_doc is not None:
+            fallback_confidence = confidence * _DETAIL_FALLBACK_CONFIDENCE_FACTOR
+            logger.debug(
+                "TMDB person detail fetch failed for '%s' (id=%s); "
+                "falling back to search document (confidence=%.2f)",
+                media.title,
+                person_id,
+                fallback_confidence,
+            )
+            return self._build_result(search_doc, fallback_confidence)
+
+        return None
 
     def _looks_like_person_name(self, title: str) -> bool:
         """Check if a title looks like a person's name.

--- a/backend/tests/enrichment/test_provider_omdb.py
+++ b/backend/tests/enrichment/test_provider_omdb.py
@@ -75,7 +75,7 @@ def test_omdb_year_and_documentary_paths() -> None:
 
 
 def test_omdb_falls_back_to_title_search_variants() -> None:
-    """A miss on the exact title yields None (no variant retry exists)."""
+    """A miss on the exact title retries stripped-title variants."""
     from podex.services.enrichment import OMDBProvider
 
     calls: list[str] = []
@@ -101,14 +101,43 @@ def test_omdb_falls_back_to_title_search_variants() -> None:
         )
 
     provider = OMDBProvider(api_key="key")
+    limiter = _CountingLimiter()
+    provider.rate_limiter = limiter
     _swap_client(provider, handler)
     result = provider.search_and_enrich(
         Media(type=MediaType.MOVIE, title="Dune: Part One"),
     )
     provider.close()
 
-    assert_that(calls).is_length(1)
-    assert_that(calls[0]).is_equal_to("Dune: Part One")
+    assert_that(calls).is_equal_to(["Dune: Part One", "Dune"])
+    assert_that(limiter.waits).is_equal_to(len(calls))
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.description).is_equal_to("Found on retry.")
+        assert_that(result.confidence).is_greater_than_or_equal_to(0.7)
+
+
+def test_omdb_title_variant_retry_misses_when_all_variants_fail() -> None:
+    """All title variants missing yields None."""
+    from podex.services.enrichment import OMDBProvider
+
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url.params.get("t", "")))
+        return httpx.Response(
+            200,
+            json={"Response": "False", "Error": "Movie not found!"},
+        )
+
+    provider = OMDBProvider(api_key="key")
+    _swap_client(provider, handler)
+    result = provider.search_and_enrich(
+        Media(type=MediaType.MOVIE, title="Dune: Part One"),
+    )
+    provider.close()
+
+    assert_that(calls).contains("Dune: Part One", "Dune")
     assert_that(result).is_none()
 
 

--- a/backend/tests/enrichment/test_provider_tmdb.py
+++ b/backend/tests/enrichment/test_provider_tmdb.py
@@ -64,9 +64,12 @@ def test_tmdb_tv_show_path() -> None:
         assert_that(result.has_useful_data()).is_true()
 
 
-def test_tmdb_person_detail_failure_yields_none() -> None:
-    """Person detail failures yield None (no search-doc fallback exists)."""
+def test_tmdb_person_detail_failure_falls_back() -> None:
+    """Person detail failures fall back to reduced-confidence search-doc data."""
     from podex.services.enrichment import TMDBPersonProvider
+    from podex.services.enrichment.tmdb_person import (
+        _DETAIL_FALLBACK_CONFIDENCE_FACTOR,
+    )
 
     search_payload = {
         "results": [
@@ -92,12 +95,20 @@ def test_tmdb_person_detail_failure_yields_none() -> None:
     )
     provider.close()
 
-    assert_that(result).is_none()
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.external_ids.get("tmdb_person_id")).is_equal_to(505710)
+        assert_that(result.cover_url).ends_with("/fh.jpg")
+        assert_that(result.confidence).is_less_than(1.0)
+        assert_that(result.confidence).is_equal_to(
+            1.0 * _DETAIL_FALLBACK_CONFIDENCE_FACTOR,
+        )
 
 
 def test_tmdb_year_filter_and_missing_details() -> None:
-    """Year-bearing media filter results; detail failures yield None."""
+    """Year-bearing media picks the matching hit; detail failures fall back."""
     from podex.services.enrichment import TMDBProvider
+    from podex.services.enrichment.tmdb import _DETAIL_FALLBACK_CONFIDENCE_FACTOR
 
     search_payload = {
         "results": [
@@ -134,34 +145,98 @@ def test_tmdb_year_filter_and_missing_details() -> None:
     result = provider.search_and_enrich(media)
     provider.close()
 
-    assert_that(result).is_none()
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.external_ids.get("tmdb_id")).is_equal_to(2)
+        assert_that(result.description).is_equal_to("New adaptation.")
+        # Perfect title + year boost + popularity → 1.0 before the factor.
+        assert_that(result.confidence).is_equal_to(
+            1.0 * _DETAIL_FALLBACK_CONFIDENCE_FACTOR,
+        )
 
 
 def test_tmdb_person_by_known_id() -> None:
-    """A stored tmdb id is ignored: the person provider always searches."""
+    """A stored tmdb id fetches person details directly at confidence 1.0."""
     from podex.services.enrichment import TMDBPersonProvider
 
+    seen_paths: list[str] = []
     detail = {
         "id": 505710,
         "name": "Frank Herbert",
         "biography": "Author.",
         "birthday": "1920-10-08",
         "profile_path": "/fh.jpg",
-        "imdb_id": "nm0378394",
+        "external_ids": {"imdb_id": "nm0378394"},
         "known_for_department": "Writing",
         "popularity": 5.0,
     }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        return httpx.Response(200, json=detail)
+
     provider = TMDBPersonProvider(api_key="key")
-    _swap_client(
-        provider,
-        lambda request: httpx.Response(200, json=detail),
-    )
+    _swap_client(provider, handler)
     media = _media("Frank Herbert", MediaType.PERSON)
     media.tmdb_id = 505710
     result = provider.search_and_enrich(media)
     provider.close()
 
-    assert_that(result).is_none()
+    assert_that(seen_paths).is_equal_to(["/person/505710"])
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.confidence).is_equal_to(1.0)
+        assert_that(result.description).is_equal_to("Author.")
+        assert_that(result.external_ids.get("imdb_id")).is_equal_to("nm0378394")
+
+
+def test_tmdb_person_known_id_falls_back_to_name_search() -> None:
+    """A failing stored-id lookup falls through to name search."""
+    from podex.services.enrichment import TMDBPersonProvider
+
+    search_payload = {
+        "results": [
+            {
+                "id": 505710,
+                "name": "Frank Herbert",
+                "known_for_department": "Writing",
+                "popularity": 5.0,
+                "profile_path": "/fh.jpg",
+            },
+        ],
+    }
+    detail = {
+        "id": 505710,
+        "name": "Frank Herbert",
+        "biography": "Author via search.",
+        "profile_path": "/fh.jpg",
+        "known_for_department": "Writing",
+        "popularity": 5.0,
+    }
+    seen_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_paths.append(request.url.path)
+        if request.url.path == "/person/999":
+            return httpx.Response(404, text="missing")
+        if "/search/person" in request.url.path:
+            return httpx.Response(200, json=search_payload)
+        return httpx.Response(200, json=detail)
+
+    provider = TMDBPersonProvider(api_key="key")
+    _swap_client(provider, handler)
+    media = _media("Frank Herbert", MediaType.PERSON)
+    media.tmdb_id = 999
+    result = provider.search_and_enrich(media)
+    provider.close()
+
+    assert_that(seen_paths[0]).is_equal_to("/person/999")
+    assert_that(seen_paths).contains("/search/person")
+    assert_that(seen_paths).contains("/person/505710")
+    assert_that(result).is_not_none()
+    if result is not None:
+        assert_that(result.description).is_equal_to("Author via search.")
+        assert_that(result.external_ids.get("tmdb_person_id")).is_equal_to(505710)
 
 
 def test_tmdb_waits_before_every_request() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(enrichment): implement documented OMDB/TMDB fallback behaviors
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` -> MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` -> PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` -> MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Implements the four provider behaviors documented by tests but previously
missing (#343):

1. **OMDB** — on exact-title miss, retry stripped-title variants via
   `generate_search_variations` (rate-limit before every request)
2. **TMDB Person** — honor `media.tmdb_id` with a confidence-1.0 direct
   `/person/{id}` fetch; fall back to name search on miss/failure
3. **TMDB Person** — detail-fetch failure → reduced-confidence result from
   the search document (`match_confidence * 0.75`)
4. **TMDB movie/TV** — same search-document fallback when detail fetch fails

Flips the four #343 tests under `backend/tests/enrichment/` back to
enriched-result expectations and adds miss / fallthrough coverage.

## Checklist

- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing

## Closes

- Closes #343

## Details

Base: current `main` (post #386/#387). Verification: `uv run pytest` → 529
passed, 1 skipped; lintro clean on touched paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c188cd50-4c4e-4eaa-ba01-ee157fef6c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

